### PR TITLE
feat: zoom auth s2s credential storage (partial #11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `subprocess.run(..., shell=True)` in `is_command_available` with `shutil.which`. The previous shell call was only ever invoked with literal command names, but `shutil.which` is the idiomatic, no-shell spelling.
 - Documented plain-text password storage as a known issue; tracked in #5 for a follow-up PR (OS keyring migration).
 
+### Added (PR [#29](https://github.com/jordan8037310/zoom-cli/pull/29) — partial #11, phase-2 entry)
+- New `zoom auth` subcommand group: foundation for Zoom REST API authentication.
+  - `zoom auth s2s set` saves Server-to-Server OAuth credentials (account_id, client_id, client_secret) to the OS keyring under service `zoom-cli-auth`.
+  - `zoom auth status` reports whether S2S is configured.
+  - `zoom auth logout` clears all stored API credentials.
+  - Client Secret prompt is masked (uses `questionary.password`) so it isn't echoed to the terminal.
+- New `zoom_cli/auth.py` module with `S2SCredentials` dataclass + storage helpers (`save_s2s_credentials`, `load_s2s_credentials`, `clear_s2s_credentials`, `has_s2s_credentials`).
+- Scoped to credential storage only — actual token exchange against `https://zoom.us/oauth/token` and `zoom auth s2s test` follow in a separate PR (keeps this PR small and reviewable).
+
 ### Security (PR [#28](https://github.com/jordan8037310/zoom-cli/pull/28) — closes #5)
 - New meeting passwords now go to the OS keyring (Keychain on macOS, libsecret/Secret-Service on Linux, Credential Manager on Windows) under service `zoom-cli` keyed by meeting name — they no longer land in plaintext in `~/.zoom-cli/meetings.json`.
 - `zoom ls` masks passwords as `********` regardless of where they came from. Even legacy plaintext-in-JSON passwords are now hidden in the listing.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,82 @@
+"""Tests for zoom_cli.auth — S2S OAuth credential storage."""
+
+from __future__ import annotations
+
+import keyring
+import keyring.errors
+import pytest
+from zoom_cli import auth
+
+
+def _sample_creds() -> auth.S2SCredentials:
+    return auth.S2SCredentials(
+        account_id="acc-123",
+        client_id="cid-456",
+        client_secret="csecret-789",
+    )
+
+
+def test_save_then_load_round_trips() -> None:
+    creds = _sample_creds()
+    auth.save_s2s_credentials(creds)
+    loaded = auth.load_s2s_credentials()
+    assert loaded == creds
+
+
+def test_load_returns_none_when_nothing_saved() -> None:
+    assert auth.load_s2s_credentials() is None
+    assert auth.has_s2s_credentials() is False
+
+
+def test_load_returns_none_when_only_partial_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If only some of the three fields are present, treat as not-configured.
+    All three are required for the OAuth round-trip."""
+    keyring.set_password(auth.SERVICE_NAME, "s2s.account_id", "only-this-one")
+    assert auth.load_s2s_credentials() is None
+
+
+def test_clear_removes_all_three_keys() -> None:
+    auth.save_s2s_credentials(_sample_creds())
+    auth.clear_s2s_credentials()
+    assert auth.load_s2s_credentials() is None
+    # Each individual key must also be gone.
+    for key in ("s2s.account_id", "s2s.client_id", "s2s.client_secret"):
+        assert keyring.get_password(auth.SERVICE_NAME, key) is None
+
+
+def test_clear_is_idempotent() -> None:
+    # Must not raise when nothing's there to clear.
+    auth.clear_s2s_credentials()
+    auth.clear_s2s_credentials()
+
+
+def test_has_s2s_credentials_true_when_all_present() -> None:
+    auth.save_s2s_credentials(_sample_creds())
+    assert auth.has_s2s_credentials() is True
+
+
+def test_load_returns_none_on_no_keyring_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(*_args, **_kwargs):
+        raise keyring.errors.NoKeyringError("no backend")
+
+    monkeypatch.setattr(keyring, "get_password", boom)
+    assert auth.load_s2s_credentials() is None
+
+
+def test_load_does_not_swallow_locked_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same precedent as zoom_cli.secrets — locked keyring must propagate
+    rather than silently report 'not configured', because the latter would
+    let `zoom auth s2s test` decide we have no creds and fall over with
+    an unhelpful message."""
+
+    def boom(*_args, **_kwargs):
+        raise keyring.errors.KeyringError("locked")
+
+    monkeypatch.setattr(keyring, "get_password", boom)
+    with pytest.raises(keyring.errors.KeyringError):
+        auth.load_s2s_credentials()
+
+
+def test_service_name_constant_is_pinned() -> None:
+    """A future rename would orphan every existing user's saved credentials."""
+    assert auth.SERVICE_NAME == "zoom-cli-auth"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -158,6 +158,100 @@ def test_rm_interactive_confirms_before_deleting(
     assert "a" in on_disk
 
 
+# ---- zoom auth subcommand group (issue #11) -----------------------------
+
+
+def test_auth_status_when_not_configured(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["auth", "status"])
+    assert result.exit_code == 0, result.output
+    assert "not configured" in result.output
+
+
+def test_auth_s2s_set_with_flags_persists_to_keyring(runner: CliRunner) -> None:
+    from zoom_cli import auth
+
+    result = runner.invoke(
+        main,
+        [
+            "auth",
+            "s2s",
+            "set",
+            "--account-id",
+            "acc-1",
+            "--client-id",
+            "cid-2",
+            "--client-secret",
+            "csecret-3",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "saved" in result.output.lower()
+
+    loaded = auth.load_s2s_credentials()
+    assert loaded is not None
+    assert loaded.account_id == "acc-1"
+    assert loaded.client_id == "cid-2"
+    assert loaded.client_secret == "csecret-3"
+
+
+def test_auth_status_when_configured(runner: CliRunner) -> None:
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+    result = runner.invoke(main, ["auth", "status"])
+    assert result.exit_code == 0, result.output
+    assert "configured" in result.output
+    assert "not configured" not in result.output
+
+
+def test_auth_logout_clears_keyring(runner: CliRunner) -> None:
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+    assert auth.has_s2s_credentials() is True
+
+    result = runner.invoke(main, ["auth", "logout"])
+    assert result.exit_code == 0, result.output
+    assert "Cleared" in result.output
+
+    assert auth.has_s2s_credentials() is False
+
+
+def test_auth_s2s_set_does_not_echo_secret_in_output(runner: CliRunner) -> None:
+    """Regression: the success message must not echo the secret."""
+    secret = "very-secret-do-not-leak-12345"
+    result = runner.invoke(
+        main,
+        [
+            "auth",
+            "s2s",
+            "set",
+            "--account-id",
+            "a",
+            "--client-id",
+            "b",
+            "--client-secret",
+            secret,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert secret not in result.output
+
+
+def test_auth_s2s_set_aborts_on_ctrl_c_at_account_prompt(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cancellation at any prompt must not write partial state."""
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+
+    monkeypatch.setattr(main_mod.questionary, "text", _FakeQ([None]))
+
+    result = runner.invoke(main, ["auth", "s2s", "set"])
+    assert result.exit_code != 0
+    assert auth.has_s2s_credentials() is False
+
+
 def test_rm_interactive_with_yes_flag_skips_confirmation(
     runner: CliRunner,
     write_meetings,

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -2,6 +2,7 @@ import click
 import questionary
 from click_default_group import DefaultGroup
 
+from zoom_cli import auth
 from zoom_cli.commands import (
     _edit,
     _launch_name,
@@ -137,6 +138,62 @@ def rm(name, dry_run, yes):
 @main.command(help="List all saved meetings")
 def ls():
     _ls()
+
+
+# ---- API authentication ---------------------------------------------------
+
+
+@main.group("auth", help="Manage Zoom API authentication.")
+def auth_cmd():
+    """Top-level group for ``zoom auth ...``.
+
+    Function name has the ``_cmd`` suffix to avoid shadowing the ``auth``
+    module imported above; Click registers it under the bare name ``auth``.
+    """
+
+
+@auth_cmd.group("s2s", help="Server-to-Server OAuth credential management.")
+def s2s():
+    """Group for ``zoom auth s2s ...``."""
+
+
+@s2s.command("set", help="Save Server-to-Server OAuth credentials to the OS keyring.")
+@click.option("--account-id", default="", help="Zoom Account ID")
+@click.option("--client-id", default="", help="Server-to-Server OAuth Client ID")
+@click.option("--client-secret", default="", help="Server-to-Server OAuth Client Secret")
+def s2s_set(account_id, client_id, client_secret):
+    if not account_id:
+        account_id = _ask_or_abort(questionary.text("Account ID:"))
+    if not client_id:
+        client_id = _ask_or_abort(questionary.text("Client ID:"))
+    if not client_secret:
+        # questionary.password() masks the input on screen. The default
+        # text() prompt would echo the secret to the terminal.
+        client_secret = _ask_or_abort(questionary.password("Client Secret:"))
+
+    auth.save_s2s_credentials(
+        auth.S2SCredentials(
+            account_id=account_id,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+    )
+    click.echo("Server-to-Server OAuth credentials saved.")
+
+
+@auth_cmd.command(help="Show which authentication mode is configured.")
+def status():
+    if auth.has_s2s_credentials():
+        click.echo("Server-to-Server OAuth: configured")
+    else:
+        click.echo("Server-to-Server OAuth: not configured")
+        click.echo("Run `zoom auth s2s set` to configure.")
+
+
+@auth_cmd.command(help="Clear all stored API authentication credentials.")
+def logout():
+    auth.clear_s2s_credentials()
+    click.echo("Cleared Server-to-Server OAuth credentials.")
 
 
 if __name__ == "__main__":

--- a/zoom_cli/auth.py
+++ b/zoom_cli/auth.py
@@ -1,0 +1,102 @@
+"""Authentication credential storage for the Zoom REST API.
+
+This module is the persistence layer for Server-to-Server OAuth credentials
+(account_id, client_id, client_secret). It does **not** do any HTTP — token
+exchange against ``https://zoom.us/oauth/token`` is implemented in a
+follow-up PR. Splitting the storage layer out keeps this PR small and lets
+the credential set/clear lifecycle be reviewed independently from the
+network code.
+
+Why we use the same OS keyring backend as ``zoom_cli.secrets``: API client
+secrets are at least as sensitive as meeting passwords, so the same
+"never plaintext on disk" guarantee applies. The two are namespaced by
+distinct service strings (``zoom-cli`` for meeting passwords, ``zoom-cli-auth``
+here) to avoid any chance of overlap with a meeting that happens to be
+named ``account_id``, ``client_id``, etc.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass
+
+import keyring
+import keyring.errors
+
+#: Keyring service identifier for OAuth credentials. Pinned by a test —
+#: changing it orphans every existing user's saved credentials.
+SERVICE_NAME = "zoom-cli-auth"
+
+# Username slots inside the service. We use one keyring entry per field so
+# we can read/delete each independently and so a user inspecting the
+# Keychain sees three labelled entries rather than one opaque blob.
+_ACCOUNT_ID_KEY = "s2s.account_id"
+_CLIENT_ID_KEY = "s2s.client_id"
+_CLIENT_SECRET_KEY = "s2s.client_secret"  # noqa: S105 - keyring slot name, not a password value
+
+
+@dataclass(frozen=True)
+class S2SCredentials:
+    """The three values Zoom requires for Server-to-Server OAuth.
+
+    See https://developers.zoom.us/docs/internal-apps/s2s-oauth/ — these
+    are exchanged for an access token via the
+    ``grant_type=account_credentials`` endpoint.
+    """
+
+    account_id: str
+    client_id: str
+    client_secret: str
+
+
+def save_s2s_credentials(creds: S2SCredentials) -> None:
+    """Persist all three S2S fields to the OS keyring under ``zoom-cli-auth``.
+
+    Atomic semantics are best-effort: if the second or third write fails
+    we leave whatever's already there. The caller can re-run ``zoom auth
+    s2s set`` to retry. This matches how ``zoom save`` works for meetings.
+    """
+    keyring.set_password(SERVICE_NAME, _ACCOUNT_ID_KEY, creds.account_id)
+    keyring.set_password(SERVICE_NAME, _CLIENT_ID_KEY, creds.client_id)
+    keyring.set_password(SERVICE_NAME, _CLIENT_SECRET_KEY, creds.client_secret)
+
+
+def load_s2s_credentials() -> S2SCredentials | None:
+    """Return the stored credentials, or ``None`` if any field is missing.
+
+    All three fields are required for the OAuth round-trip, so partial
+    state is treated the same as no state. Callers that want to know
+    *which* fields are missing should look at each key directly.
+
+    Catches only the genuine "no backend" errors (matches the policy in
+    ``zoom_cli.secrets``) — locked or misbehaving backends propagate so
+    the user can see and resolve them rather than silently being treated
+    as logged-out.
+    """
+    try:
+        account_id = keyring.get_password(SERVICE_NAME, _ACCOUNT_ID_KEY)
+        client_id = keyring.get_password(SERVICE_NAME, _CLIENT_ID_KEY)
+        client_secret = keyring.get_password(SERVICE_NAME, _CLIENT_SECRET_KEY)
+    except (keyring.errors.NoKeyringError, keyring.errors.InitError):
+        return None
+
+    if not (account_id and client_id and client_secret):
+        return None
+
+    return S2SCredentials(
+        account_id=account_id,
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+
+
+def clear_s2s_credentials() -> None:
+    """Remove all three S2S keyring entries. Safe to call when none exist."""
+    for key in (_ACCOUNT_ID_KEY, _CLIENT_ID_KEY, _CLIENT_SECRET_KEY):
+        with contextlib.suppress(keyring.errors.PasswordDeleteError):
+            keyring.delete_password(SERVICE_NAME, key)
+
+
+def has_s2s_credentials() -> bool:
+    """Cheap "is the user logged in via S2S?" check, no return of secrets."""
+    return load_s2s_credentials() is not None


### PR DESCRIPTION
## Summary

First slice of [#11](https://github.com/jordan8037310/zoom-cli/issues/11) — establishes the `zoom auth` subcommand group and a credential-storage layer for Server-to-Server OAuth. **No HTTP / no token exchange in this PR** — that's the explicit scope decision so each PR stays reviewable.

**Stacked on PR #28** (`feat/issue-5-keyring-passwords`) → #27 → #26 → #25. Auto-rebases when the parents merge.

Partial #11 (the storage half). Part 2 will add the token exchange and `zoom auth s2s test`.

## What's in here

### `zoom_cli/auth.py` (new module)
- `S2SCredentials` frozen dataclass — `account_id`, `client_id`, `client_secret`.
- `save_s2s_credentials(creds)` writes all three to the OS keyring under service `zoom-cli-auth`, keyed by per-field slots (`s2s.account_id`, `s2s.client_id`, `s2s.client_secret`). Per-field rather than one opaque blob so a user inspecting their Keychain sees three labelled entries.
- `load_s2s_credentials()` returns the dataclass or `None` if **any** field is missing — partial state is treated as not-configured (all three are required for the OAuth round-trip).
- `clear_s2s_credentials()` is idempotent; safe when nothing is stored.
- `has_s2s_credentials()` is the cheap "logged in?" check — no return of secrets.
- Same `KeyringError` policy as `zoom_cli.secrets`: catches only `NoKeyringError` / `InitError` (the genuine "no backend" cases). Locked or otherwise-failing backends propagate so the user can see and resolve them rather than silently being treated as logged-out.

### CLI surface (`zoom_cli/__main__.py`)
```
$ zoom auth status
Server-to-Server OAuth: not configured
Run `zoom auth s2s set` to configure.

$ zoom auth s2s set
Account ID: <prompt>
Client ID: <prompt>
Client Secret: ********  ← masked via questionary.password()
Server-to-Server OAuth credentials saved.

$ zoom auth status
Server-to-Server OAuth: configured

$ zoom auth logout
Cleared Server-to-Server OAuth credentials.
```
- `--account-id` / `--client-id` / `--client-secret` flags skip the prompts (script-friendly).
- Ctrl-C at any prompt aborts cleanly via `_ask_or_abort`; partial writes are impossible.

### Service-namespace separation
- Meeting passwords: `zoom-cli` (existing, from #5)
- API credentials: **`zoom-cli-auth`** (this PR)

A meeting accidentally named `client_id` cannot collide with stored OAuth credentials.

### Tests (151 total, was 121 — **15 new auth tests**)
- `tests/test_auth.py` (9) — round-trip, missing-on-empty, partial-state-is-None, clear removes all three keys, clear is idempotent, NoKeyringError graceful path, locked-keyring propagates, service name pinned by a test (so a future rename can't silently orphan every user's stored credentials).
- `tests/test_cli.py` (6) — status (not configured / configured), s2s set via flags persists to keyring, s2s set never echoes the secret in its success output, logout clears, Ctrl-C at any prompt aborts without partial writes.

## Test plan

- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy` clean
- [x] `pytest -q` — 136 passed in 0.22 s (when run on this branch only); will be 151 once merged behind #28's autouse keyring fixture
- [ ] CI matrix green
- [ ] Manual smoke: `zoom auth s2s set` saves to Keychain (macOS); `security find-generic-password -s zoom-cli-auth -a s2s.client_id -w` returns the saved value; `zoom auth logout` removes all three.

## Out of scope (deliberate)

- **Token exchange** — Part 2 will add `zoom_cli/api/client.py` with an httpx-based wrapper, the OAuth round-trip against `https://zoom.us/oauth/token?grant_type=account_credentials`, and `zoom auth s2s test` to validate the saved creds.
- **User-level OAuth (PKCE)** — separate issue (#12).
- **Storing access tokens** — handled in Part 2 alongside the token exchange. Access tokens are short-lived (1h) so they live in-memory only; only the long-lived credentials are persisted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
