### PR TITLE
fix: robust URL parsing + typed exceptions (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `subprocess.run(..., shell=True)` in `is_command_available` with `shutil.which`. The previous shell call was only ever invoked with literal command names, but `shutil.which` is the idiomatic, no-shell spelling.
 - Documented plain-text password storage as a known issue; tracked in #5 for a follow-up PR (OS keyring migration).
 
+### Changed (PR [#26](https://github.com/jordan8037310/zoom-cli/pull/26) — closes #6)
+- `_launch_name` URL parsing now uses `urllib.parse.urlsplit` + `parse_qs` instead of brittle `str.index`/`min(..., float("inf"))` slicing. Personal links (`/s/<name>`), web-client URLs (`/wc/...`), URLs with fragments, and URLs with `pwd=` not as the first query parameter all work now where they previously crashed with `ValueError`.
+- `_launch_name` correctly URL-decodes percent-encoded passwords (`pwd=hello%20world` → `hello world`).
+- `_launch_name` falls back to launching the URL directly through the `zoommtg://` scheme when the URL is not in the standard `/j/<id>` form.
+- `_launch_url` no longer swallows unexpected exceptions with a bare `except Exception`. Only the launcher's own `LauncherUnavailableError` produces a friendly error message; other exceptions propagate so genuine bugs are visible.
+- New `parse_meeting_url(url)` and `strip_url_scheme(url)` helpers in `zoom_cli.utils`.
+
 ## [1.1.6] - 2024-03-03
 
 ### Fixed

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -77,6 +77,40 @@ def test_launch_url_handles_url_without_scheme(captured_launches: list[list[str]
     assert captured_launches == [["open", "zoommtg://zoom.us/j/456"]]
 
 
+def test_launch_url_does_not_swallow_unexpected_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for #6 — bare ``except Exception`` previously hid bugs.
+
+    Genuine bugs in the launcher must propagate; only the launcher's
+    own ``LauncherUnavailableError`` is treated as a recoverable user error.
+    """
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("unexpected")
+
+    monkeypatch.setattr(commands_mod, "launch_zoommtg_url", boom)
+
+    with pytest.raises(RuntimeError, match="unexpected"):
+        commands_mod._launch_url("https://zoom.us/j/1")
+
+
+def test_launch_url_reports_launcher_unavailable_cleanly(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from zoom_cli import utils as utils_mod
+
+    def boom(*_args, **_kwargs):
+        raise utils_mod.LauncherUnavailableError("no launcher")
+
+    monkeypatch.setattr(commands_mod, "launch_zoommtg_url", boom)
+
+    commands_mod._launch_url("https://zoom.us/j/1")
+    out = capsys.readouterr().out
+    assert "Error:" in out
+    assert "no launcher" in out
+
+
 def test_launch_name_uses_saved_url(write_meetings, captured_launches: list[list[str]]) -> None:
     write_meetings({"team": {"url": "https://zoom.us/j/123?pwd=abc"}})
     commands_mod._launch_name("team")
@@ -113,6 +147,90 @@ def test_launch_name_meeting_without_url_or_id(
     commands_mod._launch_name("empty")
     assert captured_launches == []
     assert "No url or id found" in capsys.readouterr().out
+
+
+# ---- _launch_name URL-parsing edge cases (issue #6) ----------------------
+
+
+def test_launch_name_personal_link_falls_back_to_url_launch(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """Regression for #6: ``/s/personal-name`` URLs previously crashed
+    because slice-based parsing called ``url.index('/j/')``. Now they fall
+    back to launching the URL through the zoommtg scheme."""
+    write_meetings({"personal": {"url": "https://zoom.us/s/my-personal-link"}})
+    commands_mod._launch_name("personal")
+    assert captured_launches == [["open", "zoommtg://zoom.us/s/my-personal-link"]]
+
+
+def test_launch_name_web_client_url_falls_back(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    write_meetings({"webclient": {"url": "https://zoom.us/wc/123/join?pwd=abc"}})
+    commands_mod._launch_name("webclient")
+    assert captured_launches == [["open", "zoommtg://zoom.us/wc/123/join?pwd=abc"]]
+
+
+def test_launch_name_decodes_percent_encoded_password(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """``parse_qs`` URL-decodes the password before we re-build the
+    zoommtg URL, so a percent-encoded ``#`` round-trips correctly."""
+    write_meetings({"team": {"url": "https://zoom.us/j/123?pwd=ab%23cd"}})
+    commands_mod._launch_name("team")
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123&pwd=ab#cd"]]
+
+
+def test_launch_name_decodes_space_in_password(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    write_meetings({"team": {"url": "https://zoom.us/j/123?pwd=hello%20world"}})
+    commands_mod._launch_name("team")
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123&pwd=hello world"]]
+
+
+def test_launch_name_picks_pwd_when_other_query_params_present(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """Earlier slice-based code broke on multiple ``&`` params if ``pwd``
+    wasn't the first one. parse_qs handles arbitrary order."""
+    write_meetings({"team": {"url": "https://zoom.us/j/123?tk=tracking&pwd=secret&other=1"}})
+    commands_mod._launch_name("team")
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123&pwd=secret"]]
+
+
+def test_launch_name_handles_url_with_fragment(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    write_meetings({"team": {"url": "https://zoom.us/j/123?pwd=abc#section"}})
+    commands_mod._launch_name("team")
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123&pwd=abc"]]
+
+
+def test_launch_name_explicit_password_field_overrides_url_password(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """When an entry has both a URL with ``pwd=`` and an explicit
+    ``password`` field, the explicit field wins (preserves prior behavior)."""
+    write_meetings({"team": {"url": "https://zoom.us/j/123?pwd=fromurl", "password": "explicit"}})
+    commands_mod._launch_name("team")
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123&pwd=explicit"]]
+
+
+def test_launch_name_propagates_launcher_unavailable_as_error_message(
+    write_meetings,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from zoom_cli import utils as utils_mod
+
+    write_meetings({"team": {"id": "1"}})
+    monkeypatch.setattr(utils_mod.shutil, "which", lambda _cmd: None)
+
+    commands_mod._launch_name("team")
+    out = capsys.readouterr().out
+    assert "Error:" in out
+    assert "Neither" in out  # message from LauncherUnavailableError
 
 
 # ---- _edit ---------------------------------------------------------------

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -217,6 +217,54 @@ def test_launch_name_explicit_password_field_overrides_url_password(
     assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123&pwd=explicit"]]
 
 
+def test_launch_name_personal_link_with_explicit_password_passes_password(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """Regression for review feedback on #6: when a personal-link/non-/j/
+    URL has an explicit ``password`` field saved, the URL fallback path
+    must pass it to the launcher so the meeting joins without a manual
+    re-entry."""
+    write_meetings({"personal": {"url": "https://zoom.us/s/my-link", "password": "explicit"}})
+    commands_mod._launch_name("personal")
+    assert captured_launches == [["open", "zoommtg://zoom.us/s/my-link?pwd=explicit"]]
+
+
+def test_launch_name_personal_link_with_url_pwd_does_not_double_append(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """If the URL already has ``pwd=``, we must not append it again — that
+    would corrupt the URL. The URL passes through verbatim through the
+    zoommtg launcher."""
+    write_meetings({"personal": {"url": "https://zoom.us/s/my-link?pwd=fromurl"}})
+    commands_mod._launch_name("personal")
+    assert captured_launches == [["open", "zoommtg://zoom.us/s/my-link?pwd=fromurl"]]
+
+
+def test_launch_name_empty_string_password_is_respected_not_replaced(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """Regression for superpowers review on #6: an entry with
+    ``password: ""`` (intentional clear via ``zoom edit``) must keep the
+    empty value, not silently fall back to the URL's pwd= parameter.
+    Presence-check, not truthy-check."""
+    write_meetings({"team": {"url": "https://zoom.us/j/123?pwd=fromurl", "password": ""}})
+    commands_mod._launch_name("team")
+    # Empty explicit password wins over URL pwd=. launch_zoommtg with
+    # password="" produces the URL with no &pwd= suffix.
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123"]]
+
+
+def test_launch_name_handles_confno_query_param_url(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """Regression for codex review on #6: URLs of the form
+    ``?confno=<id>`` should now be recognized as meeting URLs and
+    re-emitted through the canonical zoommtg:// scheme."""
+    write_meetings({"team": {"url": "https://zoom.us/join?confno=123456789&pwd=p"}})
+    commands_mod._launch_name("team")
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123456789&pwd=p"]]
+
+
 def test_launch_name_propagates_launcher_unavailable_as_error_message(
     write_meetings,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -163,6 +163,14 @@ def test_is_command_available_returns_false_for_garbage() -> None:
         ("https://zoom.us/j/777?tk=abc&pwd=secret&other=1", "777", "secret"),
         # zoommtg:// scheme
         ("zoommtg://zoom.us/j/888?pwd=zz", "888", "zz"),
+        # confno= query-param form (Zoom emits these for some click-to-join flows)
+        ("https://zoom.us/join?confno=123456789", "123456789", ""),
+        ("https://zoom.us/join?confno=987&pwd=secret", "987", "secret"),
+        ("zoommtg://zoom.us/join?confno=42&pwd=abc", "42", "abc"),
+        # Duplicate pwd= — first wins (attacker can't override by appending)
+        ("https://zoom.us/j/100?pwd=legit&pwd=evil", "100", "legit"),
+        # Unrecognized URL still extracts password for fallback launcher to use
+        ("https://zoom.us/wc/123?pwd=fromurl", None, "fromurl"),
         # Personal link / web-client / unknown form -> meeting_id is None
         ("https://zoom.us/s/personal-link", None, ""),
         ("https://zoom.us/wc/123/join", None, ""),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -137,3 +137,56 @@ def test_is_command_available_finds_known_command() -> None:
 
 def test_is_command_available_returns_false_for_garbage() -> None:
     assert utils_mod.is_command_available("definitely-not-a-real-command-zxcvbn") is False
+
+
+# ---- parse_meeting_url ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,expected_id,expected_password",
+    [
+        # Standard meeting URLs
+        ("https://zoom.us/j/123456789", "123456789", ""),
+        ("https://zoom.us/j/123456789?pwd=abc", "123456789", "abc"),
+        ("https://us02web.zoom.us/j/987654321?pwd=xyz", "987654321", "xyz"),
+        # Subdomained / vanity hosts
+        ("https://example.zoom.us/j/111?pwd=p", "111", "p"),
+        # Trailing slash and extra path segments
+        ("https://zoom.us/j/222/", "222", ""),
+        ("https://zoom.us/j/333/extra-segment", "333", ""),
+        # URL fragment shouldn't confuse parsing
+        ("https://zoom.us/j/444?pwd=ok#frag", "444", "ok"),
+        # Percent-encoded password decodes cleanly
+        ("https://zoom.us/j/555?pwd=ab%23cd", "555", "ab#cd"),
+        ("https://zoom.us/j/666?pwd=hello%20world", "666", "hello world"),
+        # Multiple query params, pwd not first
+        ("https://zoom.us/j/777?tk=abc&pwd=secret&other=1", "777", "secret"),
+        # zoommtg:// scheme
+        ("zoommtg://zoom.us/j/888?pwd=zz", "888", "zz"),
+        # Personal link / web-client / unknown form -> meeting_id is None
+        ("https://zoom.us/s/personal-link", None, ""),
+        ("https://zoom.us/wc/123/join", None, ""),
+        ("https://zoom.us/", None, ""),
+        # Garbage
+        ("not a url", None, ""),
+        ("", None, ""),
+    ],
+)
+def test_parse_meeting_url_extracts_id_and_password(
+    url: str, expected_id: str | None, expected_password: str
+) -> None:
+    meeting_id, password = utils_mod.parse_meeting_url(url)
+    assert meeting_id == expected_id
+    assert password == expected_password
+
+
+def test_strip_url_scheme_preserves_url_without_scheme() -> None:
+    assert utils_mod.strip_url_scheme("zoom.us/j/1") == "zoom.us/j/1"
+
+
+def test_strip_url_scheme_strips_https() -> None:
+    assert utils_mod.strip_url_scheme("https://zoom.us/j/1?pwd=abc") == "zoom.us/j/1?pwd=abc"
+
+
+def test_strip_url_scheme_strips_zoommtg() -> None:
+    assert utils_mod.strip_url_scheme("zoommtg://zoom.us/j/2?pwd=xyz") == "zoom.us/j/2?pwd=xyz"

--- a/zoom_cli/commands.py
+++ b/zoom_cli/commands.py
@@ -3,57 +3,74 @@ import questionary
 
 from zoom_cli.utils import (
     ConsoleColor,
+    LauncherUnavailableError,
     get_meeting_file_contents,
     launch_zoommtg,
     launch_zoommtg_url,
+    parse_meeting_url,
+    strip_url_scheme,
     write_to_meeting_file,
 )
 
 
-def _launch_url(url):
+def _print_error(message: str) -> None:
+    print(ConsoleColor.BOLD + "Error:" + ConsoleColor.END, end=" ")
+    print(message)
+
+
+def _launch_url(url: str) -> None:
+    """Launch a Zoom meeting from any URL by rewriting the scheme to ``zoommtg://``.
+
+    Accepts URLs with or without an existing scheme. Only catches
+    ``LauncherUnavailableError`` so that genuine bugs propagate instead of
+    being swallowed by a bare ``except``.
+    """
+    rebuilt = f"zoommtg://{strip_url_scheme(url)}"
     try:
-        url_to_launch = url[url.index("://") + 3 :] if "://" in url else url
-        launch_zoommtg_url(f"zoommtg://{url_to_launch}")
-    except Exception:
-        print(ConsoleColor.BOLD + "Error:" + ConsoleColor.END, end=" ")
-        print("Unable to launch given URL:  " + ConsoleColor.BOLD + url + ConsoleColor.END + ".")
+        launch_zoommtg_url(rebuilt)
+    except LauncherUnavailableError as exc:
+        _print_error(str(exc))
 
 
-def _launch_name(name):
+def _launch_name(name: str) -> None:
     contents = get_meeting_file_contents()
 
-    if name in contents:
-        if "url" in contents[name]:
-            url = contents[name]["url"]
-
-            # Extract id from URL: between "/j/" and either "?" or end-of-string.
-            id_start = url.index("/j/") + 3
-            query_idx = url.index("?") if "?" in url else len(url)
-            id = url[id_start:query_idx]
-            password = ""
-
-            if "pwd=" in url:
-                pwd_start = url.index("pwd=") + 4
-                pwd_end = url.index("&", pwd_start) if "&" in url[pwd_start:] else len(url)
-                password = url[pwd_start:pwd_end]
-
-            launch_zoommtg(id, contents[name].get("password", password))
-        elif "id" in contents[name]:
-            launch_zoommtg(contents[name]["id"], contents[name].get("password", ""))
-        else:
-            print(ConsoleColor.BOLD + "Error:" + ConsoleColor.END, end=" ")
-            print(
-                "No url or id found for meeting with title "
-                + ConsoleColor.BOLD
-                + name
-                + ConsoleColor.END
-                + "."
-            )
-    else:
-        print(ConsoleColor.BOLD + "Error:" + ConsoleColor.END, end=" ")
-        print(
+    if name not in contents:
+        _print_error(
             "Could not find meeting with title " + ConsoleColor.BOLD + name + ConsoleColor.END + "."
         )
+        return
+
+    entry = contents[name]
+
+    try:
+        if "url" in entry:
+            meeting_id, url_password = parse_meeting_url(entry["url"])
+            password = entry.get("password") or url_password
+
+            if meeting_id is not None:
+                launch_zoommtg(meeting_id, password)
+                return
+
+            # No /j/<id> path — likely a personal link (/s/<name>) or web-client URL.
+            # Pass it through the zoommtg:// launcher so the desktop client
+            # handles the resolution.
+            launch_zoommtg_url(f"zoommtg://{strip_url_scheme(entry['url'])}")
+            return
+
+        if "id" in entry:
+            launch_zoommtg(entry["id"], entry.get("password", ""))
+            return
+
+        _print_error(
+            "No url or id found for meeting with title "
+            + ConsoleColor.BOLD
+            + name
+            + ConsoleColor.END
+            + "."
+        )
+    except LauncherUnavailableError as exc:
+        _print_error(str(exc))
 
 
 def _save_url(name, url, password):

--- a/zoom_cli/commands.py
+++ b/zoom_cli/commands.py
@@ -46,7 +46,11 @@ def _launch_name(name: str) -> None:
     try:
         if "url" in entry:
             meeting_id, url_password = parse_meeting_url(entry["url"])
-            password = entry.get("password") or url_password
+            # Presence-check via dict.get: a deliberately empty saved password
+            # ({"password": ""}) returns "" — meaning "no password" — rather
+            # than falling back to url_password. Preserves the contract from
+            # PR #25 where `_edit` lets users intentionally clear a field.
+            password = entry.get("password", url_password)
 
             if meeting_id is not None:
                 launch_zoommtg(meeting_id, password)
@@ -54,8 +58,11 @@ def _launch_name(name: str) -> None:
 
             # No /j/<id> path — likely a personal link (/s/<name>) or web-client URL.
             # Pass it through the zoommtg:// launcher so the desktop client
-            # handles the resolution.
-            launch_zoommtg_url(f"zoommtg://{strip_url_scheme(entry['url'])}")
+            # handles the resolution. We append the password only if the URL
+            # does NOT already carry one, otherwise launch_zoommtg_url would
+            # double-append `&pwd=...`.
+            extra_pwd = "" if url_password else password
+            launch_zoommtg_url(f"zoommtg://{strip_url_scheme(entry['url'])}", extra_pwd)
             return
 
         if "id" in entry:

--- a/zoom_cli/utils.py
+++ b/zoom_cli/utils.py
@@ -4,6 +4,7 @@ import json
 import os
 import shutil
 import subprocess
+from urllib.parse import parse_qs, urlsplit
 
 __version__ = "1.1.6"
 
@@ -97,3 +98,28 @@ def launch_zoommtg_url(url: str, password: str = "") -> None:
 def launch_zoommtg(id: str, password: str) -> None:
     url = "zoommtg://zoom.us/join?confno=" + id
     launch_zoommtg_url(url, password)
+
+
+def parse_meeting_url(url: str) -> tuple[str | None, str]:
+    """Extract ``(meeting_id, password)`` from a Zoom meeting URL.
+
+    Recognizes the standard ``/j/<id>`` meeting URL form. Personal links
+    (``/s/<name>``), web-client links (``/wc/<id>``), and unrecognized
+    formats return ``(None, "")`` so callers can fall back to launching
+    the URL as-is.
+
+    The ``pwd=`` query parameter is URL-decoded by ``parse_qs``, so
+    percent-encoded passwords (e.g. ``pwd=ab%23cd``) round-trip cleanly.
+    """
+    parsed = urlsplit(url)
+    path_segments = [seg for seg in parsed.path.split("/") if seg]
+    meeting_id: str | None = None
+    if len(path_segments) >= 2 and path_segments[0] == "j":
+        meeting_id = path_segments[1]
+    password = parse_qs(parsed.query).get("pwd", [""])[0]
+    return meeting_id, password
+
+
+def strip_url_scheme(url: str) -> str:
+    """Return ``url`` with any leading ``scheme://`` removed."""
+    return url.split("://", 1)[1] if "://" in url else url

--- a/zoom_cli/utils.py
+++ b/zoom_cli/utils.py
@@ -103,20 +103,39 @@ def launch_zoommtg(id: str, password: str) -> None:
 def parse_meeting_url(url: str) -> tuple[str | None, str]:
     """Extract ``(meeting_id, password)`` from a Zoom meeting URL.
 
-    Recognizes the standard ``/j/<id>`` meeting URL form. Personal links
-    (``/s/<name>``), web-client links (``/wc/<id>``), and unrecognized
-    formats return ``(None, "")`` so callers can fall back to launching
-    the URL as-is.
+    Recognizes:
+
+    - ``/j/<id>`` — the standard meeting URL form.
+    - ``?confno=<id>`` query parameter — Zoom's older click-to-join form,
+      sometimes still emitted (and the same form the ``zoommtg://`` scheme
+      uses internally).
+
+    Personal links (``/s/<name>``), web-client links (``/wc/<id>``), and
+    unrecognized formats return ``(None, password_if_any)`` so callers can
+    fall back to launching the URL as-is. Note: even for unrecognized
+    formats the ``pwd=`` parameter is still extracted, so a caller routing
+    a ``/wc/...?pwd=abc`` through the fallback launcher knows to add the
+    password if the URL doesn't already contain one.
 
     The ``pwd=`` query parameter is URL-decoded by ``parse_qs``, so
     percent-encoded passwords (e.g. ``pwd=ab%23cd``) round-trip cleanly.
+    If multiple ``pwd=`` parameters are present (malicious or buggy), the
+    **first** value wins; an attacker cannot override a legitimate first
+    value by appending ``&pwd=evil``.
     """
     parsed = urlsplit(url)
     path_segments = [seg for seg in parsed.path.split("/") if seg]
+    query = parse_qs(parsed.query)
+
     meeting_id: str | None = None
     if len(path_segments) >= 2 and path_segments[0] == "j":
         meeting_id = path_segments[1]
-    password = parse_qs(parsed.query).get("pwd", [""])[0]
+    else:
+        confno_values = query.get("confno", [])
+        if confno_values:
+            meeting_id = confno_values[0]
+
+    password = query.get("pwd", [""])[0]
     return meeting_id, password
 
 


### PR DESCRIPTION
## Summary

Implements [#6](https://github.com/jordan8037310/zoom-cli/issues/6) — replaces brittle slice-based URL parsing with `urllib.parse` and tightens exception handling so the bare `except Exception:` no longer swallows real bugs.

**Stacked on top of #25** (`chore/bootstrap-ci-tests`). When #25 merges, GitHub auto-rebases this onto `main`.

Closes #6.

## What's in here

### URL parsing — `zoom_cli/utils.py`

New `parse_meeting_url(url) -> (meeting_id, password)` helper:
- Recognizes the standard `/j/<id>` meeting URL form.
- Returns `(None, "")` for personal links (`/s/<name>`), web-client URLs (`/wc/<id>`), and unrecognized formats so callers can fall back to launching the URL as-is.
- `parse_qs` URL-decodes the password (`pwd=hello%20world` → `hello world`, `pwd=ab%23cd` → `ab#cd`).
- Handles trailing slashes, extra path segments, URL fragments, and `pwd=` not-first-in-query.

New `strip_url_scheme(url)` helper for the scheme-rewriting that `_launch_url` and the URL fallback path both need.

### Exception handling — `zoom_cli/commands.py`

`_launch_url` previously had:
```python
except Exception:
    print("Unable to launch given URL: ...")
```

That bare-ish catch swallowed everything — including bugs. Now it catches only `LauncherUnavailableError` (raised by the launcher when neither `open` nor `xdg-open` is on PATH) and prints a friendly error. Anything else propagates so genuine bugs are visible.

`_launch_name` likewise narrows to `LauncherUnavailableError`. The `ValueError` paths that previously came from `str.index("/j/")` are gone — `parse_meeting_url` returns `(None, "")` instead.

### Tests (84 total, was 55 — 29 new)

- **17-case parametrized** `parse_meeting_url` table covers: standard `/j/` URLs, vanity hosts, trailing slash and extra path segments, URL fragments, percent-encoded passwords (`#`, space), `pwd=` not-first-in-query, `zoommtg://` scheme, `/s/` personal links, `/wc/` web-client links, garbage input, and the empty string.
- `strip_url_scheme` unit tests.
- `_launch_name` regression tests for: personal links falling back to `zoommtg://` launch, web-client URLs, percent-encoded passwords, query-string fragments, multi-param queries with `pwd` last.
- `_launch_url` tests verify that `RuntimeError` propagates and `LauncherUnavailableError` produces a friendly message.

## Test plan

- [x] `ruff check .` — clean
- [x] `ruff format --check .` — clean
- [x] `mypy` — no issues
- [x] `pytest -q` — 84 passed in 0.19 s
- [ ] CI matrix green on Python 3.10–3.13 × Ubuntu+macOS (will verify in this PR's run)
- [ ] Manual smoke: `zoom <name>` for a saved personal link no longer crashes; for a saved `/j/<id>` URL still launches via `zoommtg://`.

## Behavior preserved

- Saved-password field still wins over a `pwd=` already in the URL.
- The output of `zoom ls`, `zoom save`, `zoom rm`, `zoom edit` is unchanged.
- Existing tests continue to pass without modification (only added new coverage; assertions on argv-list behavior remain identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
