### PR TITLE
chore: atomic JSON writes + --dry-run/--yes on rm (partial #24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `subprocess.run(..., shell=True)` in `is_command_available` with `shutil.which`. The previous shell call was only ever invoked with literal command names, but `shutil.which` is the idiomatic, no-shell spelling.
 - Documented plain-text password storage as a known issue; tracked in #5 for a follow-up PR (OS keyring migration).
 
+### Changed (PR [#27](https://github.com/jordan8037310/zoom-cli/pull/27) — partial #24)
+- `write_to_meeting_file` now writes atomically: serialize to a sibling tempfile, `fsync`, then `os.replace` onto `meetings.json`. A crash or kill mid-write can no longer corrupt the file — readers see either the old or the new version, never a partial JSON.
+- `zoom rm` gains `--dry-run` (preview) and `--yes`/`-y` (skip confirmation) flags.
+- When a meeting name is **picked interactively** by `zoom rm`, a confirmation prompt now fires before deletion (the new safety net catches miss-clicks). `zoom rm <name>` with a positional argument still deletes immediately — no behavior change for scripts/aliases.
+- Schema versioning and `--dry-run` on future API `delete` commands deferred to a follow-up PR.
+
 ### Changed (PR [#26](https://github.com/jordan8037310/zoom-cli/pull/26) — closes #6)
 - `_launch_name` URL parsing now uses `urllib.parse.urlsplit` + `parse_qs` instead of brittle `str.index`/`min(..., float("inf"))` slicing. Personal links (`/s/<name>`), web-client URLs (`/wc/...`), URLs with fragments, and URLs with `pwd=` not as the first query parameter all work now where they previously crashed with `ValueError`.
 - `_launch_name` correctly URL-decodes percent-encoded passwords (`pwd=hello%20world` → `hello world`).

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,11 +88,64 @@ def test_save_url_does_not_prompt_for_password_when_pwd_in_url(
 def test_rm_with_argument_no_prompt(
     runner: CliRunner, write_meetings, tmp_zoom_cli_home: Path
 ) -> None:
+    """Regression: `zoom rm <name>` with a positional name must NOT prompt
+    for confirmation — that would break existing scripts and aliases."""
     write_meetings({"a": {"id": "1"}, "b": {"id": "2"}})
     result = runner.invoke(main, ["rm", "a"])
     assert result.exit_code == 0, result.output
     on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
     assert on_disk == {"b": {"id": "2"}}
+
+
+def test_rm_dry_run_does_not_modify_file(
+    runner: CliRunner, write_meetings, tmp_zoom_cli_home: Path
+) -> None:
+    write_meetings({"a": {"id": "1"}, "b": {"id": "2"}})
+    result = runner.invoke(main, ["rm", "a", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "[dry-run]" in result.output
+    assert "a" in result.output
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    assert on_disk == {"a": {"id": "1"}, "b": {"id": "2"}}
+
+
+def test_rm_interactive_confirms_before_deleting(
+    runner: CliRunner,
+    write_meetings,
+    tmp_zoom_cli_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the name is picked interactively (no positional arg), a
+    confirmation prompt must fire. Answering 'n' must abort."""
+    import zoom_cli.__main__ as main_mod
+
+    write_meetings({"a": {"id": "1"}})
+    monkeypatch.setattr(main_mod.questionary, "select", _FakeQ(["a"]))
+
+    # Click's prompt reads from stdin; feed 'n\n' to decline.
+    result = runner.invoke(main, ["rm"], input="n\n")
+    assert result.exit_code == 0, result.output
+    assert "Aborted" in result.output
+    # Meeting still present.
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    assert "a" in on_disk
+
+
+def test_rm_interactive_with_yes_flag_skips_confirmation(
+    runner: CliRunner,
+    write_meetings,
+    tmp_zoom_cli_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import zoom_cli.__main__ as main_mod
+
+    write_meetings({"a": {"id": "1"}})
+    monkeypatch.setattr(main_mod.questionary, "select", _FakeQ(["a"]))
+
+    result = runner.invoke(main, ["rm", "--yes"])
+    assert result.exit_code == 0, result.output
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    assert "a" not in on_disk
 
 
 def test_default_launch_with_url_argument(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,6 +109,29 @@ def test_rm_dry_run_does_not_modify_file(
     assert on_disk == {"a": {"id": "1"}, "b": {"id": "2"}}
 
 
+def test_rm_interactive_dry_run_does_not_confirm_or_delete(
+    runner: CliRunner,
+    write_meetings,
+    tmp_zoom_cli_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`zoom rm --dry-run` (no positional name): pick from list, print the
+    preview, return without firing the confirmation prompt."""
+    import zoom_cli.__main__ as main_mod
+
+    write_meetings({"alpha": {"id": "1"}, "beta": {"id": "2"}})
+    monkeypatch.setattr(main_mod.questionary, "select", _FakeQ(["alpha"]))
+
+    result = runner.invoke(main, ["rm", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "[dry-run]" in result.output
+    assert "alpha" in result.output
+    assert "Remove meeting" not in result.output  # confirm prompt did NOT fire
+
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    assert on_disk == {"alpha": {"id": "1"}, "beta": {"id": "2"}}
+
+
 def test_rm_interactive_confirms_before_deleting(
     runner: CliRunner,
     write_meetings,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -203,31 +204,48 @@ def test_strip_url_scheme_strips_zoommtg() -> None:
 # ---- atomic write_to_meeting_file ---------------------------------------
 
 
-def test_write_to_meeting_file_is_atomic_uses_replace(tmp_zoom_cli_home: Path) -> None:
-    """Verify the temp-then-replace flow happens — a tempfile must be written
-    in the same dir as the target, then renamed onto it."""
+def test_write_to_meeting_file_actually_calls_os_replace(
+    tmp_zoom_cli_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pin the atomic-write contract: ``os.replace`` must be the call that
+    swaps the new content into place. A future implementation that wrote
+    ``meetings.json`` directly would silently regress without this test.
+    """
+    captured: list[tuple[str, str]] = []
+    real_replace = utils_mod.os.replace
+
+    def tracking_replace(src: str, dst: str) -> None:
+        captured.append((str(src), str(dst)))
+        real_replace(src, dst)
+
+    monkeypatch.setattr(utils_mod.os, "replace", tracking_replace)
+
     payload = {"team": {"id": "1"}}
     utils_mod.write_to_meeting_file(payload)
 
-    target = tmp_zoom_cli_home / "meetings.json"
-    on_disk = json.loads(target.read_text())
+    assert len(captured) == 1, "os.replace must be called exactly once"
+    src, dst = captured[0]
+    assert dst == str(tmp_zoom_cli_home / "meetings.json")
+    # The src is a sibling tempfile, not the target itself.
+    assert src != dst
+    assert os.path.dirname(src) == os.path.dirname(dst)
+    assert os.path.basename(src).startswith(".meetings.")
+
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
     assert on_disk == payload
 
-    # No leftover tempfiles in the dir.
     leftovers = [p for p in tmp_zoom_cli_home.iterdir() if p.name != "meetings.json"]
     assert leftovers == [], f"unexpected leftover files: {leftovers}"
 
 
-def test_write_to_meeting_file_does_not_corrupt_on_error(
+def test_write_to_meeting_file_cleans_up_when_replace_fails(
     tmp_zoom_cli_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """If the write fails after the tempfile is created, the original
-    meetings.json must remain intact."""
-    # Seed a known good file.
+    """If ``os.replace`` raises, the original file must remain intact and
+    the tempfile must be cleaned up."""
     target = tmp_zoom_cli_home / "meetings.json"
     target.write_text('{"original": {"id": "999"}}')
 
-    # Make os.replace raise to simulate a mid-replace failure.
     def boom(*_args, **_kwargs):
         raise OSError("simulated replace failure")
 
@@ -236,16 +254,50 @@ def test_write_to_meeting_file_does_not_corrupt_on_error(
     with pytest.raises(OSError, match="simulated replace failure"):
         utils_mod.write_to_meeting_file({"new": {"id": "111"}})
 
-    # Original content must still be there.
     on_disk = json.loads(target.read_text())
     assert on_disk == {"original": {"id": "999"}}
 
-    # Tempfile must have been cleaned up.
+    leftovers = [p for p in tmp_zoom_cli_home.iterdir() if p.name != "meetings.json"]
+    assert leftovers == [], f"tempfile leak: {leftovers}"
+
+
+def test_write_to_meeting_file_cleans_up_when_fsync_fails(
+    tmp_zoom_cli_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If ``os.fsync`` (called inside the ``with os.fdopen(...)`` block)
+    raises, the cleanup branch must still delete the tempfile and the
+    original meetings.json must remain intact. Covers the asymmetric path
+    flagged in code review (codex + python-review on PR #27)."""
+    target = tmp_zoom_cli_home / "meetings.json"
+    target.write_text('{"original": {"id": "999"}}')
+
+    real_fsync = utils_mod.os.fsync
+
+    def boom_on_file_fsync(fd: int) -> None:
+        # Only blow up on the *file* fsync (after it's been opened for
+        # writing). Directory fsyncs (called later for durability) should
+        # still work.
+        raise OSError("simulated fsync failure")
+
+    monkeypatch.setattr(utils_mod.os, "fsync", boom_on_file_fsync)
+
+    with pytest.raises(OSError, match="simulated fsync failure"):
+        utils_mod.write_to_meeting_file({"new": {"id": "111"}})
+
+    # Restore for any subsequent fixtures
+    monkeypatch.setattr(utils_mod.os, "fsync", real_fsync)
+
+    on_disk = json.loads(target.read_text())
+    assert on_disk == {"original": {"id": "999"}}
+
     leftovers = [p for p in tmp_zoom_cli_home.iterdir() if p.name != "meetings.json"]
     assert leftovers == [], f"tempfile leak: {leftovers}"
 
 
 def test_write_to_meeting_file_round_trips_unicode(tmp_zoom_cli_home: Path) -> None:
+    """``json.dumps`` defaults to ``ensure_ascii=True``, so non-ASCII chars
+    are escaped to ``\\uXXXX`` on disk — but ``json.loads`` decodes them
+    back, so the round-trip is lossless."""
     payload = {"meeting-with-emoji-🚀": {"password": "p@ss-Ω"}}
     utils_mod.write_to_meeting_file(payload)
     on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -198,3 +198,55 @@ def test_strip_url_scheme_strips_https() -> None:
 
 def test_strip_url_scheme_strips_zoommtg() -> None:
     assert utils_mod.strip_url_scheme("zoommtg://zoom.us/j/2?pwd=xyz") == "zoom.us/j/2?pwd=xyz"
+
+
+# ---- atomic write_to_meeting_file ---------------------------------------
+
+
+def test_write_to_meeting_file_is_atomic_uses_replace(tmp_zoom_cli_home: Path) -> None:
+    """Verify the temp-then-replace flow happens — a tempfile must be written
+    in the same dir as the target, then renamed onto it."""
+    payload = {"team": {"id": "1"}}
+    utils_mod.write_to_meeting_file(payload)
+
+    target = tmp_zoom_cli_home / "meetings.json"
+    on_disk = json.loads(target.read_text())
+    assert on_disk == payload
+
+    # No leftover tempfiles in the dir.
+    leftovers = [p for p in tmp_zoom_cli_home.iterdir() if p.name != "meetings.json"]
+    assert leftovers == [], f"unexpected leftover files: {leftovers}"
+
+
+def test_write_to_meeting_file_does_not_corrupt_on_error(
+    tmp_zoom_cli_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the write fails after the tempfile is created, the original
+    meetings.json must remain intact."""
+    # Seed a known good file.
+    target = tmp_zoom_cli_home / "meetings.json"
+    target.write_text('{"original": {"id": "999"}}')
+
+    # Make os.replace raise to simulate a mid-replace failure.
+    def boom(*_args, **_kwargs):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(utils_mod.os, "replace", boom)
+
+    with pytest.raises(OSError, match="simulated replace failure"):
+        utils_mod.write_to_meeting_file({"new": {"id": "111"}})
+
+    # Original content must still be there.
+    on_disk = json.loads(target.read_text())
+    assert on_disk == {"original": {"id": "999"}}
+
+    # Tempfile must have been cleaned up.
+    leftovers = [p for p in tmp_zoom_cli_home.iterdir() if p.name != "meetings.json"]
+    assert leftovers == [], f"tempfile leak: {leftovers}"
+
+
+def test_write_to_meeting_file_round_trips_unicode(tmp_zoom_cli_home: Path) -> None:
+    payload = {"meeting-with-emoji-🚀": {"password": "p@ss-Ω"}}
+    utils_mod.write_to_meeting_file(payload)
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    assert on_disk == payload

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -97,13 +97,39 @@ def edit(name, url, id, password):
 
 @main.command(help="Delete meeting")
 @click.argument("name", required=False)
-def rm(name):
-    if not name:
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Show what would be deleted without modifying meetings.json.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt that fires when the name is picked interactively.",
+)
+def rm(name, dry_run, yes):
+    name_was_picked_interactively = not name
+    if name_was_picked_interactively:
         choices = get_meeting_names()
         if not choices:
             click.echo("No saved meetings to remove.")
             return
         name = _ask_or_abort(questionary.select("Meeting name:", choices=choices))
+
+    if dry_run:
+        click.echo(f"[dry-run] Would remove meeting: {name}")
+        return
+
+    # Only confirm if the name came from the interactive selector — a positional
+    # `zoom rm <name>` is already a deliberate choice, and adding a prompt would
+    # break existing scripts and aliases.
+    needs_confirm = name_was_picked_interactively and not yes
+    if needs_confirm and not click.confirm(f"Remove meeting '{name}'?", default=False):
+        click.echo("Aborted.")
+        return
 
     _remove(name)
 

--- a/zoom_cli/utils.py
+++ b/zoom_cli/utils.py
@@ -63,20 +63,29 @@ def get_meeting_names() -> list[str]:
 
 
 def write_to_meeting_file(contents: dict) -> None:
-    """Write the meetings JSON atomically.
+    """Write the meetings JSON atomically and durably.
 
-    Strategy: write the new content to a sibling tempfile, ``fsync`` to flush
-    the page cache, then ``os.replace`` (which is atomic on POSIX and on
-    Windows for files on the same filesystem) to swap it into place. This
-    prevents partial-write corruption if the process is killed mid-write or
-    the system crashes — readers will see either the old file or the new
-    file, never a half-written one.
+    Strategy:
+    1. Serialize the new content to a sibling tempfile (created via
+       ``tempfile.mkstemp`` so the name is unpredictable and exclusive).
+    2. ``flush()`` + ``os.fsync()`` the tempfile's fd so its contents reach
+       the disk before we swap it into place.
+    3. ``os.replace()`` it onto ``meetings.json``. The replace is atomic on
+       POSIX and on Windows for same-filesystem replacements, so readers
+       see either the old file or the new file — never a half-written one.
+    4. ``os.fsync()`` the parent directory so the directory entry update
+       (the rename) is also durable on POSIX. Skipped on platforms where
+       opening a directory raises ``PermissionError`` (Windows).
+
+    On any exception during the write, best-effort delete the tempfile so
+    we don't leak it, then re-raise the original error. ``meetings.json``
+    itself is never opened until the final replace, so a mid-write failure
+    cannot corrupt it.
     """
     _ensure_storage()
     payload = dict_to_json_string(contents)
     dir_name = os.path.dirname(SAVE_FILE_PATH) or "."
-    # delete=False because we hand the path to os.replace ourselves.
-    fd, tmp_path = _mkstemp_for(dir_name)
+    fd, tmp_path = tempfile.mkstemp(prefix=".meetings.", suffix=".tmp", dir=dir_name)
     try:
         with os.fdopen(fd, "w") as file:
             file.write(payload)
@@ -89,10 +98,15 @@ def write_to_meeting_file(contents: dict) -> None:
             os.unlink(tmp_path)
         raise
 
-
-def _mkstemp_for(directory: str) -> tuple[int, str]:
-    """Wrap ``tempfile.mkstemp`` for this module so tests can stub it cleanly."""
-    return tempfile.mkstemp(prefix=".meetings.", suffix=".tmp", dir=directory)
+    # Durability: fsync the parent dir so the new dirent survives a crash
+    # right after the rename. POSIX-only — Windows raises PermissionError
+    # when you try to open a directory.
+    with contextlib.suppress(OSError, PermissionError):
+        dir_fd = os.open(dir_name, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
 
 
 def is_command_available(command: str) -> bool:

--- a/zoom_cli/utils.py
+++ b/zoom_cli/utils.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import shutil
 import subprocess
+import tempfile
 from urllib.parse import parse_qs, urlsplit
 
 __version__ = "1.1.6"
@@ -61,9 +63,36 @@ def get_meeting_names() -> list[str]:
 
 
 def write_to_meeting_file(contents: dict) -> None:
+    """Write the meetings JSON atomically.
+
+    Strategy: write the new content to a sibling tempfile, ``fsync`` to flush
+    the page cache, then ``os.replace`` (which is atomic on POSIX and on
+    Windows for files on the same filesystem) to swap it into place. This
+    prevents partial-write corruption if the process is killed mid-write or
+    the system crashes — readers will see either the old file or the new
+    file, never a half-written one.
+    """
     _ensure_storage()
-    with open(SAVE_FILE_PATH, "w") as file:
-        file.write(dict_to_json_string(contents))
+    payload = dict_to_json_string(contents)
+    dir_name = os.path.dirname(SAVE_FILE_PATH) or "."
+    # delete=False because we hand the path to os.replace ourselves.
+    fd, tmp_path = _mkstemp_for(dir_name)
+    try:
+        with os.fdopen(fd, "w") as file:
+            file.write(payload)
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(tmp_path, SAVE_FILE_PATH)
+    except Exception:
+        # Best-effort cleanup; suppress errors so the original exception wins.
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
+
+
+def _mkstemp_for(directory: str) -> tuple[int, str]:
+    """Wrap ``tempfile.mkstemp`` for this module so tests can stub it cleanly."""
+    return tempfile.mkstemp(prefix=".meetings.", suffix=".tmp", dir=directory)
 
 
 def is_command_available(command: str) -> bool:


### PR DESCRIPTION
## Summary

Partial implementation of [#24](https://github.com/jordan8037310/zoom-cli/issues/24) — atomic `meetings.json` writes + `--dry-run`/`--yes` on `zoom rm`.

**Stacked on PR #26** (`fix/issue-6-url-parsing`), which is itself stacked on #25. When the parents merge, GitHub will auto-rebase this onto `main`.

### Atomic writes

`write_to_meeting_file` previously did a plain `open(...).write(...)`. A kill or crash mid-write would leave a half-written `meetings.json`, and `get_meeting_file_contents` would silently swallow the resulting `JSONDecodeError` and return `{}` — quietly losing every saved meeting on next read.

New flow:
1. Serialize the new content to a sibling tempfile (created via `tempfile.mkstemp` in the same directory).
2. `flush()` + `os.fsync()` the tempfile.
3. `os.replace()` it onto `meetings.json` (atomic on POSIX and on Windows for files on the same filesystem).
4. On any exception, best-effort delete the tempfile so the original `meetings.json` is left intact.

### `zoom rm` safety

- `--dry-run` previews the deletion without modifying the file.
- `--yes` / `-y` skips the new confirmation prompt.
- The confirmation **only fires when the name is picked interactively** (no positional argument). `zoom rm <name>` continues to delete immediately, so existing scripts and shell aliases keep working — no regression.

### Tests (90 total, was 84 — 6 new)

- `write_to_meeting_file` round-trips on disk with no leftover tempfile.
- Mid-write failure (mocked `os.replace`) leaves the original content intact and cleans up the tempfile.
- Unicode round-trip (emoji + non-ASCII).
- `--dry-run` preserves data and prints `[dry-run]` preview.
- Interactive-pick + `n` answer aborts cleanly.
- Interactive-pick + `--yes` deletes without prompting.
- Existing `test_rm_with_argument_no_prompt` still passes (positional path unchanged).

## Deferred from #24 to follow-up PRs

- Schema versioning + forward migrations.
- Numeric meeting-ID validation (9–11 digits).
- URL-encoding the password before building `zoommtg://` URLs.

## Test plan

- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy` clean
- [x] `pytest -q` — 90 passed in 0.19 s
- [ ] CI matrix green
- [ ] Manual smoke: `zoom rm` interactive prompts then confirms; `zoom rm <name>` deletes without prompt; `zoom rm <name> --dry-run` previews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
