### PR TITLE
feat: zoom auth s2s test — OAuth token exchange (closes #11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `subprocess.run(..., shell=True)` in `is_command_available` with `shutil.which`. The previous shell call was only ever invoked with literal command names, but `shutil.which` is the idiomatic, no-shell spelling.
 - Documented plain-text password storage as a known issue; tracked in #5 for a follow-up PR (OS keyring migration).
 
+### Added (PR [#30](https://github.com/jordan8037310/zoom-cli/pull/30) — closes #11)
+- New `zoom auth s2s test` command exchanges saved Server-to-Server OAuth credentials for an access token and reports back ("OK" with token-expiry minutes and granted scopes, or a typed error message). Distinguishes "credentials rejected" (HTTP status from Zoom) from "couldn't reach api.zoom.us" (network/TLS failure) so the user knows where to look.
+- New `zoom_cli/api/` subpackage seeding the REST API client surface. First module: `oauth.py` with `AccessToken` dataclass (with `is_expired` property), `ZoomAuthError` exception (carrying status_code + error_code + reason), and `fetch_access_token(creds)` against `https://zoom.us/oauth/token` using HTTP Basic auth.
+- `httpx>=0.27,<1` added as runtime dependency. Tests use `httpx.MockTransport` so the production code is exercised end-to-end without ever opening a socket.
+
 ### Added (PR [#29](https://github.com/jordan8037310/zoom-cli/pull/29) — partial #11, phase-2 entry)
 - New `zoom auth` subcommand group: foundation for Zoom REST API authentication.
   - `zoom auth s2s set` saves Server-to-Server OAuth credentials (account_id, client_id, client_secret) to the OS keyring under service `zoom-cli-auth`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "click-default-group>=1.2.4,<2",
     "questionary>=2.0,<3",
     "keyring>=24.0,<26",
+    "httpx>=0.27,<1",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -238,6 +238,90 @@ def test_auth_s2s_set_does_not_echo_secret_in_output(runner: CliRunner) -> None:
     assert secret not in result.output
 
 
+# ---- zoom auth s2s test (issue #11 part 2) -------------------------------
+
+
+def test_auth_s2s_test_bails_when_no_credentials_saved(runner: CliRunner) -> None:
+    """`zoom auth s2s test` with nothing configured: print a helpful
+    message and exit non-zero so scripts can detect the unconfigured state."""
+    result = runner.invoke(main, ["auth", "s2s", "test"])
+    assert result.exit_code == 1
+    assert "No Server-to-Server" in result.output
+    assert "zoom auth s2s set" in result.output
+
+
+def test_auth_s2s_test_success_prints_ok_and_scopes(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from datetime import datetime, timedelta, timezone
+
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+    from zoom_cli.api import oauth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+
+    fake_token_value = "very-secret-do-not-leak-bearer-12345"
+    fake_token = oauth.AccessToken(
+        value=fake_token_value,
+        expires_at=datetime.now(timezone.utc) + timedelta(seconds=3600),
+        scopes=("user:read:user", "meeting:read:meeting"),
+    )
+    monkeypatch.setattr(main_mod.oauth, "fetch_access_token", lambda *_a, **_k: fake_token)
+
+    result = runner.invoke(main, ["auth", "s2s", "test"])
+    assert result.exit_code == 0, result.output
+    assert "OK" in result.output
+    assert "user:read:user" in result.output
+    assert "meeting:read:meeting" in result.output
+    # The bearer token value itself must never reach stdout.
+    assert fake_token_value not in result.output
+
+
+def test_auth_s2s_test_reports_zoom_auth_error(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+    from zoom_cli.api import oauth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+
+    def boom(*_a, **_k):
+        raise oauth.ZoomAuthError(
+            "Invalid client_id or client_secret", status_code=401, error_code="invalid_client"
+        )
+
+    monkeypatch.setattr(main_mod.oauth, "fetch_access_token", boom)
+
+    result = runner.invoke(main, ["auth", "s2s", "test"])
+    assert result.exit_code == 1
+    assert "401" in result.output
+    assert "Invalid client_id" in result.output
+
+
+def test_auth_s2s_test_reports_network_error_distinctly(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Distinguish 'creds rejected' from 'couldn't reach Zoom' — the user
+    needs to know which one to debug."""
+    import httpx
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+
+    def boom(*_a, **_k):
+        raise httpx.ConnectError("DNS failed")
+
+    monkeypatch.setattr(main_mod.oauth, "fetch_access_token", boom)
+
+    result = runner.invoke(main, ["auth", "s2s", "test"])
+    assert result.exit_code == 1
+    assert "Could not reach" in result.output
+    assert "DNS failed" in result.output
+
+
 def test_auth_s2s_set_aborts_on_ctrl_c_at_account_prompt(
     runner: CliRunner, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,0 +1,167 @@
+"""Tests for zoom_cli.api.oauth — Server-to-Server token exchange.
+
+The test strategy is httpx.MockTransport: we hand fetch_access_token a
+real httpx.Client wrapped around a fake transport, so the production
+code is exercised end-to-end (auth header, query params, JSON parsing)
+without ever opening a socket.
+"""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+from zoom_cli.api import oauth
+from zoom_cli.auth import S2SCredentials
+
+
+def _creds() -> S2SCredentials:
+    return S2SCredentials(
+        account_id="acc-123",
+        client_id="cid-456",
+        client_secret="csecret-789",
+    )
+
+
+def _client_with_handler(handler):
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def test_fetch_access_token_success() -> None:
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["auth"] = request.headers.get("authorization")
+        captured["method"] = request.method
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "tok-abc",
+                "token_type": "bearer",
+                "expires_in": 3600,
+                "scope": "user:read:user meeting:read:meeting",
+            },
+        )
+
+    with _client_with_handler(handler) as client:
+        token = oauth.fetch_access_token(_creds(), client=client)
+
+    assert token.value == "tok-abc"
+    assert token.scopes == ("user:read:user", "meeting:read:meeting")
+    assert token.expires_at > datetime.now(timezone.utc)
+    assert token.is_expired is False
+
+    # Verify the request shape Zoom requires.
+    assert captured["method"] == "POST"
+    assert captured["url"].startswith(oauth.TOKEN_URL)
+    assert "grant_type=account_credentials" in captured["url"]
+    assert "account_id=acc-123" in captured["url"]
+
+    # HTTP Basic auth: base64(client_id:client_secret)
+    expected_auth = base64.b64encode(b"cid-456:csecret-789").decode()
+    assert captured["auth"] == f"Basic {expected_auth}"
+
+
+def test_fetch_access_token_uses_default_expiry_when_missing() -> None:
+    """Zoom always sends ``expires_in`` but be defensive — fall back to
+    the documented 1-hour default if the field is somehow absent."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"access_token": "t", "scope": ""})
+
+    with _client_with_handler(handler) as client:
+        token = oauth.fetch_access_token(_creds(), client=client)
+
+    delta = (token.expires_at - datetime.now(timezone.utc)).total_seconds()
+    assert 3500 <= delta <= 3700  # ~1 hour, allow for tiny scheduler jitter
+
+
+def test_fetch_access_token_raises_on_invalid_credentials() -> None:
+    """The classic 4xx case — wrong client_id or client_secret. Surface
+    Zoom's error code and reason verbatim so the CLI can tell the user."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            401,
+            json={
+                "error": "invalid_client",
+                "reason": "Invalid client_id or client_secret",
+            },
+        )
+
+    with _client_with_handler(handler) as client, pytest.raises(oauth.ZoomAuthError) as exc_info:
+        oauth.fetch_access_token(_creds(), client=client)
+
+    err = exc_info.value
+    assert err.status_code == 401
+    assert err.error_code == "invalid_client"
+    assert "Invalid client_id" in str(err)
+
+
+def test_fetch_access_token_handles_non_json_error_body() -> None:
+    """Misconfigured proxies sometimes return HTML or empty bodies. Don't
+    crash — surface what we have."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            502, content=b"<html>bad gateway</html>", headers={"content-type": "text/html"}
+        )
+
+    with _client_with_handler(handler) as client, pytest.raises(oauth.ZoomAuthError) as exc_info:
+        oauth.fetch_access_token(_creds(), client=client)
+
+    err = exc_info.value
+    assert err.status_code == 502
+    assert err.error_code is None
+    assert "bad gateway" in str(err).lower()
+
+
+def test_fetch_access_token_raises_when_2xx_body_missing_token() -> None:
+    """Defensive: if the endpoint returns 200 but no access_token, treat
+    as an auth failure rather than handing back an empty AccessToken."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"token_type": "bearer", "expires_in": 3600})
+
+    with _client_with_handler(handler) as client, pytest.raises(oauth.ZoomAuthError) as exc_info:
+        oauth.fetch_access_token(_creds(), client=client)
+
+    assert "access_token" in str(exc_info.value).lower()
+
+
+def test_fetch_access_token_propagates_network_errors() -> None:
+    """Connection / DNS / TLS failures should bubble out as httpx.HTTPError
+    (not ZoomAuthError) so the CLI can distinguish bad creds from bad network."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("simulated DNS failure")
+
+    with _client_with_handler(handler) as client, pytest.raises(httpx.HTTPError):
+        oauth.fetch_access_token(_creds(), client=client)
+
+
+def test_access_token_is_expired_when_past_expiry() -> None:
+    expired = oauth.AccessToken(
+        value="t",
+        expires_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        scopes=(),
+    )
+    assert expired.is_expired is True
+
+
+def test_access_token_not_expired_when_in_future() -> None:
+    fresh = oauth.AccessToken(
+        value="t",
+        expires_at=datetime(2099, 1, 1, tzinfo=timezone.utc),
+        scopes=(),
+    )
+    assert fresh.is_expired is False
+
+
+def test_token_url_is_zoom_oauth_endpoint() -> None:
+    """Pin the URL — different from the API base (api.zoom.us). A future
+    rename would silently break every existing user."""
+    assert oauth.TOKEN_URL == "https://zoom.us/oauth/token"

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -1,8 +1,10 @@
 import click
+import httpx
 import questionary
 from click_default_group import DefaultGroup
 
 from zoom_cli import auth
+from zoom_cli.api import oauth
 from zoom_cli.commands import (
     _edit,
     _launch_name,
@@ -179,6 +181,45 @@ def s2s_set(account_id, client_id, client_secret):
         )
     )
     click.echo("Server-to-Server OAuth credentials saved.")
+
+
+@s2s.command(
+    "test",
+    help="Verify saved Server-to-Server OAuth credentials by exchanging them for a token.",
+)
+def s2s_test():
+    creds = auth.load_s2s_credentials()
+    if creds is None:
+        click.echo("No Server-to-Server OAuth credentials saved. Run `zoom auth s2s set` first.")
+        raise click.exceptions.Exit(code=1)
+
+    try:
+        token = oauth.fetch_access_token(creds)
+    except oauth.ZoomAuthError as exc:
+        message = str(exc) or "(no message)"
+        if exc.status_code is not None:
+            click.echo(f"Authentication failed (HTTP {exc.status_code}): {message}")
+        else:
+            click.echo(f"Authentication failed: {message}")
+        raise click.exceptions.Exit(code=1) from exc
+    except httpx.HTTPError as exc:
+        # Network / TLS / timeout — the request never got an HTTP response
+        # we can interpret. Distinguish from auth failures so the user
+        # knows whether to check creds or check connectivity.
+        click.echo(f"Could not reach Zoom OAuth endpoint: {exc}")
+        raise click.exceptions.Exit(code=1) from exc
+
+    minutes = max(int((token.expires_at - _now()).total_seconds() // 60), 0)
+    click.echo(f"OK — Server-to-Server OAuth credentials valid (token expires in {minutes}m).")
+    if token.scopes:
+        click.echo(f"Scopes: {' '.join(token.scopes)}")
+
+
+def _now():
+    """Indirection for ``datetime.now`` so tests can monkeypatch it cleanly."""
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc)
 
 
 @auth_cmd.command(help="Show which authentication mode is configured.")

--- a/zoom_cli/api/__init__.py
+++ b/zoom_cli/api/__init__.py
@@ -1,0 +1,6 @@
+"""Zoom REST API client surface.
+
+Each module in this package targets a specific area of the Zoom API
+(``oauth`` here, with ``meetings``, ``users``, ``recordings``, etc. to
+follow). Importing this package by itself does not perform any I/O.
+"""

--- a/zoom_cli/api/oauth.py
+++ b/zoom_cli/api/oauth.py
@@ -1,0 +1,149 @@
+"""Server-to-Server OAuth token exchange against Zoom.
+
+Reference: https://developers.zoom.us/docs/internal-apps/s2s-oauth/
+
+The Zoom token endpoint expects:
+    POST https://zoom.us/oauth/token?grant_type=account_credentials&account_id=...
+    Authorization: Basic <base64(client_id:client_secret)>
+
+On 2xx it responds with::
+
+    {
+      "access_token": "<JWT>",
+      "token_type": "bearer",
+      "expires_in": 3600,
+      "scope": "user:read:user ..."
+    }
+
+On 4xx it responds with::
+
+    {"reason": "Invalid client_id or client_secret", "error": "invalid_client"}
+
+We surface that as a ``ZoomAuthError`` with the parsed fields so the CLI
+can print a useful message rather than a stack trace.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+import httpx
+
+from zoom_cli.auth import S2SCredentials
+
+#: Zoom's public OAuth token endpoint. Hard-coded — different from the
+#: API base URL because OAuth lives on ``zoom.us``, not ``api.zoom.us``.
+TOKEN_URL = "https://zoom.us/oauth/token"  # noqa: S105 - public endpoint URL, not a password
+
+#: Default timeout for the token round-trip. Slightly more generous than
+#: the typical 5s ceiling because corporate proxies + first-cold-DNS can
+#: legitimately spike up to ~10s.
+DEFAULT_TIMEOUT_SECONDS = 15.0
+
+
+@dataclass(frozen=True)
+class AccessToken:
+    """A short-lived bearer token returned by the token endpoint.
+
+    ``expires_at`` is an absolute timezone-aware UTC ``datetime`` rather
+    than the relative ``expires_in`` we get from Zoom — saves every
+    caller from re-doing the math and avoids drift if the token is held
+    in a cache. ``scopes`` is the parsed ``scope`` string Zoom returns;
+    we preserve it for ``zoom auth s2s test`` to display.
+    """
+
+    value: str
+    expires_at: datetime
+    scopes: tuple[str, ...]
+
+    @property
+    def is_expired(self) -> bool:
+        return datetime.now(timezone.utc) >= self.expires_at
+
+
+class ZoomAuthError(RuntimeError):
+    """The token endpoint refused the credentials.
+
+    Carries the HTTP status, Zoom's machine-readable ``error`` code (e.g.
+    ``invalid_client``), and the human-readable ``reason`` so callers
+    can decide how to surface each one.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        error_code: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.error_code = error_code
+
+
+def fetch_access_token(
+    creds: S2SCredentials,
+    *,
+    client: httpx.Client | None = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> AccessToken:
+    """Exchange Server-to-Server OAuth credentials for a 1-hour bearer token.
+
+    The optional ``client`` parameter exists so tests can inject a
+    pre-configured ``httpx.Client`` (typically wrapped around a
+    ``httpx.MockTransport``). Production callers can leave it ``None``.
+
+    Raises:
+        ZoomAuthError: the token endpoint responded with a non-2xx status,
+            or returned a 2xx body without a usable ``access_token``.
+        httpx.HTTPError: the request never reached the endpoint
+            (DNS, TCP, TLS, or timeout failure). Callers in the CLI
+            translate this into a friendly "couldn't reach api.zoom.us"
+            message; lower layers can reason about the typed exception.
+    """
+    owns_client = client is None
+    if client is None:
+        client = httpx.Client(timeout=timeout)
+
+    try:
+        response = client.post(
+            TOKEN_URL,
+            params={
+                "grant_type": "account_credentials",
+                "account_id": creds.account_id,
+            },
+            auth=(creds.client_id, creds.client_secret),
+        )
+    finally:
+        if owns_client:
+            client.close()
+
+    if response.status_code >= 400:
+        # Zoom's error body is a small JSON dict. If the body isn't JSON
+        # (proxy returning HTML, etc.) we still surface a useful message.
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = {}
+        raise ZoomAuthError(
+            payload.get("reason") or payload.get("error_description") or response.text,
+            status_code=response.status_code,
+            error_code=payload.get("error"),
+        )
+
+    payload = response.json()
+    token_value = payload.get("access_token")
+    if not token_value:
+        raise ZoomAuthError(
+            "Token endpoint returned 2xx but no access_token field",
+            status_code=response.status_code,
+        )
+
+    expires_in = int(payload.get("expires_in", 3600))
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+
+    scopes_str = payload.get("scope", "")
+    scopes = tuple(scopes_str.split()) if scopes_str else ()
+
+    return AccessToken(value=token_value, expires_at=expires_at, scopes=scopes)


### PR DESCRIPTION
## Summary

Closes [#11](https://github.com/jordan8037310/zoom-cli/issues/11). Part 2 of the S2S OAuth work — actually exchanges the credentials saved in PR #29 for an access token, validating end-to-end that the user's setup works.

**Stacked on PR #29** (`feat/issue-11-s2s-credential-storage`) → #28 → #27 → #26 → #25. Stack is now 6 deep.

## What's in here

### `zoom_cli/api/` subpackage (new)
Seeds the REST API client surface. First module is `oauth.py`:
- **`AccessToken`** dataclass — `value`, `expires_at` (absolute UTC `datetime`, not relative `expires_in`), `scopes` (parsed tuple). Has `is_expired` property.
- **`ZoomAuthError`** — carries `status_code`, `error_code`, and human-readable reason so the CLI can format messages usefully.
- **`fetch_access_token(creds, *, client=None, timeout=15.0)`** — `POST https://zoom.us/oauth/token?grant_type=account_credentials&account_id=...` with HTTP Basic auth (`base64(client_id:client_secret)`). Raises `ZoomAuthError` on non-2xx or 2xx-without-access_token; `httpx.HTTPError` propagates so callers can distinguish bad creds from bad network.
- The optional `client` kwarg exists so tests can inject `httpx.MockTransport`. Production callers leave it `None`.

### CLI: `zoom auth s2s test`
```
$ zoom auth s2s test               # no creds saved
No Server-to-Server OAuth credentials saved. Run `zoom auth s2s set` first.
(exit 1)

$ zoom auth s2s test               # success
OK — Server-to-Server OAuth credentials valid (token expires in 59m).
Scopes: user:read:user meeting:read:meeting

$ zoom auth s2s test               # bad creds
Authentication failed (HTTP 401): Invalid client_id or client_secret
(exit 1)

$ zoom auth s2s test               # network down
Could not reach Zoom OAuth endpoint: [Errno 8] nodename nor servname provided
(exit 1)
```
Token value itself is never printed.

### Tests (162 total, was 136 — **13 new**)
- **`tests/test_oauth.py` (9)** — uses `httpx.MockTransport` so production code is exercised end-to-end (auth header, query params, JSON parsing) without opening a socket. Covers: full success round-trip pinning request shape; 4xx surfaces parsed `error_code` + reason; non-JSON 5xx body handled gracefully; 2xx without `access_token` is auth failure; network errors propagate as `httpx.HTTPError`; default-1h fallback when `expires_in` missing; `AccessToken.is_expired` property; `TOKEN_URL` pinned.
- **`tests/test_cli.py` (4)** — `test bails with helpful message when no creds`; success path prints OK + scopes but **never the token value**; `ZoomAuthError` reports HTTP status; `httpx.HTTPError` is reported distinctly from auth failure.

### New dependency
- `httpx>=0.27,<1` — modern, sync+async, type-hinted, has `MockTransport` for tests. The de-facto standard for new Python HTTP clients.

## Test plan

- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy` clean
- [x] `pytest -q` — 149 passed in 0.30 s (will be 162 in full stack)
- [ ] CI matrix green
- [ ] Manual smoke (with a real Zoom S2S app): `zoom auth s2s set`, then `zoom auth s2s test` returns OK with the expected granted scopes.

## What's next (out of scope)

Subsequent PRs will add the first downstream API endpoint (likely `zoom users me` against `GET /users/me`), which will need:
- An authenticated `Client` wrapper that injects the bearer token
- A simple in-memory token cache with refresh-on-near-expiry (the AccessToken dataclass is already designed for this)
- Per-tier rate-limit handling (issue #16)

Those land in PR #31+. This PR closes #11 as scoped (auth lifecycle complete: set → test → status → logout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
