### PR TITLE
feat: store meeting passwords in OS keyring (closes #5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `subprocess.run(..., shell=True)` in `is_command_available` with `shutil.which`. The previous shell call was only ever invoked with literal command names, but `shutil.which` is the idiomatic, no-shell spelling.
 - Documented plain-text password storage as a known issue; tracked in #5 for a follow-up PR (OS keyring migration).
 
+### Security (PR [#28](https://github.com/jordan8037310/zoom-cli/pull/28) — closes #5)
+- New meeting passwords now go to the OS keyring (Keychain on macOS, libsecret/Secret-Service on Linux, Credential Manager on Windows) under service `zoom-cli` keyed by meeting name — they no longer land in plaintext in `~/.zoom-cli/meetings.json`.
+- `zoom ls` masks passwords as `********` regardless of where they came from. Even legacy plaintext-in-JSON passwords are now hidden in the listing.
+- `zoom rm <name>` deletes the matching keyring entry alongside the JSON entry, so freed names don't leave orphan secrets.
+- `zoom edit` no longer re-prompts for the `password` field (which would have shown the current value as a default — leaking it on screen). Use `--password` to update.
+- Back-compat: `_launch_name` reads the keyring first, then falls back to plaintext-in-JSON. Existing users keep working without action; any subsequent `zoom save` migrates that meeting's password to the keyring.
+- Auto-migration of existing plaintext passwords (one-shot scan + redaction with a `version` field) is intentionally **not** done in this PR; it'll come as a separate, opt-in step.
+
 ### Changed (PR [#27](https://github.com/jordan8037310/zoom-cli/pull/27) — partial #24)
 - `write_to_meeting_file` now writes atomically: serialize to a sibling tempfile, `fsync`, then `os.replace` onto `meetings.json`. A crash or kill mid-write can no longer corrupt the file — readers see either the old or the new version, never a partial JSON.
 - `zoom rm` gains `--dry-run` (preview) and `--yes`/`-y` (skip confirmation) flags.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "click>=8.1,<9",
     "click-default-group>=1.2.4,<2",
     "questionary>=2.0,<3",
+    "keyring>=24.0,<26",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Shared pytest fixtures.
 
-These fixtures isolate every test from the user's real ``~/.zoom-cli`` directory
-and from launching real subprocesses.
+These fixtures isolate every test from the user's real ``~/.zoom-cli`` directory,
+the user's real OS keyring, and from launching real subprocesses.
 """
 
 from __future__ import annotations
@@ -10,7 +10,48 @@ import json
 import subprocess
 from pathlib import Path
 
+import keyring
+import keyring.backend
 import pytest
+
+
+class _InMemoryKeyring(keyring.backend.KeyringBackend):
+    """Tiny in-memory keyring backend for tests; isolates from the real OS keyring."""
+
+    priority = 1  # type: ignore[assignment]
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service: str, username: str) -> str | None:
+        return self._store.get((service, username))
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        self._store[(service, username)] = password
+
+    def delete_password(self, service: str, username: str) -> None:
+        if (service, username) not in self._store:
+            import keyring.errors
+
+            raise keyring.errors.PasswordDeleteError(f"{service}:{username} not set")
+        del self._store[(service, username)]
+
+
+@pytest.fixture(autouse=True)
+def isolated_keyring() -> _InMemoryKeyring:
+    """Replace the real OS keyring with an in-memory one for every test.
+
+    Autouse so no test can accidentally read or write the developer's real
+    keychain. Returns the backend instance so individual tests can pre-seed
+    it if needed.
+    """
+    backend = _InMemoryKeyring()
+    previous = keyring.get_keyring()
+    keyring.set_keyring(backend)
+    try:
+        yield backend
+    finally:
+        keyring.set_keyring(previous)
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,13 +64,17 @@ def test_save_url_via_flags(runner: CliRunner, tmp_zoom_cli_home: Path) -> None:
 
 
 def test_save_id_password_via_flags(runner: CliRunner, tmp_zoom_cli_home: Path) -> None:
+    """Password lands in keyring, not in meetings.json."""
+    from zoom_cli import secrets
+
     result = runner.invoke(
         main,
         ["save", "-n", "standup", "--id", "1234567890", "-p", "pw"],
     )
     assert result.exit_code == 0, result.output
     on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
-    assert on_disk == {"standup": {"id": "1234567890", "password": "pw"}}
+    assert on_disk == {"standup": {"id": "1234567890"}}
+    assert secrets.get_password("standup") == "pw"
 
 
 def test_save_url_does_not_prompt_for_password_when_pwd_in_url(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -267,6 +267,23 @@ def test_launch_name_falls_back_to_legacy_json_password(
     assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=555&pwd=legacy-only"]]
 
 
+def test_launch_name_empty_keyring_password_overrides_url_pwd(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """Superpowers review on PR #28: if the user explicitly stored an
+    empty-string password in the keyring (a deliberate "no password"),
+    that empty value must beat the URL's ``pwd=`` rather than falling
+    through to it."""
+    from zoom_cli import secrets
+
+    write_meetings({"team": {"url": "https://zoom.us/j/123?pwd=fromurl"}})
+    secrets.set_password("team", "")  # explicit empty
+
+    commands_mod._launch_name("team")
+    # Empty keyring password wins → no &pwd= appended.
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123"]]
+
+
 def test_save_url_with_no_password_clears_keyring(tmp_zoom_cli_home) -> None:
     """`_save_url(name, url, "")` must clear any pre-existing keyring entry —
     otherwise re-saving a meeting "without a password" would silently keep
@@ -277,6 +294,31 @@ def test_save_url_with_no_password_clears_keyring(tmp_zoom_cli_home) -> None:
     commands_mod._save_url("standup", "https://zoom.us/j/1", "")
 
     assert secrets.get_password("standup") is None
+
+
+def test_save_url_keyring_failure_leaves_json_untouched(
+    tmp_zoom_cli_home, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex regression for PR #28: save must write keyring BEFORE JSON.
+    If the keyring write fails, the prior on-disk state is preserved."""
+    from zoom_cli import secrets
+
+    # Seed: existing meeting with a known JSON contents.
+    (tmp_zoom_cli_home / "meetings.json").write_text(
+        '{"standup": {"url": "https://old.example/j/1"}}'
+    )
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("keyring backend exploded")
+
+    monkeypatch.setattr(secrets, "set_password", boom)
+
+    with pytest.raises(RuntimeError, match="keyring backend exploded"):
+        commands_mod._save_url("standup", "https://NEW.example/j/2", "newpw")
+
+    # JSON must be unchanged — the rewrite never happened.
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    assert on_disk == {"standup": {"url": "https://old.example/j/1"}}
 
 
 def test_remove_deletes_keyring_entry(write_meetings, tmp_zoom_cli_home) -> None:
@@ -442,25 +484,49 @@ def test_edit_with_password_flag_writes_to_keyring(
     assert secrets.get_password("team") == "new-pw"
 
 
-def test_edit_skips_legacy_plaintext_password_field(
+def test_edit_migrates_legacy_plaintext_password_into_keyring(
     write_meetings,
     tmp_zoom_cli_home: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A pre-keyring entry has ``password`` in JSON. `_edit` must not prompt
-    for it (we'd be exposing the plaintext via ``default=...``); it just
-    drops the field on the rewrite. The user can re-set the password via
-    ``--password`` if they want."""
+    """A pre-keyring entry has ``password`` in JSON. `_edit` must:
+    1. NOT re-prompt (would expose plaintext via ``default=...``).
+    2. Migrate the value into the keyring before dropping it from JSON.
+
+    Regression for all three reviewers on PR #28 — earlier behavior
+    silently destroyed the legacy plaintext on any edit."""
+    from zoom_cli import secrets
+
     write_meetings({"team": {"url": "https://old.example/j/1", "password": "legacy"}})
+    assert secrets.get_password("team") is None  # nothing in keyring yet
     fake = _FakeQ(["https://kept.example/j/1"])  # only the URL is prompted
     monkeypatch.setattr(commands_mod.questionary, "text", fake)
 
     commands_mod._edit("team", "", "", "")
 
     on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
-    # Legacy password field is gone — and importantly, was never offered as
-    # a default value to the user.
+    # Legacy password field is gone from JSON — but the value is in the keyring.
     assert on_disk == {"team": {"url": "https://kept.example/j/1"}}
+    assert secrets.get_password("team") == "legacy"
+
+
+def test_edit_legacy_password_migration_does_not_overwrite_existing_keyring(
+    write_meetings,
+    tmp_zoom_cli_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If a keyring entry already exists, the (stale) legacy JSON password
+    must NOT overwrite it. The keyring is authoritative."""
+    from zoom_cli import secrets
+
+    write_meetings({"team": {"url": "https://old.example/j/1", "password": "stale-legacy"}})
+    secrets.set_password("team", "fresh-keyring")
+    fake = _FakeQ(["https://kept.example/j/1"])
+    monkeypatch.setattr(commands_mod.questionary, "text", fake)
+
+    commands_mod._edit("team", "", "", "")
+
+    assert secrets.get_password("team") == "fresh-keyring"
 
 
 def test_edit_aborts_cleanly_on_ctrl_c(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -17,15 +17,24 @@ def test_save_url_persists_payload(tmp_zoom_cli_home: Path) -> None:
 
 
 def test_save_url_includes_password_when_provided(tmp_zoom_cli_home: Path) -> None:
+    """Password goes to the OS keyring, not into meetings.json."""
+    from zoom_cli import secrets
+
     commands_mod._save_url("standup", "https://zoom.us/j/1", "p@ss")
+
     on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
-    assert on_disk == {"standup": {"url": "https://zoom.us/j/1", "password": "p@ss"}}
+    assert on_disk == {"standup": {"url": "https://zoom.us/j/1"}}
+    assert secrets.get_password("standup") == "p@ss"
 
 
 def test_save_id_password_persists_payload(tmp_zoom_cli_home: Path) -> None:
+    from zoom_cli import secrets
+
     commands_mod._save_id_password("standup", "1234567890", "secret")
+
     on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
-    assert on_disk == {"standup": {"id": "1234567890", "password": "secret"}}
+    assert on_disk == {"standup": {"id": "1234567890"}}
+    assert secrets.get_password("standup") == "secret"
 
 
 def test_save_id_password_omits_password_when_empty(tmp_zoom_cli_home: Path) -> None:
@@ -217,6 +226,99 @@ def test_launch_name_explicit_password_field_overrides_url_password(
     assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123&pwd=explicit"]]
 
 
+# ---- Keyring integration (issue #5) -------------------------------------
+
+
+def test_launch_name_uses_keyring_password_when_available(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """Keyring is the source of truth — wins over plaintext in JSON."""
+    from zoom_cli import secrets
+
+    write_meetings({"team": {"id": "555"}})
+    secrets.set_password("team", "from-keyring")
+
+    commands_mod._launch_name("team")
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=555&pwd=from-keyring"]]
+
+
+def test_launch_name_keyring_wins_over_legacy_json_password(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """Back-compat ladder: if both a keyring entry and a legacy JSON
+    password exist, the keyring wins. Pre-keyring JSON entries continue
+    to work; once a user re-saves, they migrate."""
+    from zoom_cli import secrets
+
+    write_meetings({"team": {"id": "555", "password": "legacy-json"}})
+    secrets.set_password("team", "from-keyring")
+
+    commands_mod._launch_name("team")
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=555&pwd=from-keyring"]]
+
+
+def test_launch_name_falls_back_to_legacy_json_password(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """No keyring entry → fall back to plaintext JSON password (back-compat)."""
+    write_meetings({"team": {"id": "555", "password": "legacy-only"}})
+
+    commands_mod._launch_name("team")
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=555&pwd=legacy-only"]]
+
+
+def test_save_url_with_no_password_clears_keyring(tmp_zoom_cli_home) -> None:
+    """`_save_url(name, url, "")` must clear any pre-existing keyring entry —
+    otherwise re-saving a meeting "without a password" would silently keep
+    the old one."""
+    from zoom_cli import secrets
+
+    secrets.set_password("standup", "stale")
+    commands_mod._save_url("standup", "https://zoom.us/j/1", "")
+
+    assert secrets.get_password("standup") is None
+
+
+def test_remove_deletes_keyring_entry(write_meetings, tmp_zoom_cli_home) -> None:
+    """`zoom rm` must take the keyring entry with it — leaving an orphan
+    keyring entry under a freed name is a leak."""
+    from zoom_cli import secrets
+
+    write_meetings({"team": {"id": "1"}})
+    secrets.set_password("team", "p")
+
+    commands_mod._remove("team")
+
+    assert secrets.get_password("team") is None
+
+
+def test_ls_masks_keyring_password(write_meetings, capsys: pytest.CaptureFixture[str]) -> None:
+    from zoom_cli import secrets
+
+    write_meetings({"team": {"id": "1"}})
+    secrets.set_password("team", "very-secret")
+
+    commands_mod._ls()
+    out = capsys.readouterr().out
+    assert "very-secret" not in out, "real password leaked into ls output"
+    assert "********" in out
+    assert "password:" in out
+
+
+def test_ls_masks_legacy_json_password(write_meetings, capsys: pytest.CaptureFixture[str]) -> None:
+    """Legacy plaintext-in-JSON passwords must also be masked, even though
+    the storage path is the back-compat one."""
+    write_meetings({"team": {"id": "1", "password": "legacy"}})
+
+    commands_mod._ls()
+    out = capsys.readouterr().out
+    assert "legacy" not in out, "legacy plaintext password leaked into ls output"
+    assert "********" in out
+
+
+# -------------------------------------------------------------------------
+
+
 def test_launch_name_personal_link_with_explicit_password_passes_password(
     write_meetings, captured_launches: list[list[str]]
 ) -> None:
@@ -302,38 +404,63 @@ class _FakeQ:
         return self._answers.pop(0)
 
 
-def test_edit_overwrites_each_field_with_new_answer(
+def test_edit_overwrites_url_with_new_answer(
     write_meetings,
     tmp_zoom_cli_home: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    write_meetings({"team": {"url": "https://old.example/j/1", "password": "old"}})
-    fake = _FakeQ(["https://new.example/j/2", "new"])
+    """`_edit` no longer prompts for password (it's in the keyring); the URL
+    field is still re-prompted."""
+    write_meetings({"team": {"url": "https://old.example/j/1"}})
+    fake = _FakeQ(["https://new.example/j/2"])
     monkeypatch.setattr(commands_mod.questionary, "text", fake)
 
     commands_mod._edit("team", "", "", "")
 
     on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
-    assert on_disk == {"team": {"url": "https://new.example/j/2", "password": "new"}}
+    assert on_disk == {"team": {"url": "https://new.example/j/2"}}
 
 
-def test_edit_allows_clearing_a_field_with_empty_string(
+def test_edit_with_password_flag_writes_to_keyring(
     write_meetings,
     tmp_zoom_cli_home: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Regression: ``ask() or val`` silently restored the old value when the
-    user submitted an empty string. The fix preserves the empty string and
-    only treats ``None`` (Ctrl-C) as cancellation.
-    """
-    write_meetings({"team": {"url": "https://old.example/j/1", "password": "old"}})
-    fake = _FakeQ(["https://kept.example/j/1", ""])  # second answer intentionally empty
+    """Passing ``--password`` (positional ``password`` arg here) updates the
+    keyring entry; nothing about the password leaks back into meetings.json."""
+    from zoom_cli import secrets
+
+    write_meetings({"team": {"url": "https://old.example/j/1"}})
+    secrets.set_password("team", "old-pw")
+    fake = _FakeQ(["https://new.example/j/2"])
+    monkeypatch.setattr(commands_mod.questionary, "text", fake)
+
+    commands_mod._edit("team", "", "", "new-pw")
+
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    assert on_disk == {"team": {"url": "https://new.example/j/2"}}
+    assert secrets.get_password("team") == "new-pw"
+
+
+def test_edit_skips_legacy_plaintext_password_field(
+    write_meetings,
+    tmp_zoom_cli_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pre-keyring entry has ``password`` in JSON. `_edit` must not prompt
+    for it (we'd be exposing the plaintext via ``default=...``); it just
+    drops the field on the rewrite. The user can re-set the password via
+    ``--password`` if they want."""
+    write_meetings({"team": {"url": "https://old.example/j/1", "password": "legacy"}})
+    fake = _FakeQ(["https://kept.example/j/1"])  # only the URL is prompted
     monkeypatch.setattr(commands_mod.questionary, "text", fake)
 
     commands_mod._edit("team", "", "", "")
 
     on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
-    assert on_disk == {"team": {"url": "https://kept.example/j/1", "password": ""}}
+    # Legacy password field is gone — and importantly, was never offered as
+    # a default value to the user.
+    assert on_disk == {"team": {"url": "https://kept.example/j/1"}}
 
 
 def test_edit_aborts_cleanly_on_ctrl_c(

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,54 @@
+"""Tests for zoom_cli.secrets — the OS keyring facade."""
+
+from __future__ import annotations
+
+import keyring
+import keyring.errors
+import pytest
+from zoom_cli import secrets
+
+
+def test_set_then_get_round_trips() -> None:
+    secrets.set_password("daily", "p@ss")
+    assert secrets.get_password("daily") == "p@ss"
+
+
+def test_get_returns_none_for_unknown_meeting() -> None:
+    assert secrets.get_password("never-seen") is None
+
+
+def test_delete_removes_entry() -> None:
+    secrets.set_password("temp", "x")
+    secrets.delete_password("temp")
+    assert secrets.get_password("temp") is None
+
+
+def test_delete_is_noop_when_entry_absent() -> None:
+    # Must not raise.
+    secrets.delete_password("never-existed")
+
+
+def test_set_password_with_empty_string_is_stored() -> None:
+    """Caller wants 'no password' → use delete_password. set_password('')
+    intentionally writes through; this test just pins that contract."""
+    secrets.set_password("empty", "")
+    assert secrets.get_password("empty") == ""
+
+
+def test_get_password_returns_none_when_backend_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Headless Linux boxes without DBus raise KeyringError. We treat that
+    as 'no stored password' so the CLI degrades gracefully."""
+
+    def boom(*_args, **_kwargs):
+        raise keyring.errors.KeyringError("no backend")
+
+    monkeypatch.setattr(keyring, "get_password", boom)
+    assert secrets.get_password("anything") is None
+
+
+def test_service_name_constant_is_zoom_cli() -> None:
+    """Pin the service name so a future rename doesn't silently orphan
+    every existing user's stored passwords."""
+    assert secrets.SERVICE_NAME == "zoom-cli"

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -35,17 +35,44 @@ def test_set_password_with_empty_string_is_stored() -> None:
     assert secrets.get_password("empty") == ""
 
 
-def test_get_password_returns_none_when_backend_unavailable(
+def test_get_password_returns_none_when_no_keyring_backend(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Headless Linux boxes without DBus raise KeyringError. We treat that
+    """Headless Linux boxes without DBus raise NoKeyringError. We treat that
     as 'no stored password' so the CLI degrades gracefully."""
 
     def boom(*_args, **_kwargs):
-        raise keyring.errors.KeyringError("no backend")
+        raise keyring.errors.NoKeyringError("no backend")
 
     monkeypatch.setattr(keyring, "get_password", boom)
     assert secrets.get_password("anything") is None
+
+
+def test_get_password_returns_none_on_init_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """InitError is the other 'no backend' case we degrade gracefully on."""
+
+    def boom(*_args, **_kwargs):
+        raise keyring.errors.InitError("backend init failed")
+
+    monkeypatch.setattr(keyring, "get_password", boom)
+    assert secrets.get_password("anything") is None
+
+
+def test_get_password_does_not_swallow_locked_keyring(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for python-review on PR #28: a locked-keyring or other
+    KeyringError MUST propagate. Silently returning None would launch
+    meetings with no password — wrong-launch silently."""
+
+    def boom(*_args, **_kwargs):
+        raise keyring.errors.KeyringError("locked or other failure")
+
+    monkeypatch.setattr(keyring, "get_password", boom)
+    with pytest.raises(keyring.errors.KeyringError):
+        secrets.get_password("anything")
 
 
 def test_service_name_constant_is_zoom_cli() -> None:

--- a/zoom_cli/commands.py
+++ b/zoom_cli/commands.py
@@ -1,6 +1,7 @@
 import click
 import questionary
 
+from zoom_cli import secrets
 from zoom_cli.utils import (
     ConsoleColor,
     LauncherUnavailableError,
@@ -11,6 +12,24 @@ from zoom_cli.utils import (
     strip_url_scheme,
     write_to_meeting_file,
 )
+
+
+def _resolve_password(name: str, entry: dict, url_password: str = "") -> str:
+    """Pick the right password for a saved meeting.
+
+    Resolution order:
+    1. OS keyring (new entries land here as of #5).
+    2. Plaintext ``password`` field in ``meetings.json`` (back-compat for
+       entries saved before keyring migration).
+    3. ``pwd=`` extracted from the saved URL.
+
+    Empty strings count as a deliberate "no password" — only ``None`` from
+    the keyring falls through to step 2.
+    """
+    keyring_pw = secrets.get_password(name)
+    if keyring_pw is not None:
+        return keyring_pw
+    return entry.get("password", url_password)
 
 
 def _print_error(message: str) -> None:
@@ -46,11 +65,7 @@ def _launch_name(name: str) -> None:
     try:
         if "url" in entry:
             meeting_id, url_password = parse_meeting_url(entry["url"])
-            # Presence-check via dict.get: a deliberately empty saved password
-            # ({"password": ""}) returns "" — meaning "no password" — rather
-            # than falling back to url_password. Preserves the contract from
-            # PR #25 where `_edit` lets users intentionally clear a field.
-            password = entry.get("password", url_password)
+            password = _resolve_password(name, entry, url_password)
 
             if meeting_id is not None:
                 launch_zoommtg(meeting_id, password)
@@ -66,7 +81,7 @@ def _launch_name(name: str) -> None:
             return
 
         if "id" in entry:
-            launch_zoommtg(entry["id"], entry.get("password", ""))
+            launch_zoommtg(entry["id"], _resolve_password(name, entry))
             return
 
         _print_error(
@@ -83,17 +98,21 @@ def _launch_name(name: str) -> None:
 def _save_url(name, url, password):
     contents = get_meeting_file_contents()
     contents[name] = {"url": url}
-    if password:
-        contents[name]["password"] = password
     write_to_meeting_file(contents)
+    if password:
+        secrets.set_password(name, password)
+    else:
+        secrets.delete_password(name)
 
 
 def _save_id_password(name, id, password):
     contents = get_meeting_file_contents()
     contents[name] = {"id": id}
-    if password:
-        contents[name]["password"] = password
     write_to_meeting_file(contents)
+    if password:
+        secrets.set_password(name, password)
+    else:
+        secrets.delete_password(name)
 
 
 def _edit(name, url, id, password):
@@ -104,13 +123,17 @@ def _edit(name, url, id, password):
         new_dict["url"] = url
     if id:
         new_dict["id"] = id
-    if password:
-        new_dict["password"] = password
 
-    # For each existing field, re-prompt with the new value (if a flag was
-    # passed) or the old value as the default. The user can intentionally
-    # clear a field by submitting an empty string; only Ctrl-C aborts.
+    # For each existing non-secret field, re-prompt with the new value (if a
+    # flag was passed) or the old value as the default. The user can clear a
+    # field by submitting an empty string; only Ctrl-C aborts. Passwords are
+    # NOT re-prompted here — they live in the keyring and are managed via
+    # the explicit ``--password`` flag.
     for key, val in contents[name].items():
+        if key == "password":
+            # Legacy plaintext password from a pre-keyring entry. Skip the
+            # prompt; we'll migrate it to the keyring below.
+            continue
         answer = questionary.text(key, default=new_dict.get(key, val)).ask()
         if answer is None:
             raise click.Abort
@@ -120,11 +143,17 @@ def _edit(name, url, id, password):
     contents[name] = new_dict
     write_to_meeting_file(contents)
 
+    # Password updates go through the keyring. If --password was passed,
+    # update; otherwise leave whatever's already there alone.
+    if password:
+        secrets.set_password(name, password)
+
 
 def _remove(name):
     contents = get_meeting_file_contents()
     del contents[name]
     write_to_meeting_file(contents)
+    secrets.delete_password(name)
 
 
 def _ls():
@@ -136,8 +165,11 @@ def _ls():
             print(ConsoleColor.BOLD + "    url: " + ConsoleColor.END + entries["url"])
         if "id" in entries:
             print(ConsoleColor.BOLD + "    id: " + ConsoleColor.END + entries["id"])
-        if "password" in entries:
-            print(ConsoleColor.BOLD + "    password: " + ConsoleColor.END + entries["password"])
+        # Passwords are masked. They live in the OS keyring (or, for
+        # not-yet-migrated entries, plaintext in meetings.json).
+        has_password = "password" in entries or secrets.get_password(name) is not None
+        if has_password:
+            print(ConsoleColor.BOLD + "    password: " + ConsoleColor.END + "********")
 
         if idx < len(meetings) - 1:
             print()

--- a/zoom_cli/commands.py
+++ b/zoom_cli/commands.py
@@ -96,28 +96,35 @@ def _launch_name(name: str) -> None:
 
 
 def _save_url(name, url, password):
+    # Write the keyring BEFORE writing the JSON. If the keyring write fails
+    # (e.g. backend unhealthy), the user's existing meetings.json is left
+    # untouched — they don't end up with a meeting that has no usable
+    # password anywhere. Codex review on #28 caught this ordering bug.
+    if password:
+        secrets.set_password(name, password)
+    else:
+        secrets.delete_password(name)
+
     contents = get_meeting_file_contents()
     contents[name] = {"url": url}
     write_to_meeting_file(contents)
-    if password:
-        secrets.set_password(name, password)
-    else:
-        secrets.delete_password(name)
 
 
 def _save_id_password(name, id, password):
-    contents = get_meeting_file_contents()
-    contents[name] = {"id": id}
-    write_to_meeting_file(contents)
     if password:
         secrets.set_password(name, password)
     else:
         secrets.delete_password(name)
+
+    contents = get_meeting_file_contents()
+    contents[name] = {"id": id}
+    write_to_meeting_file(contents)
 
 
 def _edit(name, url, id, password):
     contents = get_meeting_file_contents()
     new_dict: dict[str, str] = {}
+    legacy_plaintext_password: str | None = None
 
     if url:
         new_dict["url"] = url
@@ -131,22 +138,31 @@ def _edit(name, url, id, password):
     # the explicit ``--password`` flag.
     for key, val in contents[name].items():
         if key == "password":
-            # Legacy plaintext password from a pre-keyring entry. Skip the
-            # prompt; we'll migrate it to the keyring below.
+            # Legacy plaintext password from a pre-keyring entry. Capture it
+            # so we can migrate it into the keyring below — never just drop
+            # it (all three reviewers on #28 flagged the silent loss).
+            legacy_plaintext_password = val
             continue
         answer = questionary.text(key, default=new_dict.get(key, val)).ask()
         if answer is None:
             raise click.Abort
         new_dict[key] = answer
 
+    # Password handling — keyring is the source of truth.
+    # Order matters: write keyring before rewriting JSON so a keyring-side
+    # failure leaves the user's prior state intact.
+    if password:
+        # Explicit --password flag wins.
+        secrets.set_password(name, password)
+    elif legacy_plaintext_password is not None and secrets.get_password(name) is None:
+        # Migrate legacy plaintext into the keyring on first edit. Only do
+        # this if there's no existing keyring entry — never overwrite a
+        # newer keyring value with stale legacy plaintext.
+        secrets.set_password(name, legacy_plaintext_password)
+
     del contents[name]
     contents[name] = new_dict
     write_to_meeting_file(contents)
-
-    # Password updates go through the keyring. If --password was passed,
-    # update; otherwise leave whatever's already there alone.
-    if password:
-        secrets.set_password(name, password)
 
 
 def _remove(name):

--- a/zoom_cli/secrets.py
+++ b/zoom_cli/secrets.py
@@ -31,13 +31,17 @@ def get_password(meeting_name: str) -> str | None:
     Returns ``None`` (not the empty string) when the entry doesn't exist so
     callers can distinguish "not in keyring" from "saved as empty"; current
     callers don't rely on that distinction but future callers might.
+
+    Catches only the "no backend available" errors (``NoKeyringError``,
+    ``InitError``) so the CLI degrades gracefully on a headless Linux box
+    with no DBus. Locked-keyring errors and other failures are intentionally
+    NOT caught here — those mean the backend is present but refused, and a
+    silent fall-through would launch meetings with the wrong (or no)
+    password. The caller sees the exception and can decide what to do.
     """
     try:
         return keyring.get_password(SERVICE_NAME, meeting_name)
-    except keyring.errors.KeyringError:
-        # Backend unavailable (e.g. no DBus on a headless Linux box). Treat
-        # as "no stored password" so the CLI degrades gracefully — meetings
-        # without a stored password just prompt or fail at launch.
+    except (keyring.errors.NoKeyringError, keyring.errors.InitError):
         return None
 
 

--- a/zoom_cli/secrets.py
+++ b/zoom_cli/secrets.py
@@ -1,0 +1,56 @@
+"""OS keyring-backed password storage for saved meetings.
+
+Replaces the prior practice of writing meeting passwords as plaintext into
+``~/.zoom-cli/meetings.json``. Each saved meeting's password lives under the
+keyring service ``zoom-cli`` keyed by the meeting name.
+
+Storage layout
+--------------
+- macOS: Keychain
+- Linux: Secret Service (libsecret) / KWallet
+- Windows: Credential Manager
+
+The :data:`SERVICE_NAME` constant is the only thing other modules import.
+Tests can swap the keyring backend with ``keyring.set_keyring(...)`` for
+isolation; nothing in this module touches the real keyring at import time.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import keyring
+import keyring.errors
+
+SERVICE_NAME = "zoom-cli"
+
+
+def get_password(meeting_name: str) -> str | None:
+    """Return the saved password for ``meeting_name`` or ``None`` if missing.
+
+    Returns ``None`` (not the empty string) when the entry doesn't exist so
+    callers can distinguish "not in keyring" from "saved as empty"; current
+    callers don't rely on that distinction but future callers might.
+    """
+    try:
+        return keyring.get_password(SERVICE_NAME, meeting_name)
+    except keyring.errors.KeyringError:
+        # Backend unavailable (e.g. no DBus on a headless Linux box). Treat
+        # as "no stored password" so the CLI degrades gracefully — meetings
+        # without a stored password just prompt or fail at launch.
+        return None
+
+
+def set_password(meeting_name: str, password: str) -> None:
+    """Store ``password`` under ``meeting_name``.
+
+    Empty strings are written through; callers that want "no password" should
+    call :func:`delete_password` instead.
+    """
+    keyring.set_password(SERVICE_NAME, meeting_name, password)
+
+
+def delete_password(meeting_name: str) -> None:
+    """Remove the entry for ``meeting_name``. No-op if it doesn't exist."""
+    with contextlib.suppress(keyring.errors.PasswordDeleteError):
+        keyring.delete_password(SERVICE_NAME, meeting_name)


### PR DESCRIPTION
## Summary

Implements [#5](https://github.com/jordan8037310/zoom-cli/issues/5) — moves meeting passwords out of plaintext JSON and into the OS keyring (Keychain on macOS, Secret-Service/libsecret on Linux, Credential Manager on Windows).

**Stacked on PR #27** (`chore/issue-24-atomic-writes-and-rm-flags`), which is stacked on PR #26, which is stacked on PR #25. When the parents merge, GitHub auto-rebases this onto `main`.

Closes #5.

## What's in here

### New module: `zoom_cli/secrets.py`
A small facade over the `keyring` library:
- `get_password(name) -> str | None` (`None` on missing entry or backend error)
- `set_password(name, password)` 
- `delete_password(name)` (no-op on missing entry)
- `SERVICE_NAME = "zoom-cli"` — pinned by a test so a future rename can't silently orphan every user's stored passwords

### Wiring in `zoom_cli/commands.py`
- **`_save_url` / `_save_id_password`** — write the password to the keyring (or delete the keyring entry when the password is empty); JSON payload no longer carries a `password` field.
- **`_remove`** — deletes the matching keyring entry alongside the JSON entry. No orphan secrets.
- **`_edit`** — no longer re-prompts for the `password` field. The previous prompt used the existing password as `default=...`, which would have leaked the plaintext on screen. Use `zoom edit -p NEW_PW` to update.
- **`_launch_name`** — uses a new `_resolve_password(name, entry, url_password)` helper with a clean fallback ladder:
  1. OS keyring (new entries land here)
  2. Plaintext `password` in JSON (back-compat for pre-keyring entries)
  3. `pwd=` extracted from the saved URL
- **`_ls`** — masks all passwords as `********`, whether they came from keyring or legacy JSON.

### Tests (116 total, was 99 — **17 new**)
- **`tests/test_secrets.py`** (7): round-trip, missing entry, delete-noop, empty-string write-through, `KeyringError` graceful fallback, service-name pinning.
- **`tests/test_commands.py`** (8 keyring-integration): launch reads keyring, keyring wins over legacy JSON, legacy JSON still works as fallback, saving without a password clears the keyring entry, `rm` deletes the keyring entry, `ls` masks both keyring and legacy passwords.
- **Edited 3 existing tests** that asserted plaintext-in-JSON to instead assert "URL/ID in JSON, password in keyring".
- **Autouse fixture `isolated_keyring`** in `conftest.py` — every test runs against an in-memory keyring backend so no test can accidentally write to the developer's real Keychain.

### Deferred (intentional)
- **Auto-migration** of existing plaintext passwords. The user's data sits unchanged on their machine until they next run `zoom save <name> -p ...`, at which point that one entry migrates. A separate PR will add a one-shot scan that moves all existing plaintext to the keyring + redacts + bumps a schema version field.

## Test plan

- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy` clean
- [x] `pytest -q` — 116 passed in 0.19 s
- [x] CI matrix green
- [ ] Manual smoke (macOS): `zoom save -n smoke -p hunter2`, then `security find-generic-password -s zoom-cli -a smoke -w` returns `hunter2`. `zoom ls` shows `password: ********`. `zoom rm smoke` removes both JSON and keyring entries.

## Behavior preserved

- Existing entries with `password` in `meetings.json` continue to launch correctly via the back-compat fallback.
- The local-launcher mode (`zoom <url>`, `zoom save`, `zoom rm`, etc.) is the same UX from the user's perspective; the only externally visible change is `zoom ls` masking the password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
