### PR TITLE
Integration: phase-1 hardening + phase-2 OAuth/API (PRs #26–#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `subprocess.run(..., shell=True)` in `is_command_available` with `shutil.which`. The previous shell call was only ever invoked with literal command names, but `shutil.which` is the idiomatic, no-shell spelling.
 - Documented plain-text password storage as a known issue; tracked in #5 for a follow-up PR (OS keyring migration).
 
+### Changed (PR [#27](https://github.com/jordan8037310/zoom-cli/pull/27) — partial #24)
+- `write_to_meeting_file` now writes atomically: serialize to a sibling tempfile, `fsync`, then `os.replace` onto `meetings.json`. A crash or kill mid-write can no longer corrupt the file — readers see either the old or the new version, never a partial JSON.
+- `zoom rm` gains `--dry-run` (preview) and `--yes`/`-y` (skip confirmation) flags.
+- When a meeting name is **picked interactively** by `zoom rm`, a confirmation prompt now fires before deletion (the new safety net catches miss-clicks). `zoom rm <name>` with a positional argument still deletes immediately — no behavior change for scripts/aliases.
+- Schema versioning and `--dry-run` on future API `delete` commands deferred to a follow-up PR.
+
 ### Changed (PR [#26](https://github.com/jordan8037310/zoom-cli/pull/26) — closes #6)
 - `_launch_name` URL parsing now uses `urllib.parse.urlsplit` + `parse_qs` instead of brittle `str.index`/`min(..., float("inf"))` slicing. Personal links (`/s/<name>`), web-client URLs (`/wc/...`), URLs with fragments, and URLs with `pwd=` not as the first query parameter all work now where they previously crashed with `ValueError`.
 - `_launch_name` correctly URL-decodes percent-encoded passwords (`pwd=hello%20world` → `hello world`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `subprocess.run(..., shell=True)` in `is_command_available` with `shutil.which`. The previous shell call was only ever invoked with literal command names, but `shutil.which` is the idiomatic, no-shell spelling.
 - Documented plain-text password storage as a known issue; tracked in #5 for a follow-up PR (OS keyring migration).
 
+### Security (PR [#28](https://github.com/jordan8037310/zoom-cli/pull/28) — closes #5)
+- New meeting passwords now go to the OS keyring (Keychain on macOS, libsecret/Secret-Service on Linux, Credential Manager on Windows) under service `zoom-cli` keyed by meeting name — they no longer land in plaintext in `~/.zoom-cli/meetings.json`.
+- `zoom ls` masks passwords as `********` regardless of where they came from. Even legacy plaintext-in-JSON passwords are now hidden in the listing.
+- `zoom rm <name>` deletes the matching keyring entry alongside the JSON entry, so freed names don't leave orphan secrets.
+- `zoom edit` no longer re-prompts for the `password` field (which would have shown the current value as a default — leaking it on screen). Use `--password` to update.
+- Back-compat: `_launch_name` reads the keyring first, then falls back to plaintext-in-JSON. Existing users keep working without action; any subsequent `zoom save` migrates that meeting's password to the keyring.
+- Auto-migration of existing plaintext passwords (one-shot scan + redaction with a `version` field) is intentionally **not** done in this PR; it'll come as a separate, opt-in step.
+
 ### Changed (PR [#27](https://github.com/jordan8037310/zoom-cli/pull/27) — partial #24)
 - `write_to_meeting_file` now writes atomically: serialize to a sibling tempfile, `fsync`, then `os.replace` onto `meetings.json`. A crash or kill mid-write can no longer corrupt the file — readers see either the old or the new version, never a partial JSON.
 - `zoom rm` gains `--dry-run` (preview) and `--yes`/`-y` (skip confirmation) flags.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `subprocess.run(..., shell=True)` in `is_command_available` with `shutil.which`. The previous shell call was only ever invoked with literal command names, but `shutil.which` is the idiomatic, no-shell spelling.
 - Documented plain-text password storage as a known issue; tracked in #5 for a follow-up PR (OS keyring migration).
 
+### Added (PR [#31](https://github.com/jordan8037310/zoom-cli/pull/31) — partial #14, first downstream API call)
+- New authenticated `ApiClient` class (`zoom_cli/api/client.py`): wraps `httpx.Client`, injects `Authorization: Bearer <token>` on every request, caches the access token in-memory until expiry, raises `ZoomApiError` (with `status_code` + Zoom's `code` field) on non-2xx responses.
+- New `zoom_cli/api/users.py::get_me` helper for `GET /users/me`.
+- New `zoom users me` CLI subcommand: prints the authenticated user's display_name, email, id, account_id, type, and status. Distinguishes `ZoomAuthError` (HTTP 401 from token endpoint), `ZoomApiError` (HTTP error from the Users API), and `httpx.HTTPError` (network/TLS failure) so users know whether to debug creds, scopes, or connectivity.
+- API base URL `https://api.zoom.us/v2` pinned by a test.
+
 ### Added (PR [#30](https://github.com/jordan8037310/zoom-cli/pull/30) — closes #11)
 - New `zoom auth s2s test` command exchanges saved Server-to-Server OAuth credentials for an access token and reports back ("OK" with token-expiry minutes and granted scopes, or a typed error message). Distinguishes "credentials rejected" (HTTP status from Zoom) from "couldn't reach api.zoom.us" (network/TLS failure) so the user knows where to look.
 - New `zoom_cli/api/` subpackage seeding the REST API client surface. First module: `oauth.py` with `AccessToken` dataclass (with `is_expired` property), `ZoomAuthError` exception (carrying status_code + error_code + reason), and `fetch_access_token(creds)` against `https://zoom.us/oauth/token` using HTTP Basic auth.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `subprocess.run(..., shell=True)` in `is_command_available` with `shutil.which`. The previous shell call was only ever invoked with literal command names, but `shutil.which` is the idiomatic, no-shell spelling.
 - Documented plain-text password storage as a known issue; tracked in #5 for a follow-up PR (OS keyring migration).
 
+### Added (PR [#29](https://github.com/jordan8037310/zoom-cli/pull/29) — partial #11, phase-2 entry)
+- New `zoom auth` subcommand group: foundation for Zoom REST API authentication.
+  - `zoom auth s2s set` saves Server-to-Server OAuth credentials (account_id, client_id, client_secret) to the OS keyring under service `zoom-cli-auth`.
+  - `zoom auth status` reports whether S2S is configured.
+  - `zoom auth logout` clears all stored API credentials.
+  - Client Secret prompt is masked (uses `questionary.password`) so it isn't echoed to the terminal.
+- New `zoom_cli/auth.py` module with `S2SCredentials` dataclass + storage helpers (`save_s2s_credentials`, `load_s2s_credentials`, `clear_s2s_credentials`, `has_s2s_credentials`).
+- Scoped to credential storage only — actual token exchange against `https://zoom.us/oauth/token` and `zoom auth s2s test` follow in a separate PR (keeps this PR small and reviewable).
+
 ### Security (PR [#28](https://github.com/jordan8037310/zoom-cli/pull/28) — closes #5)
 - New meeting passwords now go to the OS keyring (Keychain on macOS, libsecret/Secret-Service on Linux, Credential Manager on Windows) under service `zoom-cli` keyed by meeting name — they no longer land in plaintext in `~/.zoom-cli/meetings.json`.
 - `zoom ls` masks passwords as `********` regardless of where they came from. Even legacy plaintext-in-JSON passwords are now hidden in the listing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 > Bootstrap PR: [#25](https://github.com/jordan8037310/zoom-cli/pull/25) — closes #4, #7, #8 and partially addresses #9, #10.
+> Codex review follow-ups (this branch): closes #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47 (all 14 findings from Codex's PR #32 review).
+
+### Security (Codex review follow-ups)
+- **#34 (High)** — `zoom auth s2s set` no longer accepts `--client-secret` as a CLI flag. Values in argv landed in shell history and were visible via `ps`/proc to other users on the host. New contract: `ZOOM_CLIENT_SECRET` env var or masked `questionary.password()` prompt only. `--account-id` and `--client-id` still accept flags (public-ish identifiers) and pick up `ZOOM_ACCOUNT_ID` / `ZOOM_CLIENT_ID` env vars.
+- **#35 (High)** — `save_s2s_credentials` is now best-effort transactional: snapshot existing values, write new ones, restore the snapshot on any partial failure. Closes the "mixed credential set" failure mode where a partial keyring write left the user authenticating with one new field and two old ones, silently.
+- **#37 (Medium)** — Meeting passwords are URL-encoded when appended to the `zoommtg://` query string. Passwords containing `&`, `=`, `#`, `+` etc. now round-trip cleanly instead of corrupting the URL semantics.
+- **#38 (Medium)** — Trusted-host allowlist (`zoom.us`, `zoomgov.com`, and proper subdomains thereof) replaces the substring `"zoom.us" in url_or_name` check. Deceptive inputs like `https://evil.example/zoom.us/j/1` and `https://my-zoom.us-domain.com/j/1` are now rejected at the launch layer.
+- **#40 (Low)** — `~/.zoom-cli/` is created with `0o700` and `meetings.json` with `0o600`. Existing files/dirs are tightened on touch if owned by the current user and group/world-readable. Initial file creation uses `O_CREAT|O_EXCL` to avoid the umask TOCTOU window.
+
+### Fixed (Codex review follow-ups)
+- **#39 (Medium)** — `meetings.json` mutations now hold an exclusive POSIX file lock (`fcntl.flock` against `meetings.json.lock`). Prevents lost updates when concurrent `zoom save`/`edit`/`rm` invocations interleave. New `meeting_file_transaction()` context manager wraps read + lock + persist.
+- **#41 (Medium)** — `load_s2s_credentials()` no longer flattens `NoKeyringError`/`InitError` to `None`. The CLI now distinguishes "user has not configured S2S yet" (exit 1) from "this machine has no keyring backend at all" (exit 2). `has_s2s_credentials()` keeps the silent-False semantics for the probe-style `zoom auth status` command.
+- **#42 (Medium)** — Both `fetch_access_token` and `ApiClient.request` wrap the success-path `response.json()` so a non-JSON 2xx body (corporate proxy returning HTML, captive portal) surfaces as `ZoomAuthError`/`ZoomApiError` instead of leaking raw `ValueError` to callers. Includes the response's `content-type` in the error message for triage.
+- **#43 (Medium)** — New `_translate_keyring_errors` decorator in `__main__.py` applied to `s2s set`, `s2s test`, `logout`, `users me`. Splits errors three ways: `NoKeyringError`/`InitError` → exit 2 with "backend not available", other `KeyringError` → exit 3 with "may be locked", anything else propagates. No more raw Python tracebacks on a locked Keychain.
+- **#47 (High, partial)** — `AccessToken.is_expired` now treats a token as expired when within `EXPIRY_SKEW_SECONDS` (60s) of its absolute expiry, preventing the race where a request lands after Zoom rotated the token. `ApiClient.request` catches a 401 once, force-refreshes the cached token, and retries the request — covers token rotation / scope-change cases. A second 401 propagates as `ZoomApiError` so we never loop. 429 / Retry-After / token-bucket / pagination remain deferred to issue #16.
+
+### Changed (Codex review follow-ups)
+- **#36 (Medium)** — `zoom_cli/api/users.py` now exposes `get_user(client, user_id="me")` as the durable boundary for the Users API. `get_me(client)` is kept as a thin alias for backward compatibility with PR #31's CLI code. The path segment is percent-encoded so caller-supplied IDs cannot inject path/query metacharacters.
+
+### Tests added (Codex review follow-ups)
+- **#44 (Medium)** — Parametrized round-trip test over delimiter-heavy passwords (`&`, `=`, `#`, `+`, `?`, space, `%`, quote, backslash). Pin for the #37 fix.
+- **#45 (Medium)** — Parametrized test (`fail_on_call=1,2,3`) for the #35 rollback path; asserts the prior credential set survives a partial keyring failure. Plus a no-prior-state variant that asserts the rollback deletes what was written.
+- **#46 (Low)** — Tests for HTML, empty, and garbage 2xx bodies on both OAuth and Users endpoints. Pin for the #42 fix.
+- Lock-serialization test for #39 (two threads, one delayed; both meetings present after).
+- Permissions tests for #40 (fresh dir is 0o700, fresh file is 0o600, existing permissive permissions are tightened on touch).
+- 401 retry tests for #47 (single retry on 401, no retry on 403, no infinite loop on persistent 401).
+
+
 
 ### Added
 - Modern `pyproject.toml` packaging (PEP 621) with `dev` and `build` extras.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `subprocess.run(..., shell=True)` in `is_command_available` with `shutil.which`. The previous shell call was only ever invoked with literal command names, but `shutil.which` is the idiomatic, no-shell spelling.
 - Documented plain-text password storage as a known issue; tracked in #5 for a follow-up PR (OS keyring migration).
 
+### Changed (PR [#26](https://github.com/jordan8037310/zoom-cli/pull/26) — closes #6)
+- `_launch_name` URL parsing now uses `urllib.parse.urlsplit` + `parse_qs` instead of brittle `str.index`/`min(..., float("inf"))` slicing. Personal links (`/s/<name>`), web-client URLs (`/wc/...`), URLs with fragments, and URLs with `pwd=` not as the first query parameter all work now where they previously crashed with `ValueError`.
+- `_launch_name` correctly URL-decodes percent-encoded passwords (`pwd=hello%20world` → `hello world`).
+- `_launch_name` falls back to launching the URL directly through the `zoommtg://` scheme when the URL is not in the standard `/j/<id>` form.
+- `_launch_url` no longer swallows unexpected exceptions with a bare `except Exception`. Only the launcher's own `LauncherUnavailableError` produces a friendly error message; other exceptions propagate so genuine bugs are visible.
+- New `parse_meeting_url(url)` and `strip_url_scheme(url)` helpers in `zoom_cli.utils`.
+
 ## [1.1.6] - 2024-03-03
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replaced `subprocess.run(..., shell=True)` in `is_command_available` with `shutil.which`. The previous shell call was only ever invoked with literal command names, but `shutil.which` is the idiomatic, no-shell spelling.
 - Documented plain-text password storage as a known issue; tracked in #5 for a follow-up PR (OS keyring migration).
 
+### Added (PR [#30](https://github.com/jordan8037310/zoom-cli/pull/30) — closes #11)
+- New `zoom auth s2s test` command exchanges saved Server-to-Server OAuth credentials for an access token and reports back ("OK" with token-expiry minutes and granted scopes, or a typed error message). Distinguishes "credentials rejected" (HTTP status from Zoom) from "couldn't reach api.zoom.us" (network/TLS failure) so the user knows where to look.
+- New `zoom_cli/api/` subpackage seeding the REST API client surface. First module: `oauth.py` with `AccessToken` dataclass (with `is_expired` property), `ZoomAuthError` exception (carrying status_code + error_code + reason), and `fetch_access_token(creds)` against `https://zoom.us/oauth/token` using HTTP Basic auth.
+- `httpx>=0.27,<1` added as runtime dependency. Tests use `httpx.MockTransport` so the production code is exercised end-to-end without ever opening a socket.
+
 ### Added (PR [#29](https://github.com/jordan8037310/zoom-cli/pull/29) — partial #11, phase-2 entry)
 - New `zoom auth` subcommand group: foundation for Zoom REST API authentication.
   - `zoom auth s2s set` saves Server-to-Server OAuth credentials (account_id, client_id, client_secret) to the OS keyring under service `zoom-cli-auth`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "click>=8.1,<9",
     "click-default-group>=1.2.4,<2",
     "questionary>=2.0,<3",
+    "keyring>=24.0,<26",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "click-default-group>=1.2.4,<2",
     "questionary>=2.0,<3",
     "keyring>=24.0,<26",
+    "httpx>=0.27,<1",
 ]
 
 [project.optional-dependencies]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Shared pytest fixtures.
 
-These fixtures isolate every test from the user's real ``~/.zoom-cli`` directory
-and from launching real subprocesses.
+These fixtures isolate every test from the user's real ``~/.zoom-cli`` directory,
+the user's real OS keyring, and from launching real subprocesses.
 """
 
 from __future__ import annotations
@@ -10,7 +10,48 @@ import json
 import subprocess
 from pathlib import Path
 
+import keyring
+import keyring.backend
 import pytest
+
+
+class _InMemoryKeyring(keyring.backend.KeyringBackend):
+    """Tiny in-memory keyring backend for tests; isolates from the real OS keyring."""
+
+    priority = 1  # type: ignore[assignment]
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service: str, username: str) -> str | None:
+        return self._store.get((service, username))
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        self._store[(service, username)] = password
+
+    def delete_password(self, service: str, username: str) -> None:
+        if (service, username) not in self._store:
+            import keyring.errors
+
+            raise keyring.errors.PasswordDeleteError(f"{service}:{username} not set")
+        del self._store[(service, username)]
+
+
+@pytest.fixture(autouse=True)
+def isolated_keyring() -> _InMemoryKeyring:
+    """Replace the real OS keyring with an in-memory one for every test.
+
+    Autouse so no test can accidentally read or write the developer's real
+    keychain. Returns the backend instance so individual tests can pre-seed
+    it if needed.
+    """
+    backend = _InMemoryKeyring()
+    previous = keyring.get_keyring()
+    keyring.set_keyring(backend)
+    try:
+        yield backend
+    finally:
+        keyring.set_keyring(previous)
 
 
 @pytest.fixture

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -212,3 +212,111 @@ def test_request_raises_zoom_api_error_on_garbage_2xx() -> None:
     ):
         api = client_mod.ApiClient(_creds(), http_client=http)
         api.request("GET", "/users/me")
+
+
+# ---- #47: 401 single-shot retry with token refresh -----------------------
+
+
+def test_request_retries_once_on_401_with_force_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Closes #47 (partial): on a 401 the client must drop the cached
+    token, fetch a fresh one, and retry the request once. The second
+    attempt's success means the user never sees the transient 401."""
+
+    fetch_calls = {"n": 0}
+
+    def fake_fetch(*_args, **_kwargs) -> oauth.AccessToken:
+        fetch_calls["n"] += 1
+        return oauth.AccessToken(
+            value=f"tok-{fetch_calls['n']}",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            scopes=(),
+        )
+
+    monkeypatch.setattr(oauth, "fetch_access_token", fake_fetch)
+
+    request_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        request_count["n"] += 1
+        if request_count["n"] == 1:
+            # First request: server says token is invalid (revoked, scope
+            # change, etc.). Local clock thought it was still good.
+            return httpx.Response(401, json={"code": 124, "message": "Invalid access token."})
+        # Second request: succeeds with the freshly fetched token.
+        assert request.headers["Authorization"] == "Bearer tok-2"
+        return httpx.Response(200, json={"id": "user-1", "email": "a@b.c"})
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as http:
+        api = client_mod.ApiClient(_creds(), http_client=http)
+        result = api.request("GET", "/users/me")
+
+    assert result == {"id": "user-1", "email": "a@b.c"}
+    assert request_count["n"] == 2
+    assert fetch_calls["n"] == 2  # initial + force-refresh after 401
+
+
+def test_request_does_not_loop_on_persistent_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the second attempt also 401s, propagate as ZoomApiError. Never
+    loop more than once — bad credentials would otherwise fetch tokens
+    indefinitely."""
+
+    fetch_calls = {"n": 0}
+
+    def fake_fetch(*_args, **_kwargs) -> oauth.AccessToken:
+        fetch_calls["n"] += 1
+        return oauth.AccessToken(
+            value=f"tok-{fetch_calls['n']}",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            scopes=(),
+        )
+
+    monkeypatch.setattr(oauth, "fetch_access_token", fake_fetch)
+
+    request_count = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        request_count["n"] += 1
+        return httpx.Response(401, json={"code": 124, "message": "Invalid access token."})
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as http:
+        api = client_mod.ApiClient(_creds(), http_client=http)
+        with pytest.raises(client_mod.ZoomApiError) as excinfo:
+            api.request("GET", "/users/me")
+
+    assert excinfo.value.status_code == 401
+    assert request_count["n"] == 2  # original + exactly one retry, then propagate
+    assert fetch_calls["n"] == 2
+
+
+def test_request_does_not_retry_on_non_401_4xx(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 403 / 404 / 429 should NOT trigger the auth-refresh retry path —
+    those aren't auth problems and re-issuing wastes a token fetch."""
+
+    fetch_calls = {"n": 0}
+
+    def fake_fetch(*_args, **_kwargs) -> oauth.AccessToken:
+        fetch_calls["n"] += 1
+        return oauth.AccessToken(
+            value="tok",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            scopes=(),
+        )
+
+    monkeypatch.setattr(oauth, "fetch_access_token", fake_fetch)
+
+    request_count = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        request_count["n"] += 1
+        return httpx.Response(403, json={"code": 200, "message": "Insufficient privileges."})
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as http:
+        api = client_mod.ApiClient(_creds(), http_client=http)
+        with pytest.raises(client_mod.ZoomApiError):
+            api.request("GET", "/users/me")
+
+    assert request_count["n"] == 1  # no retry
+    assert fetch_calls["n"] == 1

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -155,3 +155,60 @@ def test_api_base_url_is_pinned() -> None:
     """A future rename of the API base would silently break every endpoint
     helper. Pin it here so the test fails loudly."""
     assert client_mod.API_BASE_URL == "https://api.zoom.us/v2"
+
+
+# ---- #46 / #42: malformed-JSON 2xx bodies on REST endpoints --------------
+
+
+def test_request_raises_zoom_api_error_on_html_2xx() -> None:
+    """Closes #46 / verifies #42 fix: a non-JSON 2xx body should surface as
+    ZoomApiError, not raw ValueError."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/oauth/token"):
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": "tok",
+                    "token_type": "bearer",
+                    "expires_in": 3600,
+                    "scope": "user:read:user",
+                },
+            )
+        return httpx.Response(
+            200,
+            text="<html>nope</html>",
+            headers={"Content-Type": "text/html"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    with (
+        httpx.Client(transport=transport) as http,
+        pytest.raises(client_mod.ZoomApiError) as excinfo,
+    ):
+        api = client_mod.ApiClient(_creds(), http_client=http)
+        api.request("GET", "/users/me")
+    assert "non-JSON body" in str(excinfo.value)
+
+
+def test_request_raises_zoom_api_error_on_garbage_2xx() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/oauth/token"):
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": "tok",
+                    "token_type": "bearer",
+                    "expires_in": 3600,
+                    "scope": "",
+                },
+            )
+        return httpx.Response(200, text="not json")
+
+    transport = httpx.MockTransport(handler)
+    with (
+        httpx.Client(transport=transport) as http,
+        pytest.raises(client_mod.ZoomApiError),
+    ):
+        api = client_mod.ApiClient(_creds(), http_client=http)
+        api.request("GET", "/users/me")

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,157 @@
+"""Tests for zoom_cli.api.client — ApiClient + token lifecycle."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+from zoom_cli.api import client as client_mod
+from zoom_cli.api import oauth
+from zoom_cli.api.client import API_BASE_URL, ApiClient, ZoomApiError
+from zoom_cli.auth import S2SCredentials
+
+
+def _creds() -> S2SCredentials:
+    return S2SCredentials(account_id="acc-1", client_id="cid", client_secret="csec")
+
+
+def _fresh_token(value: str = "tok-fresh", *, lifetime_seconds: int = 3600) -> oauth.AccessToken:
+    return oauth.AccessToken(
+        value=value,
+        expires_at=datetime.now(timezone.utc) + timedelta(seconds=lifetime_seconds),
+        scopes=("user:read:user",),
+    )
+
+
+def test_get_injects_authorization_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json={"id": "user-123", "email": "u@example.com"})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token("tok-X"))
+
+    with ApiClient(_creds(), http_client=http) as c:
+        result = c.get("/users/me")
+
+    assert result == {"id": "user-123", "email": "u@example.com"}
+    assert captured["url"] == f"{API_BASE_URL}/users/me"
+    assert captured["auth"] == "Bearer tok-X"
+
+
+def test_request_caches_token_across_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A single CLI invocation hitting two endpoints should fetch one token,
+    not two. Pin this so a future refactor can't accidentally regress."""
+    fetch_calls = {"n": 0}
+
+    def fake_fetch(*_a, **_k):
+        fetch_calls["n"] += 1
+        return _fresh_token()
+
+    monkeypatch.setattr(oauth, "fetch_access_token", fake_fetch)
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+
+    with ApiClient(_creds(), http_client=http) as c:
+        c.get("/users/me")
+        c.get("/users/123")
+        c.get("/meetings/999")
+
+    assert fetch_calls["n"] == 1
+
+
+def test_request_refetches_token_after_expiry(monkeypatch: pytest.MonkeyPatch) -> None:
+    fetch_calls = {"n": 0}
+
+    def fake_fetch(*_a, **_k):
+        fetch_calls["n"] += 1
+        # First call returns an already-expired token; second call returns fresh.
+        if fetch_calls["n"] == 1:
+            return oauth.AccessToken(
+                value="expired",
+                expires_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+                scopes=(),
+            )
+        return _fresh_token()
+
+    monkeypatch.setattr(oauth, "fetch_access_token", fake_fetch)
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+
+    with ApiClient(_creds(), http_client=http) as c:
+        c.get("/users/me")  # populates cache with already-expired token
+        c.get("/users/me")  # cache invalid → refetches
+
+    assert fetch_calls["n"] == 2
+
+
+def test_request_raises_on_4xx_with_zoom_error_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token())
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            404,
+            json={"code": 1001, "message": "User does not exist: 123."},
+        )
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+
+    with ApiClient(_creds(), http_client=http) as c, pytest.raises(ZoomApiError) as exc_info:
+        c.get("/users/123")
+
+    err = exc_info.value
+    assert err.status_code == 404
+    assert err.code == 1001
+    assert "does not exist" in str(err)
+
+
+def test_request_handles_non_json_error_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token())
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            502, content=b"<html>bad gateway</html>", headers={"content-type": "text/html"}
+        )
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+
+    with ApiClient(_creds(), http_client=http) as c, pytest.raises(ZoomApiError) as exc_info:
+        c.get("/users/me")
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.code is None
+
+
+def test_request_passes_query_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(200, json={})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token())
+
+    with ApiClient(_creds(), http_client=http) as c:
+        c.get("/users", params={"page_size": 100, "status": "active"})
+
+    assert "page_size=100" in captured["url"]
+    assert "status=active" in captured["url"]
+
+
+def test_api_base_url_is_pinned() -> None:
+    """A future rename of the API base would silently break every endpoint
+    helper. Pin it here so the test fails loudly."""
+    assert client_mod.API_BASE_URL == "https://api.zoom.us/v2"

--- a/tests/test_api_users.py
+++ b/tests/test_api_users.py
@@ -16,3 +16,53 @@ def test_get_me_calls_users_me_endpoint() -> None:
 
     fake_client.get.assert_called_once_with("/users/me")
     assert result == {"id": "u-1", "email": "x@y"}
+
+
+# ---- #36: durable get_user(user_id) abstraction --------------------------
+
+
+def test_get_user_default_targets_me() -> None:
+    """Closes #36: ``get_user`` with no args is the same as ``get_me``."""
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"id": "u-me"}
+
+    users.get_user(fake_client)
+
+    fake_client.get.assert_called_once_with("/users/me")
+
+
+def test_get_user_targets_specific_user_id() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"id": "u-42"}
+
+    users.get_user(fake_client, "u-42")
+
+    fake_client.get.assert_called_once_with("/users/u-42")
+
+
+def test_get_user_url_encodes_user_id_with_special_chars() -> None:
+    """A user_id containing ``/``, ``?``, ``#`` etc. must be percent-encoded
+    so it can't break out of the path segment. Defense-in-depth — current
+    callers don't pass untrusted input but a future CLI might."""
+    fake_client = MagicMock()
+    fake_client.get.return_value = {}
+
+    users.get_user(fake_client, "evil/../admin?x=1")
+
+    # `/` and `?` must be percent-encoded (`%2F` and `%3F`).
+    call_arg = fake_client.get.call_args[0][0]
+    assert "/.." not in call_arg
+    assert "?" not in call_arg
+    assert "%2F" in call_arg
+    assert "%3F" in call_arg
+
+
+def test_get_me_is_alias_for_get_user_me() -> None:
+    """The CLI's ``zoom users me`` command imports get_me; ensure the alias
+    keeps producing the same call shape (closes #36 backward compatibility)."""
+    fake_client = MagicMock()
+    fake_client.get.return_value = {}
+
+    users.get_me(fake_client)
+
+    fake_client.get.assert_called_once_with("/users/me")

--- a/tests/test_api_users.py
+++ b/tests/test_api_users.py
@@ -1,0 +1,18 @@
+"""Tests for zoom_cli.api.users — Users endpoint helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from zoom_cli.api import users
+
+
+def test_get_me_calls_users_me_endpoint() -> None:
+    """Pin the path so a typo doesn't silently target the wrong endpoint."""
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"id": "u-1", "email": "x@y"}
+
+    result = users.get_me(fake_client)
+
+    fake_client.get.assert_called_once_with("/users/me")
+    assert result == {"id": "u-1", "email": "x@y"}

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -80,3 +80,55 @@ def test_load_does_not_swallow_locked_keyring(monkeypatch: pytest.MonkeyPatch) -
 def test_service_name_constant_is_pinned() -> None:
     """A future rename would orphan every existing user's saved credentials."""
     assert auth.SERVICE_NAME == "zoom-cli-auth"
+
+
+@pytest.mark.parametrize("fail_on_call", [1, 2, 3])
+def test_save_rolls_back_on_partial_failure(
+    monkeypatch: pytest.MonkeyPatch, fail_on_call: int
+) -> None:
+    """Closes #45 / verifies #35 fix: a partial keyring failure must not leave
+    a hybrid credential set in the keyring. The rollback restores prior state."""
+    old = auth.S2SCredentials(account_id="old-acc", client_id="old-cid", client_secret="old-secret")
+    auth.save_s2s_credentials(old)
+
+    new = auth.S2SCredentials(account_id="new-acc", client_id="new-cid", client_secret="new-secret")
+
+    real_set = keyring.set_password
+    counter = {"calls": 0}
+
+    def flaky_set(service: str, username: str, password: str) -> None:
+        counter["calls"] += 1
+        if counter["calls"] == fail_on_call:
+            raise keyring.errors.KeyringError(f"simulated failure on call {fail_on_call}")
+        real_set(service, username, password)
+
+    monkeypatch.setattr(keyring, "set_password", flaky_set)
+    with pytest.raises(keyring.errors.KeyringError):
+        auth.save_s2s_credentials(new)
+
+    # Rollback should have restored the prior state. Reads use the real
+    # keyring backend (we patched set_password, not get_password).
+    assert auth.load_s2s_credentials() == old
+
+
+def test_save_rolls_back_to_empty_when_no_prior_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If there were no prior credentials, rollback should leave the keyring
+    empty rather than partially populated."""
+    new = auth.S2SCredentials(account_id="new-acc", client_id="new-cid", client_secret="new-secret")
+
+    real_set = keyring.set_password
+    counter = {"calls": 0}
+
+    def flaky_set(service: str, username: str, password: str) -> None:
+        counter["calls"] += 1
+        # Fail on the third (client_secret) write — first two succeed.
+        if counter["calls"] == 3:
+            raise keyring.errors.KeyringError("simulated")
+        real_set(service, username, password)
+
+    monkeypatch.setattr(keyring, "set_password", flaky_set)
+    with pytest.raises(keyring.errors.KeyringError):
+        auth.save_s2s_credentials(new)
+
+    # No prior creds → rollback should delete what was written → load returns None.
+    assert auth.load_s2s_credentials() is None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,82 @@
+"""Tests for zoom_cli.auth — S2S OAuth credential storage."""
+
+from __future__ import annotations
+
+import keyring
+import keyring.errors
+import pytest
+from zoom_cli import auth
+
+
+def _sample_creds() -> auth.S2SCredentials:
+    return auth.S2SCredentials(
+        account_id="acc-123",
+        client_id="cid-456",
+        client_secret="csecret-789",
+    )
+
+
+def test_save_then_load_round_trips() -> None:
+    creds = _sample_creds()
+    auth.save_s2s_credentials(creds)
+    loaded = auth.load_s2s_credentials()
+    assert loaded == creds
+
+
+def test_load_returns_none_when_nothing_saved() -> None:
+    assert auth.load_s2s_credentials() is None
+    assert auth.has_s2s_credentials() is False
+
+
+def test_load_returns_none_when_only_partial_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If only some of the three fields are present, treat as not-configured.
+    All three are required for the OAuth round-trip."""
+    keyring.set_password(auth.SERVICE_NAME, "s2s.account_id", "only-this-one")
+    assert auth.load_s2s_credentials() is None
+
+
+def test_clear_removes_all_three_keys() -> None:
+    auth.save_s2s_credentials(_sample_creds())
+    auth.clear_s2s_credentials()
+    assert auth.load_s2s_credentials() is None
+    # Each individual key must also be gone.
+    for key in ("s2s.account_id", "s2s.client_id", "s2s.client_secret"):
+        assert keyring.get_password(auth.SERVICE_NAME, key) is None
+
+
+def test_clear_is_idempotent() -> None:
+    # Must not raise when nothing's there to clear.
+    auth.clear_s2s_credentials()
+    auth.clear_s2s_credentials()
+
+
+def test_has_s2s_credentials_true_when_all_present() -> None:
+    auth.save_s2s_credentials(_sample_creds())
+    assert auth.has_s2s_credentials() is True
+
+
+def test_load_returns_none_on_no_keyring_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(*_args, **_kwargs):
+        raise keyring.errors.NoKeyringError("no backend")
+
+    monkeypatch.setattr(keyring, "get_password", boom)
+    assert auth.load_s2s_credentials() is None
+
+
+def test_load_does_not_swallow_locked_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Same precedent as zoom_cli.secrets — locked keyring must propagate
+    rather than silently report 'not configured', because the latter would
+    let `zoom auth s2s test` decide we have no creds and fall over with
+    an unhelpful message."""
+
+    def boom(*_args, **_kwargs):
+        raise keyring.errors.KeyringError("locked")
+
+    monkeypatch.setattr(keyring, "get_password", boom)
+    with pytest.raises(keyring.errors.KeyringError):
+        auth.load_s2s_credentials()
+
+
+def test_service_name_constant_is_pinned() -> None:
+    """A future rename would orphan every existing user's saved credentials."""
+    assert auth.SERVICE_NAME == "zoom-cli-auth"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -55,12 +55,31 @@ def test_has_s2s_credentials_true_when_all_present() -> None:
     assert auth.has_s2s_credentials() is True
 
 
-def test_load_returns_none_on_no_keyring_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_load_propagates_no_keyring_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Closes #41: a missing keyring backend is no longer silently flattened
+    to ``None`` — that conflated "user has not run `zoom auth s2s set`" with
+    a genuine environmental failure. Now the caller (the CLI) translates."""
+
     def boom(*_args, **_kwargs):
         raise keyring.errors.NoKeyringError("no backend")
 
     monkeypatch.setattr(keyring, "get_password", boom)
-    assert auth.load_s2s_credentials() is None
+    with pytest.raises(keyring.errors.NoKeyringError):
+        auth.load_s2s_credentials()
+
+
+def test_has_s2s_credentials_swallows_no_keyring_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``has_s2s_credentials`` is the probe-style helper used by ``zoom auth
+    status``. It deliberately swallows backend-missing errors so a "check
+    status" call doesn't blow up on a misconfigured machine."""
+
+    def boom(*_args, **_kwargs):
+        raise keyring.errors.NoKeyringError("no backend")
+
+    monkeypatch.setattr(keyring, "get_password", boom)
+    assert auth.has_s2s_credentials() is False
 
 
 def test_load_does_not_swallow_locked_keyring(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -238,6 +238,90 @@ def test_auth_s2s_set_does_not_echo_secret_in_output(runner: CliRunner) -> None:
     assert secret not in result.output
 
 
+# ---- zoom auth s2s test (issue #11 part 2) -------------------------------
+
+
+def test_auth_s2s_test_bails_when_no_credentials_saved(runner: CliRunner) -> None:
+    """`zoom auth s2s test` with nothing configured: print a helpful
+    message and exit non-zero so scripts can detect the unconfigured state."""
+    result = runner.invoke(main, ["auth", "s2s", "test"])
+    assert result.exit_code == 1
+    assert "No Server-to-Server" in result.output
+    assert "zoom auth s2s set" in result.output
+
+
+def test_auth_s2s_test_success_prints_ok_and_scopes(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from datetime import datetime, timedelta, timezone
+
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+    from zoom_cli.api import oauth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+
+    fake_token_value = "very-secret-do-not-leak-bearer-12345"
+    fake_token = oauth.AccessToken(
+        value=fake_token_value,
+        expires_at=datetime.now(timezone.utc) + timedelta(seconds=3600),
+        scopes=("user:read:user", "meeting:read:meeting"),
+    )
+    monkeypatch.setattr(main_mod.oauth, "fetch_access_token", lambda *_a, **_k: fake_token)
+
+    result = runner.invoke(main, ["auth", "s2s", "test"])
+    assert result.exit_code == 0, result.output
+    assert "OK" in result.output
+    assert "user:read:user" in result.output
+    assert "meeting:read:meeting" in result.output
+    # The bearer token value itself must never reach stdout.
+    assert fake_token_value not in result.output
+
+
+def test_auth_s2s_test_reports_zoom_auth_error(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+    from zoom_cli.api import oauth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+
+    def boom(*_a, **_k):
+        raise oauth.ZoomAuthError(
+            "Invalid client_id or client_secret", status_code=401, error_code="invalid_client"
+        )
+
+    monkeypatch.setattr(main_mod.oauth, "fetch_access_token", boom)
+
+    result = runner.invoke(main, ["auth", "s2s", "test"])
+    assert result.exit_code == 1
+    assert "401" in result.output
+    assert "Invalid client_id" in result.output
+
+
+def test_auth_s2s_test_reports_network_error_distinctly(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Distinguish 'creds rejected' from 'couldn't reach Zoom' — the user
+    needs to know which one to debug."""
+    import httpx
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+
+    def boom(*_a, **_k):
+        raise httpx.ConnectError("DNS failed")
+
+    monkeypatch.setattr(main_mod.oauth, "fetch_access_token", boom)
+
+    result = runner.invoke(main, ["auth", "s2s", "test"])
+    assert result.exit_code == 1
+    assert "Could not reach" in result.output
+    assert "DNS failed" in result.output
+
+
 def test_auth_s2s_set_aborts_on_ctrl_c_at_account_prompt(
     runner: CliRunner, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -238,6 +238,94 @@ def test_auth_s2s_set_does_not_echo_secret_in_output(runner: CliRunner) -> None:
     assert secret not in result.output
 
 
+# ---- zoom users me (PR #31) ----------------------------------------------
+
+
+def test_users_me_bails_when_no_credentials_saved(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["users", "me"])
+    assert result.exit_code == 1
+    assert "No Server-to-Server" in result.output
+
+
+def test_users_me_prints_well_known_fields(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+
+    fake_profile = {
+        "id": "user-abc",
+        "account_id": "acc-xyz",
+        "email": "alice@example.com",
+        "display_name": "Alice Example",
+        "type": 2,
+        "status": "active",
+        # Some fields we don't expect to print:
+        "phone_number": "+1-555-0100",
+        "language": "en-US",
+    }
+
+    def fake_get_me(_client):
+        return fake_profile
+
+    monkeypatch.setattr(main_mod.users, "get_me", fake_get_me)
+    # Stub out the OAuth round-trip — ApiClient is created but never exchanges tokens
+    # because get_me is replaced wholesale.
+    monkeypatch.setattr(
+        main_mod.oauth,
+        "fetch_access_token",
+        lambda *_a, **_k: _fake_access_token(),
+    )
+
+    result = runner.invoke(main, ["users", "me"])
+    assert result.exit_code == 0, result.output
+    assert "alice@example.com" in result.output
+    assert "Alice Example" in result.output
+    assert "user-abc" in result.output
+    assert "acc-xyz" in result.output
+    # We don't print every field — phone_number shouldn't appear
+    assert "phone_number" not in result.output
+
+
+def test_users_me_reports_zoom_api_error_distinctly(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+    from zoom_cli.api.client import ZoomApiError
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+
+    def boom(_client):
+        raise ZoomApiError("Something broke", status_code=500, code=9999)
+
+    monkeypatch.setattr(main_mod.users, "get_me", boom)
+    monkeypatch.setattr(
+        main_mod.oauth,
+        "fetch_access_token",
+        lambda *_a, **_k: _fake_access_token(),
+    )
+
+    result = runner.invoke(main, ["users", "me"])
+    assert result.exit_code == 1
+    assert "500" in result.output
+    assert "Something broke" in result.output
+
+
+def _fake_access_token():
+    from datetime import datetime, timedelta, timezone
+
+    from zoom_cli.api import oauth
+
+    return oauth.AccessToken(
+        value="tok",
+        expires_at=datetime.now(timezone.utc) + timedelta(seconds=3600),
+        scopes=("user:read:user",),
+    )
+
+
 # ---- zoom auth s2s test (issue #11 part 2) -------------------------------
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -158,6 +158,100 @@ def test_rm_interactive_confirms_before_deleting(
     assert "a" in on_disk
 
 
+# ---- zoom auth subcommand group (issue #11) -----------------------------
+
+
+def test_auth_status_when_not_configured(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["auth", "status"])
+    assert result.exit_code == 0, result.output
+    assert "not configured" in result.output
+
+
+def test_auth_s2s_set_with_flags_persists_to_keyring(runner: CliRunner) -> None:
+    from zoom_cli import auth
+
+    result = runner.invoke(
+        main,
+        [
+            "auth",
+            "s2s",
+            "set",
+            "--account-id",
+            "acc-1",
+            "--client-id",
+            "cid-2",
+            "--client-secret",
+            "csecret-3",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "saved" in result.output.lower()
+
+    loaded = auth.load_s2s_credentials()
+    assert loaded is not None
+    assert loaded.account_id == "acc-1"
+    assert loaded.client_id == "cid-2"
+    assert loaded.client_secret == "csecret-3"
+
+
+def test_auth_status_when_configured(runner: CliRunner) -> None:
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+    result = runner.invoke(main, ["auth", "status"])
+    assert result.exit_code == 0, result.output
+    assert "configured" in result.output
+    assert "not configured" not in result.output
+
+
+def test_auth_logout_clears_keyring(runner: CliRunner) -> None:
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+    assert auth.has_s2s_credentials() is True
+
+    result = runner.invoke(main, ["auth", "logout"])
+    assert result.exit_code == 0, result.output
+    assert "Cleared" in result.output
+
+    assert auth.has_s2s_credentials() is False
+
+
+def test_auth_s2s_set_does_not_echo_secret_in_output(runner: CliRunner) -> None:
+    """Regression: the success message must not echo the secret."""
+    secret = "very-secret-do-not-leak-12345"
+    result = runner.invoke(
+        main,
+        [
+            "auth",
+            "s2s",
+            "set",
+            "--account-id",
+            "a",
+            "--client-id",
+            "b",
+            "--client-secret",
+            secret,
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert secret not in result.output
+
+
+def test_auth_s2s_set_aborts_on_ctrl_c_at_account_prompt(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cancellation at any prompt must not write partial state."""
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+
+    monkeypatch.setattr(main_mod.questionary, "text", _FakeQ([None]))
+
+    result = runner.invoke(main, ["auth", "s2s", "set"])
+    assert result.exit_code != 0
+    assert auth.has_s2s_credentials() is False
+
+
 def test_rm_interactive_with_yes_flag_skips_confirmation(
     runner: CliRunner,
     write_meetings,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -577,3 +577,58 @@ def test_edit_with_empty_store_short_circuits(
     result = runner.invoke(main, ["edit"])
     assert result.exit_code == 0
     assert "No saved meetings" in result.output
+
+
+# ---- launch command (#38 untrusted-host refusal) -------------------------
+
+
+def test_launch_refuses_url_with_untrusted_scheme_host(
+    runner: CliRunner, captured_launches: list[list[str]]
+) -> None:
+    """Closes #38: an explicit scheme + non-Zoom host must be refused at the
+    CLI layer with a clear error and exit code != 0. Never reaches the
+    launcher subprocess."""
+    result = runner.invoke(main, ["https://evil.example/zoom.us/j/123"])
+    assert result.exit_code != 0
+    assert "untrusted host" in result.output.lower()
+    assert captured_launches == []
+
+
+def test_launch_refuses_substring_lookalike(
+    runner: CliRunner, captured_launches: list[list[str]]
+) -> None:
+    """``my-zoom.us-domain.com`` contains the literal substring ``zoom.us``
+    but is not a Zoom subdomain. Old substring-based routing accepted it."""
+    result = runner.invoke(main, ["https://my-zoom.us-domain.com/j/123"])
+    assert result.exit_code != 0
+    assert "untrusted host" in result.output.lower()
+    assert captured_launches == []
+
+
+def test_launch_accepts_zoom_subdomain(
+    runner: CliRunner, captured_launches: list[list[str]]
+) -> None:
+    result = runner.invoke(main, ["https://us02web.zoom.us/j/123"])
+    assert result.exit_code == 0, result.output
+    assert len(captured_launches) == 1
+    assert captured_launches[0][1].startswith("zoommtg://us02web.zoom.us/")
+
+
+def test_launch_accepts_bare_zoom_url_no_scheme(
+    runner: CliRunner, captured_launches: list[list[str]]
+) -> None:
+    result = runner.invoke(main, ["zoom.us/j/123"])
+    assert result.exit_code == 0, result.output
+    assert len(captured_launches) == 1
+
+
+def test_launch_routes_non_url_to_saved_meeting_lookup(
+    runner: CliRunner, write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """A bare argument that doesn't parse as a Zoom URL routes to the
+    saved-meeting branch (the existing behaviour for `zoom <name>`)."""
+    write_meetings({"daily": {"id": "999"}})
+    result = runner.invoke(main, ["daily"])
+    assert result.exit_code == 0, result.output
+    assert len(captured_launches) == 1
+    assert "confno=999" in captured_launches[0][1]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,11 +88,64 @@ def test_save_url_does_not_prompt_for_password_when_pwd_in_url(
 def test_rm_with_argument_no_prompt(
     runner: CliRunner, write_meetings, tmp_zoom_cli_home: Path
 ) -> None:
+    """Regression: `zoom rm <name>` with a positional name must NOT prompt
+    for confirmation — that would break existing scripts and aliases."""
     write_meetings({"a": {"id": "1"}, "b": {"id": "2"}})
     result = runner.invoke(main, ["rm", "a"])
     assert result.exit_code == 0, result.output
     on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
     assert on_disk == {"b": {"id": "2"}}
+
+
+def test_rm_dry_run_does_not_modify_file(
+    runner: CliRunner, write_meetings, tmp_zoom_cli_home: Path
+) -> None:
+    write_meetings({"a": {"id": "1"}, "b": {"id": "2"}})
+    result = runner.invoke(main, ["rm", "a", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "[dry-run]" in result.output
+    assert "a" in result.output
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    assert on_disk == {"a": {"id": "1"}, "b": {"id": "2"}}
+
+
+def test_rm_interactive_confirms_before_deleting(
+    runner: CliRunner,
+    write_meetings,
+    tmp_zoom_cli_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the name is picked interactively (no positional arg), a
+    confirmation prompt must fire. Answering 'n' must abort."""
+    import zoom_cli.__main__ as main_mod
+
+    write_meetings({"a": {"id": "1"}})
+    monkeypatch.setattr(main_mod.questionary, "select", _FakeQ(["a"]))
+
+    # Click's prompt reads from stdin; feed 'n\n' to decline.
+    result = runner.invoke(main, ["rm"], input="n\n")
+    assert result.exit_code == 0, result.output
+    assert "Aborted" in result.output
+    # Meeting still present.
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    assert "a" in on_disk
+
+
+def test_rm_interactive_with_yes_flag_skips_confirmation(
+    runner: CliRunner,
+    write_meetings,
+    tmp_zoom_cli_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import zoom_cli.__main__ as main_mod
+
+    write_meetings({"a": {"id": "1"}})
+    monkeypatch.setattr(main_mod.questionary, "select", _FakeQ(["a"]))
+
+    result = runner.invoke(main, ["rm", "--yes"])
+    assert result.exit_code == 0, result.output
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    assert "a" not in on_disk
 
 
 def test_default_launch_with_url_argument(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -632,3 +632,112 @@ def test_launch_routes_non_url_to_saved_meeting_lookup(
     assert result.exit_code == 0, result.output
     assert len(captured_launches) == 1
     assert "confno=999" in captured_launches[0][1]
+
+
+# ---- #41 / #43: keyring error translation at CLI boundary ----------------
+
+
+def _force_keyring_error(monkeypatch: pytest.MonkeyPatch, exc: Exception) -> None:
+    """Patch every keyring entry point used by the CLI to raise ``exc``."""
+    import keyring
+
+    def boom(*_args, **_kwargs):
+        raise exc
+
+    monkeypatch.setattr(keyring, "get_password", boom)
+    monkeypatch.setattr(keyring, "set_password", boom)
+    monkeypatch.setattr(keyring, "delete_password", boom)
+
+
+def test_s2s_test_translates_no_keyring_to_distinct_exit_code(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Closes #41: 'no backend' must give exit 2 with a backend-specific
+    message, distinct from the 'not configured' exit 1."""
+    import keyring.errors
+
+    _force_keyring_error(monkeypatch, keyring.errors.NoKeyringError("no backend"))
+    result = runner.invoke(main, ["auth", "s2s", "test"])
+    assert result.exit_code == 2
+    assert "keyring backend not available" in result.output.lower()
+
+
+def test_s2s_test_translates_locked_keyring_to_friendly_error(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Closes #43: a generic KeyringError (e.g. locked Keychain) gives a
+    friendly message and exit code 3 — not a Python traceback."""
+    import keyring.errors
+
+    _force_keyring_error(monkeypatch, keyring.errors.KeyringError("locked"))
+    result = runner.invoke(main, ["auth", "s2s", "test"])
+    assert result.exit_code == 3
+    assert "may be locked" in result.output.lower()
+    # No traceback noise.
+    assert "Traceback" not in result.output
+
+
+def test_users_me_translates_keyring_errors(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`zoom users me` must not surface raw KeyringError on a locked
+    keychain — it goes through the same translation as auth commands."""
+    import keyring.errors
+
+    _force_keyring_error(monkeypatch, keyring.errors.KeyringError("locked"))
+    result = runner.invoke(main, ["users", "me"])
+    assert result.exit_code == 3
+    assert "Traceback" not in result.output
+
+
+def test_logout_translates_keyring_errors(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import keyring.errors
+
+    _force_keyring_error(monkeypatch, keyring.errors.NoKeyringError("no backend"))
+    result = runner.invoke(main, ["auth", "logout"])
+    assert result.exit_code == 2
+    assert "keyring backend not available" in result.output.lower()
+
+
+def test_status_swallows_no_backend_and_reports_not_configured(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``zoom auth status`` is a probe-style command — it should not exit
+    non-zero just because the backend is missing. The friendly 'not
+    configured' message is enough; users debugging a real backend issue
+    use ``zoom auth s2s test``."""
+    import keyring.errors
+
+    _force_keyring_error(monkeypatch, keyring.errors.NoKeyringError("no backend"))
+    result = runner.invoke(main, ["auth", "status"])
+    assert result.exit_code == 0
+    assert "not configured" in result.output
+
+
+def test_s2s_set_translates_keyring_save_error(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the keyring write itself fails (locked backend), the user gets a
+    friendly error, not a raw exception trace."""
+    import keyring
+    import keyring.errors
+
+    # `save` reads existing values first (snapshot) — those reads succeed
+    # on the in-memory backend. The first set_password fails.
+    real_set = keyring.set_password
+
+    def boom(service, username, password):
+        raise keyring.errors.KeyringError("locked")
+
+    monkeypatch.setattr(keyring, "set_password", boom)
+    result = runner.invoke(
+        main,
+        ["auth", "s2s", "set", "--account-id", "a", "--client-id", "b"],
+        env={"ZOOM_CLIENT_SECRET": "c"},
+    )
+    assert result.exit_code == 3
+    assert "may be locked" in result.output.lower()
+    # Restore for fixture teardown.
+    monkeypatch.setattr(keyring, "set_password", real_set)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,6 +109,29 @@ def test_rm_dry_run_does_not_modify_file(
     assert on_disk == {"a": {"id": "1"}, "b": {"id": "2"}}
 
 
+def test_rm_interactive_dry_run_does_not_confirm_or_delete(
+    runner: CliRunner,
+    write_meetings,
+    tmp_zoom_cli_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`zoom rm --dry-run` (no positional name): pick from list, print the
+    preview, return without firing the confirmation prompt."""
+    import zoom_cli.__main__ as main_mod
+
+    write_meetings({"alpha": {"id": "1"}, "beta": {"id": "2"}})
+    monkeypatch.setattr(main_mod.questionary, "select", _FakeQ(["alpha"]))
+
+    result = runner.invoke(main, ["rm", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "[dry-run]" in result.output
+    assert "alpha" in result.output
+    assert "Remove meeting" not in result.output  # confirm prompt did NOT fire
+
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    assert on_disk == {"alpha": {"id": "1"}, "beta": {"id": "2"}}
+
+
 def test_rm_interactive_confirms_before_deleting(
     runner: CliRunner,
     write_meetings,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,13 +64,17 @@ def test_save_url_via_flags(runner: CliRunner, tmp_zoom_cli_home: Path) -> None:
 
 
 def test_save_id_password_via_flags(runner: CliRunner, tmp_zoom_cli_home: Path) -> None:
+    """Password lands in keyring, not in meetings.json."""
+    from zoom_cli import secrets
+
     result = runner.invoke(
         main,
         ["save", "-n", "standup", "--id", "1234567890", "-p", "pw"],
     )
     assert result.exit_code == 0, result.output
     on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
-    assert on_disk == {"standup": {"id": "1234567890", "password": "pw"}}
+    assert on_disk == {"standup": {"id": "1234567890"}}
+    assert secrets.get_password("standup") == "pw"
 
 
 def test_save_url_does_not_prompt_for_password_when_pwd_in_url(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -167,9 +167,27 @@ def test_auth_status_when_not_configured(runner: CliRunner) -> None:
     assert "not configured" in result.output
 
 
-def test_auth_s2s_set_with_flags_persists_to_keyring(runner: CliRunner) -> None:
+def test_auth_s2s_set_with_env_secret_persists_to_keyring(runner: CliRunner) -> None:
     from zoom_cli import auth
 
+    result = runner.invoke(
+        main,
+        ["auth", "s2s", "set", "--account-id", "acc-1", "--client-id", "cid-2"],
+        env={"ZOOM_CLIENT_SECRET": "csecret-3"},
+    )
+    assert result.exit_code == 0, result.output
+    assert "saved" in result.output.lower()
+
+    loaded = auth.load_s2s_credentials()
+    assert loaded is not None
+    assert loaded.account_id == "acc-1"
+    assert loaded.client_id == "cid-2"
+    assert loaded.client_secret == "csecret-3"
+
+
+def test_auth_s2s_set_rejects_client_secret_flag(runner: CliRunner) -> None:
+    """Closes #34: --client-secret must NOT exist as a CLI flag, since values
+    in argv land in shell history and are visible via process inspection."""
     result = runner.invoke(
         main,
         [
@@ -181,17 +199,36 @@ def test_auth_s2s_set_with_flags_persists_to_keyring(runner: CliRunner) -> None:
             "--client-id",
             "cid-2",
             "--client-secret",
-            "csecret-3",
+            "should-be-rejected",
         ],
     )
+    assert result.exit_code != 0
+    # Click prints "No such option" or similar on unknown flags.
+    assert "no such option" in result.output.lower() or "unrecognized" in result.output.lower()
+
+
+def test_auth_s2s_set_reads_account_and_client_id_from_env(runner: CliRunner) -> None:
+    """All three identifiers can come from env vars (only client_secret is
+    forbidden from the flag path; account_id and client_id are public-ish
+    identifiers but env support keeps scripted use ergonomic)."""
+    from zoom_cli import auth
+
+    result = runner.invoke(
+        main,
+        ["auth", "s2s", "set"],
+        env={
+            "ZOOM_ACCOUNT_ID": "env-acc",
+            "ZOOM_CLIENT_ID": "env-cid",
+            "ZOOM_CLIENT_SECRET": "env-secret",
+        },
+    )
     assert result.exit_code == 0, result.output
-    assert "saved" in result.output.lower()
 
     loaded = auth.load_s2s_credentials()
     assert loaded is not None
-    assert loaded.account_id == "acc-1"
-    assert loaded.client_id == "cid-2"
-    assert loaded.client_secret == "csecret-3"
+    assert loaded.account_id == "env-acc"
+    assert loaded.client_id == "env-cid"
+    assert loaded.client_secret == "env-secret"
 
 
 def test_auth_status_when_configured(runner: CliRunner) -> None:
@@ -222,17 +259,8 @@ def test_auth_s2s_set_does_not_echo_secret_in_output(runner: CliRunner) -> None:
     secret = "very-secret-do-not-leak-12345"
     result = runner.invoke(
         main,
-        [
-            "auth",
-            "s2s",
-            "set",
-            "--account-id",
-            "a",
-            "--client-id",
-            "b",
-            "--client-secret",
-            secret,
-        ],
+        ["auth", "s2s", "set", "--account-id", "a", "--client-id", "b"],
+        env={"ZOOM_CLIENT_SECRET": secret},
     )
     assert result.exit_code == 0, result.output
     assert secret not in result.output

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -267,6 +267,23 @@ def test_launch_name_falls_back_to_legacy_json_password(
     assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=555&pwd=legacy-only"]]
 
 
+def test_launch_name_empty_keyring_password_overrides_url_pwd(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """Superpowers review on PR #28: if the user explicitly stored an
+    empty-string password in the keyring (a deliberate "no password"),
+    that empty value must beat the URL's ``pwd=`` rather than falling
+    through to it."""
+    from zoom_cli import secrets
+
+    write_meetings({"team": {"url": "https://zoom.us/j/123?pwd=fromurl"}})
+    secrets.set_password("team", "")  # explicit empty
+
+    commands_mod._launch_name("team")
+    # Empty keyring password wins → no &pwd= appended.
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123"]]
+
+
 def test_save_url_with_no_password_clears_keyring(tmp_zoom_cli_home) -> None:
     """`_save_url(name, url, "")` must clear any pre-existing keyring entry —
     otherwise re-saving a meeting "without a password" would silently keep
@@ -277,6 +294,31 @@ def test_save_url_with_no_password_clears_keyring(tmp_zoom_cli_home) -> None:
     commands_mod._save_url("standup", "https://zoom.us/j/1", "")
 
     assert secrets.get_password("standup") is None
+
+
+def test_save_url_keyring_failure_leaves_json_untouched(
+    tmp_zoom_cli_home, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex regression for PR #28: save must write keyring BEFORE JSON.
+    If the keyring write fails, the prior on-disk state is preserved."""
+    from zoom_cli import secrets
+
+    # Seed: existing meeting with a known JSON contents.
+    (tmp_zoom_cli_home / "meetings.json").write_text(
+        '{"standup": {"url": "https://old.example/j/1"}}'
+    )
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("keyring backend exploded")
+
+    monkeypatch.setattr(secrets, "set_password", boom)
+
+    with pytest.raises(RuntimeError, match="keyring backend exploded"):
+        commands_mod._save_url("standup", "https://NEW.example/j/2", "newpw")
+
+    # JSON must be unchanged — the rewrite never happened.
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    assert on_disk == {"standup": {"url": "https://old.example/j/1"}}
 
 
 def test_remove_deletes_keyring_entry(write_meetings, tmp_zoom_cli_home) -> None:
@@ -442,25 +484,49 @@ def test_edit_with_password_flag_writes_to_keyring(
     assert secrets.get_password("team") == "new-pw"
 
 
-def test_edit_skips_legacy_plaintext_password_field(
+def test_edit_migrates_legacy_plaintext_password_into_keyring(
     write_meetings,
     tmp_zoom_cli_home: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A pre-keyring entry has ``password`` in JSON. `_edit` must not prompt
-    for it (we'd be exposing the plaintext via ``default=...``); it just
-    drops the field on the rewrite. The user can re-set the password via
-    ``--password`` if they want."""
+    """A pre-keyring entry has ``password`` in JSON. `_edit` must:
+    1. NOT re-prompt (would expose plaintext via ``default=...``).
+    2. Migrate the value into the keyring before dropping it from JSON.
+
+    Regression for all three reviewers on PR #28 — earlier behavior
+    silently destroyed the legacy plaintext on any edit."""
+    from zoom_cli import secrets
+
     write_meetings({"team": {"url": "https://old.example/j/1", "password": "legacy"}})
+    assert secrets.get_password("team") is None  # nothing in keyring yet
     fake = _FakeQ(["https://kept.example/j/1"])  # only the URL is prompted
     monkeypatch.setattr(commands_mod.questionary, "text", fake)
 
     commands_mod._edit("team", "", "", "")
 
     on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
-    # Legacy password field is gone — and importantly, was never offered as
-    # a default value to the user.
+    # Legacy password field is gone from JSON — but the value is in the keyring.
     assert on_disk == {"team": {"url": "https://kept.example/j/1"}}
+    assert secrets.get_password("team") == "legacy"
+
+
+def test_edit_legacy_password_migration_does_not_overwrite_existing_keyring(
+    write_meetings,
+    tmp_zoom_cli_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If a keyring entry already exists, the (stale) legacy JSON password
+    must NOT overwrite it. The keyring is authoritative."""
+    from zoom_cli import secrets
+
+    write_meetings({"team": {"url": "https://old.example/j/1", "password": "stale-legacy"}})
+    secrets.set_password("team", "fresh-keyring")
+    fake = _FakeQ(["https://kept.example/j/1"])
+    monkeypatch.setattr(commands_mod.questionary, "text", fake)
+
+    commands_mod._edit("team", "", "", "")
+
+    assert secrets.get_password("team") == "fresh-keyring"
 
 
 def test_edit_aborts_cleanly_on_ctrl_c(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -180,22 +180,33 @@ def test_launch_name_web_client_url_falls_back(
     assert captured_launches == [["open", "zoommtg://zoom.us/wc/123/join?pwd=abc"]]
 
 
-def test_launch_name_decodes_percent_encoded_password(
+def test_launch_name_round_trips_percent_encoded_password(
     write_meetings, captured_launches: list[list[str]]
 ) -> None:
-    """``parse_qs`` URL-decodes the password before we re-build the
-    zoommtg URL, so a percent-encoded ``#`` round-trips correctly."""
+    """``parse_qs`` URL-decodes the password from the saved URL, then the
+    launcher re-encodes it when building the zoommtg URL (closes #37). The
+    decoded round-trip must yield the original byte-for-byte."""
+    from urllib.parse import parse_qs, urlsplit
+
     write_meetings({"team": {"url": "https://zoom.us/j/123?pwd=ab%23cd"}})
     commands_mod._launch_name("team")
-    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123&pwd=ab#cd"]]
+    assert len(captured_launches) == 1
+    argv = captured_launches[0]
+    assert argv[0] == "open"
+    pwd_values = parse_qs(urlsplit(argv[1]).query).get("pwd", [])
+    assert pwd_values == ["ab#cd"]
 
 
-def test_launch_name_decodes_space_in_password(
+def test_launch_name_round_trips_space_in_password(
     write_meetings, captured_launches: list[list[str]]
 ) -> None:
+    from urllib.parse import parse_qs, urlsplit
+
     write_meetings({"team": {"url": "https://zoom.us/j/123?pwd=hello%20world"}})
     commands_mod._launch_name("team")
-    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123&pwd=hello world"]]
+    assert len(captured_launches) == 1
+    pwd_values = parse_qs(urlsplit(captured_launches[0][1]).query).get("pwd", [])
+    assert pwd_values == ["hello world"]
 
 
 def test_launch_name_picks_pwd_when_other_query_params_present(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -17,15 +17,24 @@ def test_save_url_persists_payload(tmp_zoom_cli_home: Path) -> None:
 
 
 def test_save_url_includes_password_when_provided(tmp_zoom_cli_home: Path) -> None:
+    """Password goes to the OS keyring, not into meetings.json."""
+    from zoom_cli import secrets
+
     commands_mod._save_url("standup", "https://zoom.us/j/1", "p@ss")
+
     on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
-    assert on_disk == {"standup": {"url": "https://zoom.us/j/1", "password": "p@ss"}}
+    assert on_disk == {"standup": {"url": "https://zoom.us/j/1"}}
+    assert secrets.get_password("standup") == "p@ss"
 
 
 def test_save_id_password_persists_payload(tmp_zoom_cli_home: Path) -> None:
+    from zoom_cli import secrets
+
     commands_mod._save_id_password("standup", "1234567890", "secret")
+
     on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
-    assert on_disk == {"standup": {"id": "1234567890", "password": "secret"}}
+    assert on_disk == {"standup": {"id": "1234567890"}}
+    assert secrets.get_password("standup") == "secret"
 
 
 def test_save_id_password_omits_password_when_empty(tmp_zoom_cli_home: Path) -> None:
@@ -217,6 +226,99 @@ def test_launch_name_explicit_password_field_overrides_url_password(
     assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123&pwd=explicit"]]
 
 
+# ---- Keyring integration (issue #5) -------------------------------------
+
+
+def test_launch_name_uses_keyring_password_when_available(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """Keyring is the source of truth — wins over plaintext in JSON."""
+    from zoom_cli import secrets
+
+    write_meetings({"team": {"id": "555"}})
+    secrets.set_password("team", "from-keyring")
+
+    commands_mod._launch_name("team")
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=555&pwd=from-keyring"]]
+
+
+def test_launch_name_keyring_wins_over_legacy_json_password(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """Back-compat ladder: if both a keyring entry and a legacy JSON
+    password exist, the keyring wins. Pre-keyring JSON entries continue
+    to work; once a user re-saves, they migrate."""
+    from zoom_cli import secrets
+
+    write_meetings({"team": {"id": "555", "password": "legacy-json"}})
+    secrets.set_password("team", "from-keyring")
+
+    commands_mod._launch_name("team")
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=555&pwd=from-keyring"]]
+
+
+def test_launch_name_falls_back_to_legacy_json_password(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """No keyring entry → fall back to plaintext JSON password (back-compat)."""
+    write_meetings({"team": {"id": "555", "password": "legacy-only"}})
+
+    commands_mod._launch_name("team")
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=555&pwd=legacy-only"]]
+
+
+def test_save_url_with_no_password_clears_keyring(tmp_zoom_cli_home) -> None:
+    """`_save_url(name, url, "")` must clear any pre-existing keyring entry —
+    otherwise re-saving a meeting "without a password" would silently keep
+    the old one."""
+    from zoom_cli import secrets
+
+    secrets.set_password("standup", "stale")
+    commands_mod._save_url("standup", "https://zoom.us/j/1", "")
+
+    assert secrets.get_password("standup") is None
+
+
+def test_remove_deletes_keyring_entry(write_meetings, tmp_zoom_cli_home) -> None:
+    """`zoom rm` must take the keyring entry with it — leaving an orphan
+    keyring entry under a freed name is a leak."""
+    from zoom_cli import secrets
+
+    write_meetings({"team": {"id": "1"}})
+    secrets.set_password("team", "p")
+
+    commands_mod._remove("team")
+
+    assert secrets.get_password("team") is None
+
+
+def test_ls_masks_keyring_password(write_meetings, capsys: pytest.CaptureFixture[str]) -> None:
+    from zoom_cli import secrets
+
+    write_meetings({"team": {"id": "1"}})
+    secrets.set_password("team", "very-secret")
+
+    commands_mod._ls()
+    out = capsys.readouterr().out
+    assert "very-secret" not in out, "real password leaked into ls output"
+    assert "********" in out
+    assert "password:" in out
+
+
+def test_ls_masks_legacy_json_password(write_meetings, capsys: pytest.CaptureFixture[str]) -> None:
+    """Legacy plaintext-in-JSON passwords must also be masked, even though
+    the storage path is the back-compat one."""
+    write_meetings({"team": {"id": "1", "password": "legacy"}})
+
+    commands_mod._ls()
+    out = capsys.readouterr().out
+    assert "legacy" not in out, "legacy plaintext password leaked into ls output"
+    assert "********" in out
+
+
+# -------------------------------------------------------------------------
+
+
 def test_launch_name_personal_link_with_explicit_password_passes_password(
     write_meetings, captured_launches: list[list[str]]
 ) -> None:
@@ -302,38 +404,63 @@ class _FakeQ:
         return self._answers.pop(0)
 
 
-def test_edit_overwrites_each_field_with_new_answer(
+def test_edit_overwrites_url_with_new_answer(
     write_meetings,
     tmp_zoom_cli_home: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    write_meetings({"team": {"url": "https://old.example/j/1", "password": "old"}})
-    fake = _FakeQ(["https://new.example/j/2", "new"])
+    """`_edit` no longer prompts for password (it's in the keyring); the URL
+    field is still re-prompted."""
+    write_meetings({"team": {"url": "https://old.example/j/1"}})
+    fake = _FakeQ(["https://new.example/j/2"])
     monkeypatch.setattr(commands_mod.questionary, "text", fake)
 
     commands_mod._edit("team", "", "", "")
 
     on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
-    assert on_disk == {"team": {"url": "https://new.example/j/2", "password": "new"}}
+    assert on_disk == {"team": {"url": "https://new.example/j/2"}}
 
 
-def test_edit_allows_clearing_a_field_with_empty_string(
+def test_edit_with_password_flag_writes_to_keyring(
     write_meetings,
     tmp_zoom_cli_home: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Regression: ``ask() or val`` silently restored the old value when the
-    user submitted an empty string. The fix preserves the empty string and
-    only treats ``None`` (Ctrl-C) as cancellation.
-    """
-    write_meetings({"team": {"url": "https://old.example/j/1", "password": "old"}})
-    fake = _FakeQ(["https://kept.example/j/1", ""])  # second answer intentionally empty
+    """Passing ``--password`` (positional ``password`` arg here) updates the
+    keyring entry; nothing about the password leaks back into meetings.json."""
+    from zoom_cli import secrets
+
+    write_meetings({"team": {"url": "https://old.example/j/1"}})
+    secrets.set_password("team", "old-pw")
+    fake = _FakeQ(["https://new.example/j/2"])
+    monkeypatch.setattr(commands_mod.questionary, "text", fake)
+
+    commands_mod._edit("team", "", "", "new-pw")
+
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    assert on_disk == {"team": {"url": "https://new.example/j/2"}}
+    assert secrets.get_password("team") == "new-pw"
+
+
+def test_edit_skips_legacy_plaintext_password_field(
+    write_meetings,
+    tmp_zoom_cli_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pre-keyring entry has ``password`` in JSON. `_edit` must not prompt
+    for it (we'd be exposing the plaintext via ``default=...``); it just
+    drops the field on the rewrite. The user can re-set the password via
+    ``--password`` if they want."""
+    write_meetings({"team": {"url": "https://old.example/j/1", "password": "legacy"}})
+    fake = _FakeQ(["https://kept.example/j/1"])  # only the URL is prompted
     monkeypatch.setattr(commands_mod.questionary, "text", fake)
 
     commands_mod._edit("team", "", "", "")
 
     on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
-    assert on_disk == {"team": {"url": "https://kept.example/j/1", "password": ""}}
+    # Legacy password field is gone — and importantly, was never offered as
+    # a default value to the user.
+    assert on_disk == {"team": {"url": "https://kept.example/j/1"}}
 
 
 def test_edit_aborts_cleanly_on_ctrl_c(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -77,6 +77,40 @@ def test_launch_url_handles_url_without_scheme(captured_launches: list[list[str]
     assert captured_launches == [["open", "zoommtg://zoom.us/j/456"]]
 
 
+def test_launch_url_does_not_swallow_unexpected_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for #6 — bare ``except Exception`` previously hid bugs.
+
+    Genuine bugs in the launcher must propagate; only the launcher's
+    own ``LauncherUnavailableError`` is treated as a recoverable user error.
+    """
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("unexpected")
+
+    monkeypatch.setattr(commands_mod, "launch_zoommtg_url", boom)
+
+    with pytest.raises(RuntimeError, match="unexpected"):
+        commands_mod._launch_url("https://zoom.us/j/1")
+
+
+def test_launch_url_reports_launcher_unavailable_cleanly(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from zoom_cli import utils as utils_mod
+
+    def boom(*_args, **_kwargs):
+        raise utils_mod.LauncherUnavailableError("no launcher")
+
+    monkeypatch.setattr(commands_mod, "launch_zoommtg_url", boom)
+
+    commands_mod._launch_url("https://zoom.us/j/1")
+    out = capsys.readouterr().out
+    assert "Error:" in out
+    assert "no launcher" in out
+
+
 def test_launch_name_uses_saved_url(write_meetings, captured_launches: list[list[str]]) -> None:
     write_meetings({"team": {"url": "https://zoom.us/j/123?pwd=abc"}})
     commands_mod._launch_name("team")
@@ -113,6 +147,90 @@ def test_launch_name_meeting_without_url_or_id(
     commands_mod._launch_name("empty")
     assert captured_launches == []
     assert "No url or id found" in capsys.readouterr().out
+
+
+# ---- _launch_name URL-parsing edge cases (issue #6) ----------------------
+
+
+def test_launch_name_personal_link_falls_back_to_url_launch(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """Regression for #6: ``/s/personal-name`` URLs previously crashed
+    because slice-based parsing called ``url.index('/j/')``. Now they fall
+    back to launching the URL through the zoommtg scheme."""
+    write_meetings({"personal": {"url": "https://zoom.us/s/my-personal-link"}})
+    commands_mod._launch_name("personal")
+    assert captured_launches == [["open", "zoommtg://zoom.us/s/my-personal-link"]]
+
+
+def test_launch_name_web_client_url_falls_back(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    write_meetings({"webclient": {"url": "https://zoom.us/wc/123/join?pwd=abc"}})
+    commands_mod._launch_name("webclient")
+    assert captured_launches == [["open", "zoommtg://zoom.us/wc/123/join?pwd=abc"]]
+
+
+def test_launch_name_decodes_percent_encoded_password(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """``parse_qs`` URL-decodes the password before we re-build the
+    zoommtg URL, so a percent-encoded ``#`` round-trips correctly."""
+    write_meetings({"team": {"url": "https://zoom.us/j/123?pwd=ab%23cd"}})
+    commands_mod._launch_name("team")
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123&pwd=ab#cd"]]
+
+
+def test_launch_name_decodes_space_in_password(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    write_meetings({"team": {"url": "https://zoom.us/j/123?pwd=hello%20world"}})
+    commands_mod._launch_name("team")
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123&pwd=hello world"]]
+
+
+def test_launch_name_picks_pwd_when_other_query_params_present(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """Earlier slice-based code broke on multiple ``&`` params if ``pwd``
+    wasn't the first one. parse_qs handles arbitrary order."""
+    write_meetings({"team": {"url": "https://zoom.us/j/123?tk=tracking&pwd=secret&other=1"}})
+    commands_mod._launch_name("team")
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123&pwd=secret"]]
+
+
+def test_launch_name_handles_url_with_fragment(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    write_meetings({"team": {"url": "https://zoom.us/j/123?pwd=abc#section"}})
+    commands_mod._launch_name("team")
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123&pwd=abc"]]
+
+
+def test_launch_name_explicit_password_field_overrides_url_password(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """When an entry has both a URL with ``pwd=`` and an explicit
+    ``password`` field, the explicit field wins (preserves prior behavior)."""
+    write_meetings({"team": {"url": "https://zoom.us/j/123?pwd=fromurl", "password": "explicit"}})
+    commands_mod._launch_name("team")
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123&pwd=explicit"]]
+
+
+def test_launch_name_propagates_launcher_unavailable_as_error_message(
+    write_meetings,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from zoom_cli import utils as utils_mod
+
+    write_meetings({"team": {"id": "1"}})
+    monkeypatch.setattr(utils_mod.shutil, "which", lambda _cmd: None)
+
+    commands_mod._launch_name("team")
+    out = capsys.readouterr().out
+    assert "Error:" in out
+    assert "Neither" in out  # message from LauncherUnavailableError
 
 
 # ---- _edit ---------------------------------------------------------------

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -217,6 +217,54 @@ def test_launch_name_explicit_password_field_overrides_url_password(
     assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123&pwd=explicit"]]
 
 
+def test_launch_name_personal_link_with_explicit_password_passes_password(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """Regression for review feedback on #6: when a personal-link/non-/j/
+    URL has an explicit ``password`` field saved, the URL fallback path
+    must pass it to the launcher so the meeting joins without a manual
+    re-entry."""
+    write_meetings({"personal": {"url": "https://zoom.us/s/my-link", "password": "explicit"}})
+    commands_mod._launch_name("personal")
+    assert captured_launches == [["open", "zoommtg://zoom.us/s/my-link?pwd=explicit"]]
+
+
+def test_launch_name_personal_link_with_url_pwd_does_not_double_append(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """If the URL already has ``pwd=``, we must not append it again — that
+    would corrupt the URL. The URL passes through verbatim through the
+    zoommtg launcher."""
+    write_meetings({"personal": {"url": "https://zoom.us/s/my-link?pwd=fromurl"}})
+    commands_mod._launch_name("personal")
+    assert captured_launches == [["open", "zoommtg://zoom.us/s/my-link?pwd=fromurl"]]
+
+
+def test_launch_name_empty_string_password_is_respected_not_replaced(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """Regression for superpowers review on #6: an entry with
+    ``password: ""`` (intentional clear via ``zoom edit``) must keep the
+    empty value, not silently fall back to the URL's pwd= parameter.
+    Presence-check, not truthy-check."""
+    write_meetings({"team": {"url": "https://zoom.us/j/123?pwd=fromurl", "password": ""}})
+    commands_mod._launch_name("team")
+    # Empty explicit password wins over URL pwd=. launch_zoommtg with
+    # password="" produces the URL with no &pwd= suffix.
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123"]]
+
+
+def test_launch_name_handles_confno_query_param_url(
+    write_meetings, captured_launches: list[list[str]]
+) -> None:
+    """Regression for codex review on #6: URLs of the form
+    ``?confno=<id>`` should now be recognized as meeting URLs and
+    re-emitted through the canonical zoommtg:// scheme."""
+    write_meetings({"team": {"url": "https://zoom.us/join?confno=123456789&pwd=p"}})
+    commands_mod._launch_name("team")
+    assert captured_launches == [["open", "zoommtg://zoom.us/join?confno=123456789&pwd=p"]]
+
+
 def test_launch_name_propagates_launcher_unavailable_as_error_message(
     write_meetings,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -218,3 +218,35 @@ def test_fetch_access_token_raises_zoom_auth_error_on_garbage_2xx() -> None:
             S2SCredentials(account_id="a", client_id="b", client_secret="c"),
             client=http,
         )
+
+
+# ---- #47: token expiry skew ---------------------------------------------
+
+
+def test_access_token_is_expired_within_skew_window() -> None:
+    """Closes #47 (partial): a token with 30s left until expiry is treated
+    as expired. Default skew is 60s — see ``oauth.EXPIRY_SKEW_SECONDS``."""
+    from datetime import timedelta
+
+    near_expiry = oauth.AccessToken(
+        value="t",
+        expires_at=datetime.now(timezone.utc) + timedelta(seconds=30),
+        scopes=(),
+    )
+    assert near_expiry.is_expired is True
+
+
+def test_access_token_not_expired_outside_skew_window() -> None:
+    from datetime import timedelta
+
+    well_in_future = oauth.AccessToken(
+        value="t",
+        expires_at=datetime.now(timezone.utc) + timedelta(seconds=600),
+        scopes=(),
+    )
+    assert well_in_future.is_expired is False
+
+
+def test_expiry_skew_constant_is_pinned() -> None:
+    """Pin the constant so a future tweak shows up in review."""
+    assert oauth.EXPIRY_SKEW_SECONDS == 60

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -165,3 +165,56 @@ def test_token_url_is_zoom_oauth_endpoint() -> None:
     """Pin the URL — different from the API base (api.zoom.us). A future
     rename would silently break every existing user."""
     assert oauth.TOKEN_URL == "https://zoom.us/oauth/token"
+
+
+# ---- #46 / #42: malformed-JSON 2xx success bodies ------------------------
+
+
+def test_fetch_access_token_raises_zoom_auth_error_on_html_2xx() -> None:
+    """Closes #46 / verifies #42 fix: a 2xx body that isn't JSON (corporate
+    proxy returning HTML, captive portal) used to leak raw ValueError."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text="<html><body>Captive portal login required</body></html>",
+            headers={"Content-Type": "text/html"},
+        )
+
+    with (
+        httpx.Client(transport=httpx.MockTransport(handler)) as http,
+        pytest.raises(oauth.ZoomAuthError) as excinfo,
+    ):
+        oauth.fetch_access_token(
+            S2SCredentials(account_id="a", client_id="b", client_secret="c"),
+            client=http,
+        )
+    assert "non-JSON body" in str(excinfo.value)
+
+
+def test_fetch_access_token_raises_zoom_auth_error_on_empty_2xx() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"")
+
+    with (
+        httpx.Client(transport=httpx.MockTransport(handler)) as http,
+        pytest.raises(oauth.ZoomAuthError),
+    ):
+        oauth.fetch_access_token(
+            S2SCredentials(account_id="a", client_id="b", client_secret="c"),
+            client=http,
+        )
+
+
+def test_fetch_access_token_raises_zoom_auth_error_on_garbage_2xx() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="not json at all")
+
+    with (
+        httpx.Client(transport=httpx.MockTransport(handler)) as http,
+        pytest.raises(oauth.ZoomAuthError),
+    ):
+        oauth.fetch_access_token(
+            S2SCredentials(account_id="a", client_id="b", client_secret="c"),
+            client=http,
+        )

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,0 +1,167 @@
+"""Tests for zoom_cli.api.oauth — Server-to-Server token exchange.
+
+The test strategy is httpx.MockTransport: we hand fetch_access_token a
+real httpx.Client wrapped around a fake transport, so the production
+code is exercised end-to-end (auth header, query params, JSON parsing)
+without ever opening a socket.
+"""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+from zoom_cli.api import oauth
+from zoom_cli.auth import S2SCredentials
+
+
+def _creds() -> S2SCredentials:
+    return S2SCredentials(
+        account_id="acc-123",
+        client_id="cid-456",
+        client_secret="csecret-789",
+    )
+
+
+def _client_with_handler(handler):
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def test_fetch_access_token_success() -> None:
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["auth"] = request.headers.get("authorization")
+        captured["method"] = request.method
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "tok-abc",
+                "token_type": "bearer",
+                "expires_in": 3600,
+                "scope": "user:read:user meeting:read:meeting",
+            },
+        )
+
+    with _client_with_handler(handler) as client:
+        token = oauth.fetch_access_token(_creds(), client=client)
+
+    assert token.value == "tok-abc"
+    assert token.scopes == ("user:read:user", "meeting:read:meeting")
+    assert token.expires_at > datetime.now(timezone.utc)
+    assert token.is_expired is False
+
+    # Verify the request shape Zoom requires.
+    assert captured["method"] == "POST"
+    assert captured["url"].startswith(oauth.TOKEN_URL)
+    assert "grant_type=account_credentials" in captured["url"]
+    assert "account_id=acc-123" in captured["url"]
+
+    # HTTP Basic auth: base64(client_id:client_secret)
+    expected_auth = base64.b64encode(b"cid-456:csecret-789").decode()
+    assert captured["auth"] == f"Basic {expected_auth}"
+
+
+def test_fetch_access_token_uses_default_expiry_when_missing() -> None:
+    """Zoom always sends ``expires_in`` but be defensive — fall back to
+    the documented 1-hour default if the field is somehow absent."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"access_token": "t", "scope": ""})
+
+    with _client_with_handler(handler) as client:
+        token = oauth.fetch_access_token(_creds(), client=client)
+
+    delta = (token.expires_at - datetime.now(timezone.utc)).total_seconds()
+    assert 3500 <= delta <= 3700  # ~1 hour, allow for tiny scheduler jitter
+
+
+def test_fetch_access_token_raises_on_invalid_credentials() -> None:
+    """The classic 4xx case — wrong client_id or client_secret. Surface
+    Zoom's error code and reason verbatim so the CLI can tell the user."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            401,
+            json={
+                "error": "invalid_client",
+                "reason": "Invalid client_id or client_secret",
+            },
+        )
+
+    with _client_with_handler(handler) as client, pytest.raises(oauth.ZoomAuthError) as exc_info:
+        oauth.fetch_access_token(_creds(), client=client)
+
+    err = exc_info.value
+    assert err.status_code == 401
+    assert err.error_code == "invalid_client"
+    assert "Invalid client_id" in str(err)
+
+
+def test_fetch_access_token_handles_non_json_error_body() -> None:
+    """Misconfigured proxies sometimes return HTML or empty bodies. Don't
+    crash — surface what we have."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            502, content=b"<html>bad gateway</html>", headers={"content-type": "text/html"}
+        )
+
+    with _client_with_handler(handler) as client, pytest.raises(oauth.ZoomAuthError) as exc_info:
+        oauth.fetch_access_token(_creds(), client=client)
+
+    err = exc_info.value
+    assert err.status_code == 502
+    assert err.error_code is None
+    assert "bad gateway" in str(err).lower()
+
+
+def test_fetch_access_token_raises_when_2xx_body_missing_token() -> None:
+    """Defensive: if the endpoint returns 200 but no access_token, treat
+    as an auth failure rather than handing back an empty AccessToken."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"token_type": "bearer", "expires_in": 3600})
+
+    with _client_with_handler(handler) as client, pytest.raises(oauth.ZoomAuthError) as exc_info:
+        oauth.fetch_access_token(_creds(), client=client)
+
+    assert "access_token" in str(exc_info.value).lower()
+
+
+def test_fetch_access_token_propagates_network_errors() -> None:
+    """Connection / DNS / TLS failures should bubble out as httpx.HTTPError
+    (not ZoomAuthError) so the CLI can distinguish bad creds from bad network."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("simulated DNS failure")
+
+    with _client_with_handler(handler) as client, pytest.raises(httpx.HTTPError):
+        oauth.fetch_access_token(_creds(), client=client)
+
+
+def test_access_token_is_expired_when_past_expiry() -> None:
+    expired = oauth.AccessToken(
+        value="t",
+        expires_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        scopes=(),
+    )
+    assert expired.is_expired is True
+
+
+def test_access_token_not_expired_when_in_future() -> None:
+    fresh = oauth.AccessToken(
+        value="t",
+        expires_at=datetime(2099, 1, 1, tzinfo=timezone.utc),
+        scopes=(),
+    )
+    assert fresh.is_expired is False
+
+
+def test_token_url_is_zoom_oauth_endpoint() -> None:
+    """Pin the URL — different from the API base (api.zoom.us). A future
+    rename would silently break every existing user."""
+    assert oauth.TOKEN_URL == "https://zoom.us/oauth/token"

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,54 @@
+"""Tests for zoom_cli.secrets — the OS keyring facade."""
+
+from __future__ import annotations
+
+import keyring
+import keyring.errors
+import pytest
+from zoom_cli import secrets
+
+
+def test_set_then_get_round_trips() -> None:
+    secrets.set_password("daily", "p@ss")
+    assert secrets.get_password("daily") == "p@ss"
+
+
+def test_get_returns_none_for_unknown_meeting() -> None:
+    assert secrets.get_password("never-seen") is None
+
+
+def test_delete_removes_entry() -> None:
+    secrets.set_password("temp", "x")
+    secrets.delete_password("temp")
+    assert secrets.get_password("temp") is None
+
+
+def test_delete_is_noop_when_entry_absent() -> None:
+    # Must not raise.
+    secrets.delete_password("never-existed")
+
+
+def test_set_password_with_empty_string_is_stored() -> None:
+    """Caller wants 'no password' → use delete_password. set_password('')
+    intentionally writes through; this test just pins that contract."""
+    secrets.set_password("empty", "")
+    assert secrets.get_password("empty") == ""
+
+
+def test_get_password_returns_none_when_backend_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Headless Linux boxes without DBus raise KeyringError. We treat that
+    as 'no stored password' so the CLI degrades gracefully."""
+
+    def boom(*_args, **_kwargs):
+        raise keyring.errors.KeyringError("no backend")
+
+    monkeypatch.setattr(keyring, "get_password", boom)
+    assert secrets.get_password("anything") is None
+
+
+def test_service_name_constant_is_zoom_cli() -> None:
+    """Pin the service name so a future rename doesn't silently orphan
+    every existing user's stored passwords."""
+    assert secrets.SERVICE_NAME == "zoom-cli"

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -35,17 +35,44 @@ def test_set_password_with_empty_string_is_stored() -> None:
     assert secrets.get_password("empty") == ""
 
 
-def test_get_password_returns_none_when_backend_unavailable(
+def test_get_password_returns_none_when_no_keyring_backend(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Headless Linux boxes without DBus raise KeyringError. We treat that
+    """Headless Linux boxes without DBus raise NoKeyringError. We treat that
     as 'no stored password' so the CLI degrades gracefully."""
 
     def boom(*_args, **_kwargs):
-        raise keyring.errors.KeyringError("no backend")
+        raise keyring.errors.NoKeyringError("no backend")
 
     monkeypatch.setattr(keyring, "get_password", boom)
     assert secrets.get_password("anything") is None
+
+
+def test_get_password_returns_none_on_init_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """InitError is the other 'no backend' case we degrade gracefully on."""
+
+    def boom(*_args, **_kwargs):
+        raise keyring.errors.InitError("backend init failed")
+
+    monkeypatch.setattr(keyring, "get_password", boom)
+    assert secrets.get_password("anything") is None
+
+
+def test_get_password_does_not_swallow_locked_keyring(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for python-review on PR #28: a locked-keyring or other
+    KeyringError MUST propagate. Silently returning None would launch
+    meetings with no password — wrong-launch silently."""
+
+    def boom(*_args, **_kwargs):
+        raise keyring.errors.KeyringError("locked or other failure")
+
+    monkeypatch.setattr(keyring, "get_password", boom)
+    with pytest.raises(keyring.errors.KeyringError):
+        secrets.get_password("anything")
 
 
 def test_service_name_constant_is_zoom_cli() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -163,6 +163,14 @@ def test_is_command_available_returns_false_for_garbage() -> None:
         ("https://zoom.us/j/777?tk=abc&pwd=secret&other=1", "777", "secret"),
         # zoommtg:// scheme
         ("zoommtg://zoom.us/j/888?pwd=zz", "888", "zz"),
+        # confno= query-param form (Zoom emits these for some click-to-join flows)
+        ("https://zoom.us/join?confno=123456789", "123456789", ""),
+        ("https://zoom.us/join?confno=987&pwd=secret", "987", "secret"),
+        ("zoommtg://zoom.us/join?confno=42&pwd=abc", "42", "abc"),
+        # Duplicate pwd= — first wins (attacker can't override by appending)
+        ("https://zoom.us/j/100?pwd=legit&pwd=evil", "100", "legit"),
+        # Unrecognized URL still extracts password for fallback launcher to use
+        ("https://zoom.us/wc/123?pwd=fromurl", None, "fromurl"),
         # Personal link / web-client / unknown form -> meeting_id is None
         ("https://zoom.us/s/personal-link", None, ""),
         ("https://zoom.us/wc/123/join", None, ""),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -411,3 +411,97 @@ def test_launch_zoommtg_url_rejects_substring_lookalike(
     with pytest.raises(utils_mod.UntrustedHostError):
         utils_mod.launch_zoommtg_url("zoommtg://my-zoom.us-domain.com/j/1")
     assert captured_launches == []
+
+
+# ---- #40: storage permissions hardening ---------------------------------
+
+
+def test_ensure_storage_creates_dir_with_0o700(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Closes #40: a fresh ~/.zoom-cli is owner-only."""
+    home = tmp_path / "fresh-zoom-cli"
+    save_file = home / "meetings.json"
+    monkeypatch.setattr(utils_mod, "ZOOM_CLI_DIR", str(home))
+    monkeypatch.setattr(utils_mod, "SAVE_FILE_PATH", str(save_file))
+
+    utils_mod._ensure_storage()
+
+    assert home.is_dir()
+    # Mask down to the permission bits we care about.
+    assert (home.stat().st_mode & 0o777) == 0o700
+
+
+def test_ensure_storage_creates_file_with_0o600(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "fresh-zoom-cli"
+    save_file = home / "meetings.json"
+    monkeypatch.setattr(utils_mod, "ZOOM_CLI_DIR", str(home))
+    monkeypatch.setattr(utils_mod, "SAVE_FILE_PATH", str(save_file))
+
+    utils_mod._ensure_storage()
+
+    assert save_file.exists()
+    assert (save_file.stat().st_mode & 0o777) == 0o600
+
+
+def test_ensure_storage_tightens_existing_permissive_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Existing ~/.zoom-cli created under a permissive umask gets tightened
+    on the next touch."""
+    home = tmp_path / "loose-zoom-cli"
+    home.mkdir(mode=0o755)  # group/world-readable — needs tightening
+    save_file = home / "meetings.json"
+    save_file.write_text("{}")
+    os.chmod(save_file, 0o644)
+
+    monkeypatch.setattr(utils_mod, "ZOOM_CLI_DIR", str(home))
+    monkeypatch.setattr(utils_mod, "SAVE_FILE_PATH", str(save_file))
+
+    utils_mod._ensure_storage()
+
+    assert (home.stat().st_mode & 0o777) == 0o700
+    assert (save_file.stat().st_mode & 0o777) == 0o600
+
+
+# ---- #39: meeting_file_transaction concurrency --------------------------
+
+
+def test_meeting_file_transaction_persists_changes(tmp_zoom_cli_home: Path) -> None:
+    with utils_mod.meeting_file_transaction() as contents:
+        contents["new"] = {"id": "1"}
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    assert on_disk == {"new": {"id": "1"}}
+
+
+def test_meeting_file_transaction_lock_serializes_concurrent_writes(
+    tmp_zoom_cli_home: Path,
+) -> None:
+    """Closes #39: two threads that each save a different meeting must both
+    end up persisted. Without the lock, the second writer's snapshot would
+    overwrite the first."""
+    import threading
+    import time
+
+    barrier = threading.Barrier(2)
+
+    def add_meeting(name: str, delay: float) -> None:
+        barrier.wait()  # both threads enter the transaction at the "same time"
+        with utils_mod.meeting_file_transaction() as contents:
+            # Simulate a slow read-modify-write window. With a real lock,
+            # the second thread blocks at the `with` until the first exits.
+            time.sleep(delay)
+            contents[name] = {"id": name}
+
+    t1 = threading.Thread(target=add_meeting, args=("alpha", 0.05))
+    t2 = threading.Thread(target=add_meeting, args=("beta", 0.0))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    assert "alpha" in on_disk
+    assert "beta" in on_disk

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -203,31 +204,48 @@ def test_strip_url_scheme_strips_zoommtg() -> None:
 # ---- atomic write_to_meeting_file ---------------------------------------
 
 
-def test_write_to_meeting_file_is_atomic_uses_replace(tmp_zoom_cli_home: Path) -> None:
-    """Verify the temp-then-replace flow happens — a tempfile must be written
-    in the same dir as the target, then renamed onto it."""
+def test_write_to_meeting_file_actually_calls_os_replace(
+    tmp_zoom_cli_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pin the atomic-write contract: ``os.replace`` must be the call that
+    swaps the new content into place. A future implementation that wrote
+    ``meetings.json`` directly would silently regress without this test.
+    """
+    captured: list[tuple[str, str]] = []
+    real_replace = utils_mod.os.replace
+
+    def tracking_replace(src: str, dst: str) -> None:
+        captured.append((str(src), str(dst)))
+        real_replace(src, dst)
+
+    monkeypatch.setattr(utils_mod.os, "replace", tracking_replace)
+
     payload = {"team": {"id": "1"}}
     utils_mod.write_to_meeting_file(payload)
 
-    target = tmp_zoom_cli_home / "meetings.json"
-    on_disk = json.loads(target.read_text())
+    assert len(captured) == 1, "os.replace must be called exactly once"
+    src, dst = captured[0]
+    assert dst == str(tmp_zoom_cli_home / "meetings.json")
+    # The src is a sibling tempfile, not the target itself.
+    assert src != dst
+    assert os.path.dirname(src) == os.path.dirname(dst)
+    assert os.path.basename(src).startswith(".meetings.")
+
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
     assert on_disk == payload
 
-    # No leftover tempfiles in the dir.
     leftovers = [p for p in tmp_zoom_cli_home.iterdir() if p.name != "meetings.json"]
     assert leftovers == [], f"unexpected leftover files: {leftovers}"
 
 
-def test_write_to_meeting_file_does_not_corrupt_on_error(
+def test_write_to_meeting_file_cleans_up_when_replace_fails(
     tmp_zoom_cli_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """If the write fails after the tempfile is created, the original
-    meetings.json must remain intact."""
-    # Seed a known good file.
+    """If ``os.replace`` raises, the original file must remain intact and
+    the tempfile must be cleaned up."""
     target = tmp_zoom_cli_home / "meetings.json"
     target.write_text('{"original": {"id": "999"}}')
 
-    # Make os.replace raise to simulate a mid-replace failure.
     def boom(*_args, **_kwargs):
         raise OSError("simulated replace failure")
 
@@ -236,16 +254,50 @@ def test_write_to_meeting_file_does_not_corrupt_on_error(
     with pytest.raises(OSError, match="simulated replace failure"):
         utils_mod.write_to_meeting_file({"new": {"id": "111"}})
 
-    # Original content must still be there.
     on_disk = json.loads(target.read_text())
     assert on_disk == {"original": {"id": "999"}}
 
-    # Tempfile must have been cleaned up.
+    leftovers = [p for p in tmp_zoom_cli_home.iterdir() if p.name != "meetings.json"]
+    assert leftovers == [], f"tempfile leak: {leftovers}"
+
+
+def test_write_to_meeting_file_cleans_up_when_fsync_fails(
+    tmp_zoom_cli_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If ``os.fsync`` (called inside the ``with os.fdopen(...)`` block)
+    raises, the cleanup branch must still delete the tempfile and the
+    original meetings.json must remain intact. Covers the asymmetric path
+    flagged in code review (codex + python-review on PR #27)."""
+    target = tmp_zoom_cli_home / "meetings.json"
+    target.write_text('{"original": {"id": "999"}}')
+
+    real_fsync = utils_mod.os.fsync
+
+    def boom_on_file_fsync(fd: int) -> None:
+        # Only blow up on the *file* fsync (after it's been opened for
+        # writing). Directory fsyncs (called later for durability) should
+        # still work.
+        raise OSError("simulated fsync failure")
+
+    monkeypatch.setattr(utils_mod.os, "fsync", boom_on_file_fsync)
+
+    with pytest.raises(OSError, match="simulated fsync failure"):
+        utils_mod.write_to_meeting_file({"new": {"id": "111"}})
+
+    # Restore for any subsequent fixtures
+    monkeypatch.setattr(utils_mod.os, "fsync", real_fsync)
+
+    on_disk = json.loads(target.read_text())
+    assert on_disk == {"original": {"id": "999"}}
+
     leftovers = [p for p in tmp_zoom_cli_home.iterdir() if p.name != "meetings.json"]
     assert leftovers == [], f"tempfile leak: {leftovers}"
 
 
 def test_write_to_meeting_file_round_trips_unicode(tmp_zoom_cli_home: Path) -> None:
+    """``json.dumps`` defaults to ``ensure_ascii=True``, so non-ASCII chars
+    are escaped to ``\\uXXXX`` on disk — but ``json.loads`` decodes them
+    back, so the round-trip is lossless."""
     payload = {"meeting-with-emoji-🚀": {"password": "p@ss-Ω"}}
     utils_mod.write_to_meeting_file(payload)
     on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -198,3 +198,55 @@ def test_strip_url_scheme_strips_https() -> None:
 
 def test_strip_url_scheme_strips_zoommtg() -> None:
     assert utils_mod.strip_url_scheme("zoommtg://zoom.us/j/2?pwd=xyz") == "zoom.us/j/2?pwd=xyz"
+
+
+# ---- atomic write_to_meeting_file ---------------------------------------
+
+
+def test_write_to_meeting_file_is_atomic_uses_replace(tmp_zoom_cli_home: Path) -> None:
+    """Verify the temp-then-replace flow happens — a tempfile must be written
+    in the same dir as the target, then renamed onto it."""
+    payload = {"team": {"id": "1"}}
+    utils_mod.write_to_meeting_file(payload)
+
+    target = tmp_zoom_cli_home / "meetings.json"
+    on_disk = json.loads(target.read_text())
+    assert on_disk == payload
+
+    # No leftover tempfiles in the dir.
+    leftovers = [p for p in tmp_zoom_cli_home.iterdir() if p.name != "meetings.json"]
+    assert leftovers == [], f"unexpected leftover files: {leftovers}"
+
+
+def test_write_to_meeting_file_does_not_corrupt_on_error(
+    tmp_zoom_cli_home: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the write fails after the tempfile is created, the original
+    meetings.json must remain intact."""
+    # Seed a known good file.
+    target = tmp_zoom_cli_home / "meetings.json"
+    target.write_text('{"original": {"id": "999"}}')
+
+    # Make os.replace raise to simulate a mid-replace failure.
+    def boom(*_args, **_kwargs):
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr(utils_mod.os, "replace", boom)
+
+    with pytest.raises(OSError, match="simulated replace failure"):
+        utils_mod.write_to_meeting_file({"new": {"id": "111"}})
+
+    # Original content must still be there.
+    on_disk = json.loads(target.read_text())
+    assert on_disk == {"original": {"id": "999"}}
+
+    # Tempfile must have been cleaned up.
+    leftovers = [p for p in tmp_zoom_cli_home.iterdir() if p.name != "meetings.json"]
+    assert leftovers == [], f"tempfile leak: {leftovers}"
+
+
+def test_write_to_meeting_file_round_trips_unicode(tmp_zoom_cli_home: Path) -> None:
+    payload = {"meeting-with-emoji-🚀": {"password": "p@ss-Ω"}}
+    utils_mod.write_to_meeting_file(payload)
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    assert on_disk == payload

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -137,3 +137,56 @@ def test_is_command_available_finds_known_command() -> None:
 
 def test_is_command_available_returns_false_for_garbage() -> None:
     assert utils_mod.is_command_available("definitely-not-a-real-command-zxcvbn") is False
+
+
+# ---- parse_meeting_url ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url,expected_id,expected_password",
+    [
+        # Standard meeting URLs
+        ("https://zoom.us/j/123456789", "123456789", ""),
+        ("https://zoom.us/j/123456789?pwd=abc", "123456789", "abc"),
+        ("https://us02web.zoom.us/j/987654321?pwd=xyz", "987654321", "xyz"),
+        # Subdomained / vanity hosts
+        ("https://example.zoom.us/j/111?pwd=p", "111", "p"),
+        # Trailing slash and extra path segments
+        ("https://zoom.us/j/222/", "222", ""),
+        ("https://zoom.us/j/333/extra-segment", "333", ""),
+        # URL fragment shouldn't confuse parsing
+        ("https://zoom.us/j/444?pwd=ok#frag", "444", "ok"),
+        # Percent-encoded password decodes cleanly
+        ("https://zoom.us/j/555?pwd=ab%23cd", "555", "ab#cd"),
+        ("https://zoom.us/j/666?pwd=hello%20world", "666", "hello world"),
+        # Multiple query params, pwd not first
+        ("https://zoom.us/j/777?tk=abc&pwd=secret&other=1", "777", "secret"),
+        # zoommtg:// scheme
+        ("zoommtg://zoom.us/j/888?pwd=zz", "888", "zz"),
+        # Personal link / web-client / unknown form -> meeting_id is None
+        ("https://zoom.us/s/personal-link", None, ""),
+        ("https://zoom.us/wc/123/join", None, ""),
+        ("https://zoom.us/", None, ""),
+        # Garbage
+        ("not a url", None, ""),
+        ("", None, ""),
+    ],
+)
+def test_parse_meeting_url_extracts_id_and_password(
+    url: str, expected_id: str | None, expected_password: str
+) -> None:
+    meeting_id, password = utils_mod.parse_meeting_url(url)
+    assert meeting_id == expected_id
+    assert password == expected_password
+
+
+def test_strip_url_scheme_preserves_url_without_scheme() -> None:
+    assert utils_mod.strip_url_scheme("zoom.us/j/1") == "zoom.us/j/1"
+
+
+def test_strip_url_scheme_strips_https() -> None:
+    assert utils_mod.strip_url_scheme("https://zoom.us/j/1?pwd=abc") == "zoom.us/j/1?pwd=abc"
+
+
+def test_strip_url_scheme_strips_zoommtg() -> None:
+    assert utils_mod.strip_url_scheme("zoommtg://zoom.us/j/2?pwd=xyz") == "zoom.us/j/2?pwd=xyz"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -117,13 +117,23 @@ def test_launch_zoommtg_url_does_not_shell_interpret_metacharacters(
 ) -> None:
     """Regression test for #4: shell metacharacters in user data must not be
     interpreted as shell syntax. Argv-list ``subprocess.run`` guarantees this.
+
+    As of #37, passwords are URL-encoded into the ``pwd=`` query parameter,
+    so the shell-injection security guarantee is satisfied two ways: argv-
+    list (no shell parsing) and percent-encoding (no URL injection). This
+    test pins both — the URL-decoded form of the ``pwd=`` parameter must
+    match the original password byte-for-byte.
     """
+    from urllib.parse import parse_qs, urlsplit
+
     utils_mod.launch_zoommtg("123", metacharacter_password)
     assert len(captured_launches) == 1
     argv = captured_launches[0]
     assert argv[0] == "open"
-    # The metacharacters must arrive verbatim in argv[1] — never expanded.
-    assert metacharacter_password in argv[1]
+    # Decoded password round-trips: percent-decoding the pwd= query value
+    # must yield exactly the original (no shell expansion either way).
+    pwd_values = parse_qs(urlsplit(argv[1]).query).get("pwd", [])
+    assert pwd_values == [metacharacter_password]
 
 
 def test_console_color_constants_are_strings() -> None:
@@ -302,3 +312,102 @@ def test_write_to_meeting_file_round_trips_unicode(tmp_zoom_cli_home: Path) -> N
     utils_mod.write_to_meeting_file(payload)
     on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
     assert on_disk == payload
+
+
+# ---- #44: delimiter-heavy password coverage ------------------------------
+
+
+@pytest.mark.parametrize(
+    "delimiter_password",
+    [
+        "a&b",
+        "a=b",
+        "a#b",
+        "a+b",
+        "a?b",
+        "hello world",
+        "100%done",
+        "a&b=c#d+e?f g%h",  # everything at once
+        "with'quote",
+        'with"quote',
+        "back\\slash",
+    ],
+)
+def test_launch_zoommtg_url_round_trips_delimiter_password(
+    captured_launches: list[list[str]], delimiter_password: str
+) -> None:
+    """Closes #44, verifies #37 fix: passwords containing URL delimiters
+    round-trip cleanly through the zoommtg:// query string. Before the
+    URL-encoding fix, a `pwd=a&b=c#d` would be parsed as multiple query
+    parameters and a fragment by Zoom's client."""
+    from urllib.parse import parse_qs, urlsplit
+
+    utils_mod.launch_zoommtg("123", delimiter_password)
+    assert len(captured_launches) == 1
+    argv = captured_launches[0]
+    assert argv[0] == "open"
+    pwd_values = parse_qs(urlsplit(argv[1]).query).get("pwd", [])
+    assert pwd_values == [delimiter_password], (
+        f"pwd round-trip failed for {delimiter_password!r}: got {pwd_values!r} from URL {argv[1]!r}"
+    )
+
+
+# ---- #38: trusted Zoom domain allowlist ----------------------------------
+
+
+@pytest.mark.parametrize(
+    "host,trusted",
+    [
+        ("zoom.us", True),
+        ("us02web.zoom.us", True),
+        ("example.zoom.us", True),
+        ("zoomgov.com", True),
+        ("us02.zoomgov.com", True),
+        ("ZOOM.US", True),  # case-insensitive
+        ("", False),
+        ("evil.example.com", False),
+        ("my-zoom.us-domain.com", False),  # substring, not subdomain
+        ("zoom.us.evil.com", False),  # zoom.us is not a suffix domain
+        ("notzoom.us", False),
+    ],
+)
+def test_is_trusted_zoom_host(host: str, trusted: bool) -> None:
+    assert utils_mod.is_trusted_zoom_host(host) is trusted
+
+
+@pytest.mark.parametrize(
+    "url,trusted",
+    [
+        ("https://zoom.us/j/123", True),
+        ("https://us02web.zoom.us/j/123?pwd=abc", True),
+        ("zoommtg://zoom.us/join?confno=1", True),
+        ("zoom.us/j/123", True),  # no scheme
+        ("us02web.zoom.us/j/123", True),
+        ("https://zoomgov.com/j/123", True),
+        ("https://evil.example/zoom.us/j/1", False),
+        ("https://my-zoom.us-domain.com/j/1", False),
+        ("not-a-url", False),
+        ("", False),
+    ],
+)
+def test_looks_like_zoom_url(url: str, trusted: bool) -> None:
+    assert utils_mod.looks_like_zoom_url(url) is trusted
+
+
+def test_launch_zoommtg_url_rejects_untrusted_host(
+    captured_launches: list[list[str]],
+) -> None:
+    """Closes #38: an untrusted host must never reach the launcher."""
+    with pytest.raises(utils_mod.UntrustedHostError):
+        utils_mod.launch_zoommtg_url("zoommtg://evil.example/j/1?pwd=p")
+    assert captured_launches == []
+
+
+def test_launch_zoommtg_url_rejects_substring_lookalike(
+    captured_launches: list[list[str]],
+) -> None:
+    """The old ``\"zoom.us\" in url_or_name`` substring check would have
+    accepted this; the new allowlist-based check rejects it."""
+    with pytest.raises(utils_mod.UntrustedHostError):
+        utils_mod.launch_zoommtg_url("zoommtg://my-zoom.us-domain.com/j/1")
+    assert captured_launches == []

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -1,3 +1,5 @@
+import os
+
 import click
 import httpx
 import questionary
@@ -160,15 +162,33 @@ def s2s():
     """Group for ``zoom auth s2s ...``."""
 
 
-@s2s.command("set", help="Save Server-to-Server OAuth credentials to the OS keyring.")
-@click.option("--account-id", default="", help="Zoom Account ID")
-@click.option("--client-id", default="", help="Server-to-Server OAuth Client ID")
-@click.option("--client-secret", default="", help="Server-to-Server OAuth Client Secret")
-def s2s_set(account_id, client_id, client_secret):
+@s2s.command(
+    "set",
+    help=(
+        "Save Server-to-Server OAuth credentials to the OS keyring. "
+        "The client secret is read from the ZOOM_CLIENT_SECRET env var or, "
+        "if unset, prompted interactively (masked). It is intentionally NOT "
+        "accepted as a command-line flag (closes #34)."
+    ),
+)
+@click.option("--account-id", default="", envvar="ZOOM_ACCOUNT_ID", help="Zoom Account ID")
+@click.option(
+    "--client-id",
+    default="",
+    envvar="ZOOM_CLIENT_ID",
+    help="Server-to-Server OAuth Client ID",
+)
+def s2s_set(account_id, client_id):
     if not account_id:
         account_id = _ask_or_abort(questionary.text("Account ID:"))
     if not client_id:
         client_id = _ask_or_abort(questionary.text("Client ID:"))
+
+    # Client secret is intentionally NOT a CLI flag — values in argv land in
+    # shell history and are visible via `ps`/proc to other users on the host
+    # for the lifetime of the command. Accept via masked prompt or the
+    # ZOOM_CLIENT_SECRET env var only. Closes #34.
+    client_secret = os.environ.get("ZOOM_CLIENT_SECRET", "")
     if not client_secret:
         # questionary.password() masks the input on screen. The default
         # text() prompt would echo the secret to the terminal.

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -1,7 +1,9 @@
+import functools
 import os
 
 import click
 import httpx
+import keyring.errors
 import questionary
 from click_default_group import DefaultGroup
 
@@ -33,6 +35,48 @@ def _ask_or_abort(question):
     if answer is None:
         raise click.Abort
     return answer
+
+
+# ---- error translation -----------------------------------------------------
+#
+# Closes #41 / #43: keyring failures should surface as actionable CLI
+# errors, not Python tracebacks. We split the error space three ways so the
+# user knows what to do:
+#
+#   - NoKeyringError / InitError → no backend at all (exit 2).
+#     Action: install/configure a keyring backend.
+#   - Other KeyringError → backend present but refused (exit 3).
+#     Action: unlock the keychain.
+#   - Anything else → propagates normally.
+#
+# Decorator order in command stacks: place ``@_translate_keyring_errors``
+# closest to ``def`` so it wraps the bare function. Click options decorate
+# the wrapper next, then ``@s2s.command`` registers the wrapped command.
+
+
+def _translate_keyring_errors(func):
+    """Map keyring exceptions to friendly CLI exits with distinct codes."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except (keyring.errors.NoKeyringError, keyring.errors.InitError) as exc:
+            click.echo(
+                f"OS keyring backend not available: {exc}\n"
+                "Install or configure a keyring backend before retrying.",
+                err=True,
+            )
+            raise click.exceptions.Exit(code=2) from exc
+        except keyring.errors.KeyringError as exc:
+            click.echo(
+                f"OS keyring error (the backend may be locked): {exc}\n"
+                "Unlock your keychain and retry.",
+                err=True,
+            )
+            raise click.exceptions.Exit(code=3) from exc
+
+    return wrapper
 
 
 @click.group(cls=DefaultGroup, default="launch", default_if_no_args=True)
@@ -185,6 +229,7 @@ def s2s():
     envvar="ZOOM_CLIENT_ID",
     help="Server-to-Server OAuth Client ID",
 )
+@_translate_keyring_errors
 def s2s_set(account_id, client_id):
     if not account_id:
         account_id = _ask_or_abort(questionary.text("Account ID:"))
@@ -215,6 +260,7 @@ def s2s_set(account_id, client_id):
     "test",
     help="Verify saved Server-to-Server OAuth credentials by exchanging them for a token.",
 )
+@_translate_keyring_errors
 def s2s_test():
     creds = auth.load_s2s_credentials()
     if creds is None:
@@ -252,6 +298,14 @@ def _now():
 
 @auth_cmd.command(help="Show which authentication mode is configured.")
 def status():
+    """``status`` deliberately does NOT use ``@_translate_keyring_errors``.
+
+    ``has_s2s_credentials`` swallows backend-missing errors itself and
+    reports "not configured", which is the right UX for a probe-style
+    command — you don't want a 'check status' to crash the script. Users
+    debugging a missing backend should run ``zoom auth s2s test`` (which
+    surfaces the backend error).
+    """
     if auth.has_s2s_credentials():
         click.echo("Server-to-Server OAuth: configured")
     else:
@@ -260,6 +314,7 @@ def status():
 
 
 @auth_cmd.command(help="Clear all stored API authentication credentials.")
+@_translate_keyring_errors
 def logout():
     auth.clear_s2s_credentials()
     click.echo("Cleared Server-to-Server OAuth credentials.")
@@ -274,6 +329,7 @@ def users_cmd():
 
 
 @users_cmd.command("me", help="Print the authenticated user's profile (GET /users/me).")
+@_translate_keyring_errors
 def users_me():
     creds = auth.load_s2s_credentials()
     if creds is None:

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -97,13 +97,39 @@ def edit(name, url, id, password):
 
 @main.command(help="Delete meeting")
 @click.argument("name", required=False)
-def rm(name):
-    if not name:
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Show what would be deleted without modifying meetings.json.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt that fires when the name is picked interactively.",
+)
+def rm(name, dry_run, yes):
+    name_was_picked_interactively = not name
+    if name_was_picked_interactively:
         choices = get_meeting_names()
         if not choices:
             click.echo("No saved meetings to remove.")
             return
         name = _ask_or_abort(questionary.select("Meeting name:", choices=choices))
+
+    if dry_run:
+        click.echo(f"[dry-run] Would remove meeting: {name}")
+        return
+
+    # Only confirm if the name came from the interactive selector — a positional
+    # `zoom rm <name>` is already a deliberate choice, and adding a prompt would
+    # break existing scripts and aliases.
+    needs_confirm = name_was_picked_interactively and not yes
+    if needs_confirm and not click.confirm(f"Remove meeting '{name}'?", default=False):
+        click.echo("Aborted.")
+        return
 
     _remove(name)
 

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -17,7 +17,7 @@ from zoom_cli.commands import (
     _save_id_password,
     _save_url,
 )
-from zoom_cli.utils import __version__, get_meeting_names
+from zoom_cli.utils import __version__, get_meeting_names, looks_like_zoom_url
 
 
 def _ask_or_abort(question):
@@ -44,7 +44,14 @@ def main():
 @main.command(help="Launch meeting [url or saved meeting name]")
 @click.argument("url_or_name")
 def launch(url_or_name):
-    if "://" in url_or_name or "zoom.us" in url_or_name:
+    # Distinguish URL from saved-meeting-name by checking the host, not by
+    # substring match against "zoom.us" — the substring trick mis-routed
+    # deceptive inputs like "https://evil.example/zoom.us/j/1". Closes #38.
+    has_scheme = "://" in url_or_name
+    if has_scheme and not looks_like_zoom_url(url_or_name):
+        click.echo(f"Refusing to launch URL with untrusted host: {url_or_name}", err=True)
+        raise click.exceptions.Exit(code=1)
+    if has_scheme or looks_like_zoom_url(url_or_name):
         _launch_url(url_or_name)
     else:
         _launch_name(url_or_name)

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -1,8 +1,10 @@
 import click
+import httpx
 import questionary
 from click_default_group import DefaultGroup
 
 from zoom_cli import auth
+from zoom_cli.api import oauth
 from zoom_cli.commands import (
     _edit,
     _launch_name,
@@ -179,6 +181,45 @@ def s2s_set(account_id, client_id, client_secret):
         )
     )
     click.echo("Server-to-Server OAuth credentials saved.")
+
+
+@s2s.command(
+    "test",
+    help="Verify saved Server-to-Server OAuth credentials by exchanging them for a token.",
+)
+def s2s_test():
+    creds = auth.load_s2s_credentials()
+    if creds is None:
+        click.echo("No Server-to-Server OAuth credentials saved. Run `zoom auth s2s set` first.")
+        raise click.exceptions.Exit(code=1)
+
+    try:
+        token = oauth.fetch_access_token(creds)
+    except oauth.ZoomAuthError as exc:
+        message = str(exc) or "(no message)"
+        if exc.status_code is not None:
+            click.echo(f"Authentication failed (HTTP {exc.status_code}): {message}")
+        else:
+            click.echo(f"Authentication failed: {message}")
+        raise click.exceptions.Exit(code=1) from exc
+    except httpx.HTTPError as exc:
+        # Network / TLS / timeout — the request never got an HTTP response
+        # we can interpret. Distinguish from auth failures so the user
+        # knows whether to check creds or check connectivity.
+        click.echo(f"Could not reach Zoom OAuth endpoint: {exc}")
+        raise click.exceptions.Exit(code=1) from exc
+
+    minutes = max(int((token.expires_at - _now()).total_seconds() // 60), 0)
+    click.echo(f"OK — Server-to-Server OAuth credentials valid (token expires in {minutes}m).")
+    if token.scopes:
+        click.echo(f"Scopes: {' '.join(token.scopes)}")
+
+
+def _now():
+    """Indirection for ``datetime.now`` so tests can monkeypatch it cleanly."""
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc)
 
 
 @auth_cmd.command(help="Show which authentication mode is configured.")

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -2,6 +2,7 @@ import click
 import questionary
 from click_default_group import DefaultGroup
 
+from zoom_cli import auth
 from zoom_cli.commands import (
     _edit,
     _launch_name,
@@ -137,6 +138,62 @@ def rm(name, dry_run, yes):
 @main.command(help="List all saved meetings")
 def ls():
     _ls()
+
+
+# ---- API authentication ---------------------------------------------------
+
+
+@main.group("auth", help="Manage Zoom API authentication.")
+def auth_cmd():
+    """Top-level group for ``zoom auth ...``.
+
+    Function name has the ``_cmd`` suffix to avoid shadowing the ``auth``
+    module imported above; Click registers it under the bare name ``auth``.
+    """
+
+
+@auth_cmd.group("s2s", help="Server-to-Server OAuth credential management.")
+def s2s():
+    """Group for ``zoom auth s2s ...``."""
+
+
+@s2s.command("set", help="Save Server-to-Server OAuth credentials to the OS keyring.")
+@click.option("--account-id", default="", help="Zoom Account ID")
+@click.option("--client-id", default="", help="Server-to-Server OAuth Client ID")
+@click.option("--client-secret", default="", help="Server-to-Server OAuth Client Secret")
+def s2s_set(account_id, client_id, client_secret):
+    if not account_id:
+        account_id = _ask_or_abort(questionary.text("Account ID:"))
+    if not client_id:
+        client_id = _ask_or_abort(questionary.text("Client ID:"))
+    if not client_secret:
+        # questionary.password() masks the input on screen. The default
+        # text() prompt would echo the secret to the terminal.
+        client_secret = _ask_or_abort(questionary.password("Client Secret:"))
+
+    auth.save_s2s_credentials(
+        auth.S2SCredentials(
+            account_id=account_id,
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+    )
+    click.echo("Server-to-Server OAuth credentials saved.")
+
+
+@auth_cmd.command(help="Show which authentication mode is configured.")
+def status():
+    if auth.has_s2s_credentials():
+        click.echo("Server-to-Server OAuth: configured")
+    else:
+        click.echo("Server-to-Server OAuth: not configured")
+        click.echo("Run `zoom auth s2s set` to configure.")
+
+
+@auth_cmd.command(help="Clear all stored API authentication credentials.")
+def logout():
+    auth.clear_s2s_credentials()
+    click.echo("Cleared Server-to-Server OAuth credentials.")
 
 
 if __name__ == "__main__":

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -4,7 +4,8 @@ import questionary
 from click_default_group import DefaultGroup
 
 from zoom_cli import auth
-from zoom_cli.api import oauth
+from zoom_cli.api import oauth, users
+from zoom_cli.api.client import ApiClient, ZoomApiError
 from zoom_cli.commands import (
     _edit,
     _launch_name,
@@ -235,6 +236,42 @@ def status():
 def logout():
     auth.clear_s2s_credentials()
     click.echo("Cleared Server-to-Server OAuth credentials.")
+
+
+# ---- Zoom Users REST API -------------------------------------------------
+
+
+@main.group("users", help="Zoom Users API (https://developers.zoom.us/docs/api/users/).")
+def users_cmd():
+    """Group for ``zoom users ...``."""
+
+
+@users_cmd.command("me", help="Print the authenticated user's profile (GET /users/me).")
+def users_me():
+    creds = auth.load_s2s_credentials()
+    if creds is None:
+        click.echo("No Server-to-Server OAuth credentials saved. Run `zoom auth s2s set` first.")
+        raise click.exceptions.Exit(code=1)
+
+    try:
+        with ApiClient(creds) as client:
+            profile = users.get_me(client)
+    except oauth.ZoomAuthError as exc:
+        click.echo(f"Authentication failed (HTTP {exc.status_code}): {exc}")
+        raise click.exceptions.Exit(code=1) from exc
+    except ZoomApiError as exc:
+        click.echo(f"Zoom API error (HTTP {exc.status_code}): {exc}")
+        raise click.exceptions.Exit(code=1) from exc
+    except httpx.HTTPError as exc:
+        click.echo(f"Could not reach Zoom API: {exc}")
+        raise click.exceptions.Exit(code=1) from exc
+
+    # Print a few well-known fields. The full payload is many dozen
+    # fields; users who want all of them can pipe the underlying call
+    # through `jq` once we add `--json` (out of scope for this PR).
+    for field in ("display_name", "email", "id", "account_id", "type", "status"):
+        if field in profile:
+            click.echo(f"{field}: {profile[field]}")
 
 
 if __name__ == "__main__":

--- a/zoom_cli/api/__init__.py
+++ b/zoom_cli/api/__init__.py
@@ -1,0 +1,6 @@
+"""Zoom REST API client surface.
+
+Each module in this package targets a specific area of the Zoom API
+(``oauth`` here, with ``meetings``, ``users``, ``recordings``, etc. to
+follow). Importing this package by itself does not perform any I/O.
+"""

--- a/zoom_cli/api/client.py
+++ b/zoom_cli/api/client.py
@@ -1,0 +1,145 @@
+"""Authenticated HTTP client for the Zoom REST API.
+
+This module exposes :class:`ApiClient`, a thin wrapper over ``httpx.Client``
+that adds:
+
+- automatic bearer-token injection on every request,
+- an in-memory access-token cache (Zoom tokens live for 1 hour and there's
+  no value in persisting them — they're cheaper to re-fetch than to keep
+  in a keyring),
+- a :class:`ZoomApiError` raised on non-2xx responses with the parsed
+  Zoom error envelope (``{"code": ..., "message": ...}``).
+
+Out of scope here, deliberately:
+
+- Per-tier rate-limit handling and 429 retry — that's issue #16. The
+  shape of the client is stable enough that adding a token-bucket
+  decorator later will be additive.
+- Pagination helpers — folded into issue #16 alongside the limiter.
+- 401-driven force-refresh — happy path is enough for the first round
+  of API endpoints.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from zoom_cli.api import oauth
+from zoom_cli.auth import S2SCredentials
+
+#: Zoom REST API base URL. All paths are relative to this.
+API_BASE_URL = "https://api.zoom.us/v2"
+
+#: Default request timeout in seconds. Higher than the OAuth timeout
+#: because some endpoints (recordings list, dashboards) are slower.
+DEFAULT_TIMEOUT_SECONDS = 30.0
+
+
+class ZoomApiError(RuntimeError):
+    """A non-2xx response from a Zoom REST API endpoint.
+
+    Distinct from :class:`oauth.ZoomAuthError` so callers can tell a
+    bad-credentials problem from a genuine API error.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int,
+        code: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.code = code
+
+
+class ApiClient:
+    """Authenticated client for ``api.zoom.us``.
+
+    Construct once per CLI invocation (or once per long-running process)
+    and pass into the per-resource helper modules (``users.py``, etc.).
+    The client owns its underlying ``httpx.Client``; use as a context
+    manager to ensure connections are closed.
+    """
+
+    def __init__(
+        self,
+        credentials: S2SCredentials,
+        *,
+        http_client: httpx.Client | None = None,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self._credentials = credentials
+        self._owns_client = http_client is None
+        self._http = http_client if http_client is not None else httpx.Client(timeout=timeout)
+        self._cached_token: oauth.AccessToken | None = None
+
+    # ---- context-manager hooks ---------------------------------------
+
+    def __enter__(self) -> ApiClient:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._http.close()
+
+    # ---- token lifecycle ---------------------------------------------
+
+    def _access_token(self) -> oauth.AccessToken:
+        """Return a usable access token, fetching a new one if needed.
+
+        We re-use the cached token while it's still valid. Since Zoom
+        tokens are 1-hour bearers, almost every CLI invocation gets a
+        single token. Long-running callers (a future ``zoom watch``)
+        will hit the refresh path naturally.
+        """
+        if self._cached_token is None or self._cached_token.is_expired:
+            self._cached_token = oauth.fetch_access_token(self._credentials, client=self._http)
+        return self._cached_token
+
+    # ---- HTTP --------------------------------------------------------
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Issue an authenticated request and return the parsed JSON body.
+
+        Raises :class:`ZoomApiError` for any non-2xx response.
+        """
+        token = self._access_token()
+        url = f"{API_BASE_URL}{path}" if path.startswith("/") else f"{API_BASE_URL}/{path}"
+        response = self._http.request(
+            method,
+            url,
+            params=params,
+            json=json,
+            headers={"Authorization": f"Bearer {token.value}"},
+        )
+        if response.status_code >= 400:
+            try:
+                payload = response.json()
+            except ValueError:
+                payload = {}
+            raise ZoomApiError(
+                payload.get("message") or response.text,
+                status_code=response.status_code,
+                code=payload.get("code"),
+            )
+        if not response.content:
+            return {}
+        return response.json()
+
+    def get(self, path: str, *, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Convenience wrapper for ``GET``."""
+        return self.request("GET", path, params=params)

--- a/zoom_cli/api/client.py
+++ b/zoom_cli/api/client.py
@@ -6,7 +6,12 @@ that adds:
 - automatic bearer-token injection on every request,
 - an in-memory access-token cache (Zoom tokens live for 1 hour and there's
   no value in persisting them — they're cheaper to re-fetch than to keep
-  in a keyring),
+  in a keyring); cache uses a 60s expiry skew (see
+  :data:`oauth.EXPIRY_SKEW_SECONDS`) so we don't send requests with
+  about-to-expire tokens,
+- a single-shot 401 retry that force-refreshes the token and re-issues the
+  request once (closes #47, partial) — covers the "Zoom revoked the token
+  before our clock said it expired" race,
 - a :class:`ZoomApiError` raised on non-2xx responses with the parsed
   Zoom error envelope (``{"code": ..., "message": ...}``).
 
@@ -16,8 +21,6 @@ Out of scope here, deliberately:
   shape of the client is stable enough that adding a token-bucket
   decorator later will be additive.
 - Pagination helpers — folded into issue #16 alongside the limiter.
-- 401-driven force-refresh — happy path is enough for the first round
-  of API endpoints.
 """
 
 from __future__ import annotations
@@ -91,19 +94,43 @@ class ApiClient:
 
     # ---- token lifecycle ---------------------------------------------
 
-    def _access_token(self) -> oauth.AccessToken:
+    def _access_token(self, *, force_refresh: bool = False) -> oauth.AccessToken:
         """Return a usable access token, fetching a new one if needed.
 
-        We re-use the cached token while it's still valid. Since Zoom
-        tokens are 1-hour bearers, almost every CLI invocation gets a
-        single token. Long-running callers (a future ``zoom watch``)
-        will hit the refresh path naturally.
+        We re-use the cached token while it's still valid (with a 60s
+        expiry skew — see :data:`oauth.EXPIRY_SKEW_SECONDS`). Long-running
+        callers (a future ``zoom watch``) will hit the refresh path
+        naturally as the token approaches expiry.
+
+        ``force_refresh=True`` is used by the 401 retry path: even if the
+        cached token *thinks* it's still valid, the server has told us
+        otherwise, so we drop the cache and re-fetch.
         """
+        if force_refresh:
+            self._cached_token = None
         if self._cached_token is None or self._cached_token.is_expired:
             self._cached_token = oauth.fetch_access_token(self._credentials, client=self._http)
         return self._cached_token
 
     # ---- HTTP --------------------------------------------------------
+
+    def _send(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: dict[str, Any] | None,
+        json: dict[str, Any] | None,
+        force_refresh: bool = False,
+    ) -> httpx.Response:
+        token = self._access_token(force_refresh=force_refresh)
+        return self._http.request(
+            method,
+            url,
+            params=params,
+            json=json,
+            headers={"Authorization": f"Bearer {token.value}"},
+        )
 
     def request(
         self,
@@ -115,17 +142,17 @@ class ApiClient:
     ) -> dict[str, Any]:
         """Issue an authenticated request and return the parsed JSON body.
 
+        On a 401, force-refresh the token and retry once (closes #47,
+        partial) — covers the case where Zoom revoked the token before
+        our local clock said it expired (rotation, scope change). A second
+        401 propagates as :class:`ZoomApiError` so we never loop.
+
         Raises :class:`ZoomApiError` for any non-2xx response.
         """
-        token = self._access_token()
         url = f"{API_BASE_URL}{path}" if path.startswith("/") else f"{API_BASE_URL}/{path}"
-        response = self._http.request(
-            method,
-            url,
-            params=params,
-            json=json,
-            headers={"Authorization": f"Bearer {token.value}"},
-        )
+        response = self._send(method, url, params=params, json=json)
+        if response.status_code == 401:
+            response = self._send(method, url, params=params, json=json, force_refresh=True)
         if response.status_code >= 400:
             try:
                 payload = response.json()

--- a/zoom_cli/api/client.py
+++ b/zoom_cli/api/client.py
@@ -138,7 +138,18 @@ class ApiClient:
             )
         if not response.content:
             return {}
-        return response.json()
+        # Closes #42: a 2xx body that isn't JSON used to leak raw ValueError.
+        # Translate to ZoomApiError so callers always see the same typed
+        # exception envelope regardless of which side of the proxy chain
+        # corrupted the response.
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise ZoomApiError(
+                "Zoom API returned 2xx with non-JSON body "
+                f"(content-type={response.headers.get('content-type', 'unknown')})",
+                status_code=response.status_code,
+            ) from exc
 
     def get(self, path: str, *, params: dict[str, Any] | None = None) -> dict[str, Any]:
         """Convenience wrapper for ``GET``."""

--- a/zoom_cli/api/oauth.py
+++ b/zoom_cli/api/oauth.py
@@ -1,0 +1,149 @@
+"""Server-to-Server OAuth token exchange against Zoom.
+
+Reference: https://developers.zoom.us/docs/internal-apps/s2s-oauth/
+
+The Zoom token endpoint expects:
+    POST https://zoom.us/oauth/token?grant_type=account_credentials&account_id=...
+    Authorization: Basic <base64(client_id:client_secret)>
+
+On 2xx it responds with::
+
+    {
+      "access_token": "<JWT>",
+      "token_type": "bearer",
+      "expires_in": 3600,
+      "scope": "user:read:user ..."
+    }
+
+On 4xx it responds with::
+
+    {"reason": "Invalid client_id or client_secret", "error": "invalid_client"}
+
+We surface that as a ``ZoomAuthError`` with the parsed fields so the CLI
+can print a useful message rather than a stack trace.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+import httpx
+
+from zoom_cli.auth import S2SCredentials
+
+#: Zoom's public OAuth token endpoint. Hard-coded — different from the
+#: API base URL because OAuth lives on ``zoom.us``, not ``api.zoom.us``.
+TOKEN_URL = "https://zoom.us/oauth/token"  # noqa: S105 - public endpoint URL, not a password
+
+#: Default timeout for the token round-trip. Slightly more generous than
+#: the typical 5s ceiling because corporate proxies + first-cold-DNS can
+#: legitimately spike up to ~10s.
+DEFAULT_TIMEOUT_SECONDS = 15.0
+
+
+@dataclass(frozen=True)
+class AccessToken:
+    """A short-lived bearer token returned by the token endpoint.
+
+    ``expires_at`` is an absolute timezone-aware UTC ``datetime`` rather
+    than the relative ``expires_in`` we get from Zoom — saves every
+    caller from re-doing the math and avoids drift if the token is held
+    in a cache. ``scopes`` is the parsed ``scope`` string Zoom returns;
+    we preserve it for ``zoom auth s2s test`` to display.
+    """
+
+    value: str
+    expires_at: datetime
+    scopes: tuple[str, ...]
+
+    @property
+    def is_expired(self) -> bool:
+        return datetime.now(timezone.utc) >= self.expires_at
+
+
+class ZoomAuthError(RuntimeError):
+    """The token endpoint refused the credentials.
+
+    Carries the HTTP status, Zoom's machine-readable ``error`` code (e.g.
+    ``invalid_client``), and the human-readable ``reason`` so callers
+    can decide how to surface each one.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        error_code: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.error_code = error_code
+
+
+def fetch_access_token(
+    creds: S2SCredentials,
+    *,
+    client: httpx.Client | None = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> AccessToken:
+    """Exchange Server-to-Server OAuth credentials for a 1-hour bearer token.
+
+    The optional ``client`` parameter exists so tests can inject a
+    pre-configured ``httpx.Client`` (typically wrapped around a
+    ``httpx.MockTransport``). Production callers can leave it ``None``.
+
+    Raises:
+        ZoomAuthError: the token endpoint responded with a non-2xx status,
+            or returned a 2xx body without a usable ``access_token``.
+        httpx.HTTPError: the request never reached the endpoint
+            (DNS, TCP, TLS, or timeout failure). Callers in the CLI
+            translate this into a friendly "couldn't reach api.zoom.us"
+            message; lower layers can reason about the typed exception.
+    """
+    owns_client = client is None
+    if client is None:
+        client = httpx.Client(timeout=timeout)
+
+    try:
+        response = client.post(
+            TOKEN_URL,
+            params={
+                "grant_type": "account_credentials",
+                "account_id": creds.account_id,
+            },
+            auth=(creds.client_id, creds.client_secret),
+        )
+    finally:
+        if owns_client:
+            client.close()
+
+    if response.status_code >= 400:
+        # Zoom's error body is a small JSON dict. If the body isn't JSON
+        # (proxy returning HTML, etc.) we still surface a useful message.
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = {}
+        raise ZoomAuthError(
+            payload.get("reason") or payload.get("error_description") or response.text,
+            status_code=response.status_code,
+            error_code=payload.get("error"),
+        )
+
+    payload = response.json()
+    token_value = payload.get("access_token")
+    if not token_value:
+        raise ZoomAuthError(
+            "Token endpoint returned 2xx but no access_token field",
+            status_code=response.status_code,
+        )
+
+    expires_in = int(payload.get("expires_in", 3600))
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+
+    scopes_str = payload.get("scope", "")
+    scopes = tuple(scopes_str.split()) if scopes_str else ()
+
+    return AccessToken(value=token_value, expires_at=expires_at, scopes=scopes)

--- a/zoom_cli/api/oauth.py
+++ b/zoom_cli/api/oauth.py
@@ -132,7 +132,20 @@ def fetch_access_token(
             error_code=payload.get("error"),
         )
 
-    payload = response.json()
+    # Closes #42: a 2xx body that isn't JSON (corporate proxy returning HTML,
+    # captive portal, intermediate cache returning empty) used to leak raw
+    # ValueError. Translate to ZoomAuthError so callers see the same typed
+    # exception they'd see for an auth refusal — different status, same
+    # error class, easier to handle uniformly.
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise ZoomAuthError(
+            "Token endpoint returned 2xx with non-JSON body "
+            f"(content-type={response.headers.get('content-type', 'unknown')})",
+            status_code=response.status_code,
+        ) from exc
+
     token_value = payload.get("access_token")
     if not token_value:
         raise ZoomAuthError(

--- a/zoom_cli/api/oauth.py
+++ b/zoom_cli/api/oauth.py
@@ -41,6 +41,13 @@ TOKEN_URL = "https://zoom.us/oauth/token"  # noqa: S105 - public endpoint URL, n
 #: legitimately spike up to ~10s.
 DEFAULT_TIMEOUT_SECONDS = 15.0
 
+#: Safety margin on token expiry checks (closes #47, partial). Without a
+#: skew, a token issued at t=0 is considered valid until t=3600 — but if we
+#: send a request at t=3599.5 the server may have already revoked it. 60s
+#: matches the typical clock-skew tolerance and is short enough that we
+#: still get nearly the full 1-hour token lifetime.
+EXPIRY_SKEW_SECONDS = 60
+
 
 @dataclass(frozen=True)
 class AccessToken:
@@ -59,7 +66,11 @@ class AccessToken:
 
     @property
     def is_expired(self) -> bool:
-        return datetime.now(timezone.utc) >= self.expires_at
+        """True if the token has expired or is within
+        :data:`EXPIRY_SKEW_SECONDS` of expiry. Closes #47 (partial)."""
+        return datetime.now(timezone.utc) >= self.expires_at - timedelta(
+            seconds=EXPIRY_SKEW_SECONDS
+        )
 
 
 class ZoomAuthError(RuntimeError):

--- a/zoom_cli/api/users.py
+++ b/zoom_cli/api/users.py
@@ -1,0 +1,27 @@
+"""Zoom Users API helpers.
+
+Reference: https://developers.zoom.us/docs/api/users/
+
+This module is intentionally thin — each function maps to one Zoom
+endpoint and returns the raw JSON envelope. We don't wrap responses in
+typed dataclasses yet because:
+
+1. The CLI surface is the only consumer right now and it just prints
+   selected fields. Boxing into a dataclass adds no value at this stage.
+2. A future codegen pass against the OpenAPI spec (issue #22) will
+   produce proper types — handwriting them now would just be churn.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from zoom_cli.api.client import ApiClient
+
+
+def get_me(client: ApiClient) -> dict[str, Any]:
+    """``GET /users/me`` — return the authenticated user's profile.
+
+    Required scopes: ``user:read:user`` (or any scope that includes it).
+    """
+    return client.get("/users/me")

--- a/zoom_cli/api/users.py
+++ b/zoom_cli/api/users.py
@@ -10,18 +10,44 @@ typed dataclasses yet because:
    selected fields. Boxing into a dataclass adds no value at this stage.
 2. A future codegen pass against the OpenAPI spec (issue #22) will
    produce proper types — handwriting them now would just be churn.
+
+API shape:
+    :func:`get_user` is the durable helper, taking a ``user_id`` (default
+    ``"me"`` — the authenticated principal). :func:`get_me` is a thin
+    alias kept for the CLI ``zoom users me`` command (closes #36 — Codex
+    #14 flagged that hardcoding the implicit "me" principal would make
+    later target-user commands awkward).
+
+Out of scope here, deferred to issue #14:
+- ``GET /users`` listing with pagination.
+- ``--json`` flag for raw output.
 """
 
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import quote
 
 from zoom_cli.api.client import ApiClient
 
 
-def get_me(client: ApiClient) -> dict[str, Any]:
-    """``GET /users/me`` — return the authenticated user's profile.
+def get_user(client: ApiClient, user_id: str = "me") -> dict[str, Any]:
+    """``GET /users/{user_id}`` — return the requested user's profile.
 
-    Required scopes: ``user:read:user`` (or any scope that includes it).
+    Pass ``user_id="me"`` (the default) for the authenticated principal,
+    or a specific Zoom user ID / email. The path segment is percent-
+    encoded so caller-supplied IDs cannot inject query/path metacharacters
+    even if a future CLI threads user input straight through.
+
+    Required scopes: ``user:read:user``.
     """
-    return client.get("/users/me")
+    return client.get(f"/users/{quote(user_id, safe='')}")
+
+
+def get_me(client: ApiClient) -> dict[str, Any]:
+    """``GET /users/me`` — alias for :func:`get_user` with ``user_id="me"``.
+
+    Kept for the ``zoom users me`` CLI command and any external callers
+    that imported it from PR #31. Prefer :func:`get_user` in new code.
+    """
+    return get_user(client, "me")

--- a/zoom_cli/auth.py
+++ b/zoom_cli/auth.py
@@ -1,0 +1,102 @@
+"""Authentication credential storage for the Zoom REST API.
+
+This module is the persistence layer for Server-to-Server OAuth credentials
+(account_id, client_id, client_secret). It does **not** do any HTTP — token
+exchange against ``https://zoom.us/oauth/token`` is implemented in a
+follow-up PR. Splitting the storage layer out keeps this PR small and lets
+the credential set/clear lifecycle be reviewed independently from the
+network code.
+
+Why we use the same OS keyring backend as ``zoom_cli.secrets``: API client
+secrets are at least as sensitive as meeting passwords, so the same
+"never plaintext on disk" guarantee applies. The two are namespaced by
+distinct service strings (``zoom-cli`` for meeting passwords, ``zoom-cli-auth``
+here) to avoid any chance of overlap with a meeting that happens to be
+named ``account_id``, ``client_id``, etc.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass
+
+import keyring
+import keyring.errors
+
+#: Keyring service identifier for OAuth credentials. Pinned by a test —
+#: changing it orphans every existing user's saved credentials.
+SERVICE_NAME = "zoom-cli-auth"
+
+# Username slots inside the service. We use one keyring entry per field so
+# we can read/delete each independently and so a user inspecting the
+# Keychain sees three labelled entries rather than one opaque blob.
+_ACCOUNT_ID_KEY = "s2s.account_id"
+_CLIENT_ID_KEY = "s2s.client_id"
+_CLIENT_SECRET_KEY = "s2s.client_secret"  # noqa: S105 - keyring slot name, not a password value
+
+
+@dataclass(frozen=True)
+class S2SCredentials:
+    """The three values Zoom requires for Server-to-Server OAuth.
+
+    See https://developers.zoom.us/docs/internal-apps/s2s-oauth/ — these
+    are exchanged for an access token via the
+    ``grant_type=account_credentials`` endpoint.
+    """
+
+    account_id: str
+    client_id: str
+    client_secret: str
+
+
+def save_s2s_credentials(creds: S2SCredentials) -> None:
+    """Persist all three S2S fields to the OS keyring under ``zoom-cli-auth``.
+
+    Atomic semantics are best-effort: if the second or third write fails
+    we leave whatever's already there. The caller can re-run ``zoom auth
+    s2s set`` to retry. This matches how ``zoom save`` works for meetings.
+    """
+    keyring.set_password(SERVICE_NAME, _ACCOUNT_ID_KEY, creds.account_id)
+    keyring.set_password(SERVICE_NAME, _CLIENT_ID_KEY, creds.client_id)
+    keyring.set_password(SERVICE_NAME, _CLIENT_SECRET_KEY, creds.client_secret)
+
+
+def load_s2s_credentials() -> S2SCredentials | None:
+    """Return the stored credentials, or ``None`` if any field is missing.
+
+    All three fields are required for the OAuth round-trip, so partial
+    state is treated the same as no state. Callers that want to know
+    *which* fields are missing should look at each key directly.
+
+    Catches only the genuine "no backend" errors (matches the policy in
+    ``zoom_cli.secrets``) — locked or misbehaving backends propagate so
+    the user can see and resolve them rather than silently being treated
+    as logged-out.
+    """
+    try:
+        account_id = keyring.get_password(SERVICE_NAME, _ACCOUNT_ID_KEY)
+        client_id = keyring.get_password(SERVICE_NAME, _CLIENT_ID_KEY)
+        client_secret = keyring.get_password(SERVICE_NAME, _CLIENT_SECRET_KEY)
+    except (keyring.errors.NoKeyringError, keyring.errors.InitError):
+        return None
+
+    if not (account_id and client_id and client_secret):
+        return None
+
+    return S2SCredentials(
+        account_id=account_id,
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+
+
+def clear_s2s_credentials() -> None:
+    """Remove all three S2S keyring entries. Safe to call when none exist."""
+    for key in (_ACCOUNT_ID_KEY, _CLIENT_ID_KEY, _CLIENT_SECRET_KEY):
+        with contextlib.suppress(keyring.errors.PasswordDeleteError):
+            keyring.delete_password(SERVICE_NAME, key)
+
+
+def has_s2s_credentials() -> bool:
+    """Cheap "is the user logged in via S2S?" check, no return of secrets."""
+    return load_s2s_credentials() is not None

--- a/zoom_cli/auth.py
+++ b/zoom_cli/auth.py
@@ -91,17 +91,17 @@ def load_s2s_credentials() -> S2SCredentials | None:
     state is treated the same as no state. Callers that want to know
     *which* fields are missing should look at each key directly.
 
-    Catches only the genuine "no backend" errors (matches the policy in
-    ``zoom_cli.secrets``) — locked or misbehaving backends propagate so
-    the user can see and resolve them rather than silently being treated
-    as logged-out.
+    Behavior change in #41: ``NoKeyringError`` and ``InitError`` now
+    propagate rather than being silently flattened to ``None``. The two
+    states ("user has not configured S2S yet" vs "this machine has no
+    keyring backend at all") need different remediation paths and the
+    CLI surfaces them with different exit codes. Locked or otherwise
+    misbehaving backends already propagated; this just makes the
+    backend-missing case behave the same way for consistency.
     """
-    try:
-        account_id = keyring.get_password(SERVICE_NAME, _ACCOUNT_ID_KEY)
-        client_id = keyring.get_password(SERVICE_NAME, _CLIENT_ID_KEY)
-        client_secret = keyring.get_password(SERVICE_NAME, _CLIENT_SECRET_KEY)
-    except (keyring.errors.NoKeyringError, keyring.errors.InitError):
-        return None
+    account_id = keyring.get_password(SERVICE_NAME, _ACCOUNT_ID_KEY)
+    client_id = keyring.get_password(SERVICE_NAME, _CLIENT_ID_KEY)
+    client_secret = keyring.get_password(SERVICE_NAME, _CLIENT_SECRET_KEY)
 
     if not (account_id and client_id and client_secret):
         return None
@@ -121,5 +121,14 @@ def clear_s2s_credentials() -> None:
 
 
 def has_s2s_credentials() -> bool:
-    """Cheap "is the user logged in via S2S?" check, no return of secrets."""
-    return load_s2s_credentials() is not None
+    """Cheap "is the user logged in via S2S?" check, no return of secrets.
+
+    Returns ``False`` if the backend is unavailable (rather than raising)
+    so the CLI ``status`` command can give a friendlier message; callers
+    that need to distinguish "no backend" from "no creds" should use
+    :func:`load_s2s_credentials` directly.
+    """
+    try:
+        return load_s2s_credentials() is not None
+    except (keyring.errors.NoKeyringError, keyring.errors.InitError):
+        return False

--- a/zoom_cli/auth.py
+++ b/zoom_cli/auth.py
@@ -49,16 +49,39 @@ class S2SCredentials:
     client_secret: str
 
 
+_ALL_KEYS = (_ACCOUNT_ID_KEY, _CLIENT_ID_KEY, _CLIENT_SECRET_KEY)
+
+
 def save_s2s_credentials(creds: S2SCredentials) -> None:
     """Persist all three S2S fields to the OS keyring under ``zoom-cli-auth``.
 
-    Atomic semantics are best-effort: if the second or third write fails
-    we leave whatever's already there. The caller can re-run ``zoom auth
-    s2s set`` to retry. This matches how ``zoom save`` works for meetings.
+    Best-effort transactional: snapshot the existing values first, then write
+    the three new ones in order. If any write raises, restore the snapshot
+    so the user is left with the prior credential set rather than a hybrid
+    of new + old fields. ``load_s2s_credentials`` would otherwise return a
+    full-looking tuple composed of mismatched values, leading the user to
+    authenticate with the wrong account/client combination silently.
+    Closes #35.
     """
-    keyring.set_password(SERVICE_NAME, _ACCOUNT_ID_KEY, creds.account_id)
-    keyring.set_password(SERVICE_NAME, _CLIENT_ID_KEY, creds.client_id)
-    keyring.set_password(SERVICE_NAME, _CLIENT_SECRET_KEY, creds.client_secret)
+    snapshot = {key: keyring.get_password(SERVICE_NAME, key) for key in _ALL_KEYS}
+    written: list[str] = []
+    try:
+        for key, value in (
+            (_ACCOUNT_ID_KEY, creds.account_id),
+            (_CLIENT_ID_KEY, creds.client_id),
+            (_CLIENT_SECRET_KEY, creds.client_secret),
+        ):
+            keyring.set_password(SERVICE_NAME, key, value)
+            written.append(key)
+    except Exception:
+        for key in written:
+            previous = snapshot[key]
+            with contextlib.suppress(Exception):
+                if previous is None:
+                    keyring.delete_password(SERVICE_NAME, key)
+                else:
+                    keyring.set_password(SERVICE_NAME, key, previous)
+        raise
 
 
 def load_s2s_credentials() -> S2SCredentials | None:
@@ -92,7 +115,7 @@ def load_s2s_credentials() -> S2SCredentials | None:
 
 def clear_s2s_credentials() -> None:
     """Remove all three S2S keyring entries. Safe to call when none exist."""
-    for key in (_ACCOUNT_ID_KEY, _CLIENT_ID_KEY, _CLIENT_SECRET_KEY):
+    for key in _ALL_KEYS:
         with contextlib.suppress(keyring.errors.PasswordDeleteError):
             keyring.delete_password(SERVICE_NAME, key)
 

--- a/zoom_cli/commands.py
+++ b/zoom_cli/commands.py
@@ -1,6 +1,7 @@
 import click
 import questionary
 
+from zoom_cli import secrets
 from zoom_cli.utils import (
     ConsoleColor,
     LauncherUnavailableError,
@@ -11,6 +12,24 @@ from zoom_cli.utils import (
     strip_url_scheme,
     write_to_meeting_file,
 )
+
+
+def _resolve_password(name: str, entry: dict, url_password: str = "") -> str:
+    """Pick the right password for a saved meeting.
+
+    Resolution order:
+    1. OS keyring (new entries land here as of #5).
+    2. Plaintext ``password`` field in ``meetings.json`` (back-compat for
+       entries saved before keyring migration).
+    3. ``pwd=`` extracted from the saved URL.
+
+    Empty strings count as a deliberate "no password" — only ``None`` from
+    the keyring falls through to step 2.
+    """
+    keyring_pw = secrets.get_password(name)
+    if keyring_pw is not None:
+        return keyring_pw
+    return entry.get("password", url_password)
 
 
 def _print_error(message: str) -> None:
@@ -46,11 +65,7 @@ def _launch_name(name: str) -> None:
     try:
         if "url" in entry:
             meeting_id, url_password = parse_meeting_url(entry["url"])
-            # Presence-check via dict.get: a deliberately empty saved password
-            # ({"password": ""}) returns "" — meaning "no password" — rather
-            # than falling back to url_password. Preserves the contract from
-            # PR #25 where `_edit` lets users intentionally clear a field.
-            password = entry.get("password", url_password)
+            password = _resolve_password(name, entry, url_password)
 
             if meeting_id is not None:
                 launch_zoommtg(meeting_id, password)
@@ -66,7 +81,7 @@ def _launch_name(name: str) -> None:
             return
 
         if "id" in entry:
-            launch_zoommtg(entry["id"], entry.get("password", ""))
+            launch_zoommtg(entry["id"], _resolve_password(name, entry))
             return
 
         _print_error(
@@ -83,17 +98,21 @@ def _launch_name(name: str) -> None:
 def _save_url(name, url, password):
     contents = get_meeting_file_contents()
     contents[name] = {"url": url}
-    if password:
-        contents[name]["password"] = password
     write_to_meeting_file(contents)
+    if password:
+        secrets.set_password(name, password)
+    else:
+        secrets.delete_password(name)
 
 
 def _save_id_password(name, id, password):
     contents = get_meeting_file_contents()
     contents[name] = {"id": id}
-    if password:
-        contents[name]["password"] = password
     write_to_meeting_file(contents)
+    if password:
+        secrets.set_password(name, password)
+    else:
+        secrets.delete_password(name)
 
 
 def _edit(name, url, id, password):
@@ -104,13 +123,17 @@ def _edit(name, url, id, password):
         new_dict["url"] = url
     if id:
         new_dict["id"] = id
-    if password:
-        new_dict["password"] = password
 
-    # For each existing field, re-prompt with the new value (if a flag was
-    # passed) or the old value as the default. The user can intentionally
-    # clear a field by submitting an empty string; only Ctrl-C aborts.
+    # For each existing non-secret field, re-prompt with the new value (if a
+    # flag was passed) or the old value as the default. The user can clear a
+    # field by submitting an empty string; only Ctrl-C aborts. Passwords are
+    # NOT re-prompted here — they live in the keyring and are managed via
+    # the explicit ``--password`` flag.
     for key, val in contents[name].items():
+        if key == "password":
+            # Legacy plaintext password from a pre-keyring entry. Skip the
+            # prompt; we'll migrate it to the keyring below.
+            continue
         answer = questionary.text(key, default=new_dict.get(key, val)).ask()
         if answer is None:
             raise click.Abort
@@ -120,11 +143,17 @@ def _edit(name, url, id, password):
     contents[name] = new_dict
     write_to_meeting_file(contents)
 
+    # Password updates go through the keyring. If --password was passed,
+    # update; otherwise leave whatever's already there alone.
+    if password:
+        secrets.set_password(name, password)
+
 
 def _remove(name):
     contents = get_meeting_file_contents()
     del contents[name]
     write_to_meeting_file(contents)
+    secrets.delete_password(name)
 
 
 def _ls():
@@ -136,8 +165,11 @@ def _ls():
             print(ConsoleColor.BOLD + "    url: " + ConsoleColor.END + entries["url"])
         if "id" in entries:
             print(ConsoleColor.BOLD + "    id: " + ConsoleColor.END + entries["id"])
-        if "password" in entries:
-            print(ConsoleColor.BOLD + "    password: " + ConsoleColor.END + entries["password"])
+        # Passwords are masked. They live in the OS keyring (or, for
+        # not-yet-migrated entries, plaintext in meetings.json).
+        has_password = "password" in entries or secrets.get_password(name) is not None
+        if has_password:
+            print(ConsoleColor.BOLD + "    password: " + ConsoleColor.END + "********")
 
         if idx < len(meetings) - 1:
             print()

--- a/zoom_cli/commands.py
+++ b/zoom_cli/commands.py
@@ -3,57 +3,74 @@ import questionary
 
 from zoom_cli.utils import (
     ConsoleColor,
+    LauncherUnavailableError,
     get_meeting_file_contents,
     launch_zoommtg,
     launch_zoommtg_url,
+    parse_meeting_url,
+    strip_url_scheme,
     write_to_meeting_file,
 )
 
 
-def _launch_url(url):
+def _print_error(message: str) -> None:
+    print(ConsoleColor.BOLD + "Error:" + ConsoleColor.END, end=" ")
+    print(message)
+
+
+def _launch_url(url: str) -> None:
+    """Launch a Zoom meeting from any URL by rewriting the scheme to ``zoommtg://``.
+
+    Accepts URLs with or without an existing scheme. Only catches
+    ``LauncherUnavailableError`` so that genuine bugs propagate instead of
+    being swallowed by a bare ``except``.
+    """
+    rebuilt = f"zoommtg://{strip_url_scheme(url)}"
     try:
-        url_to_launch = url[url.index("://") + 3 :] if "://" in url else url
-        launch_zoommtg_url(f"zoommtg://{url_to_launch}")
-    except Exception:
-        print(ConsoleColor.BOLD + "Error:" + ConsoleColor.END, end=" ")
-        print("Unable to launch given URL:  " + ConsoleColor.BOLD + url + ConsoleColor.END + ".")
+        launch_zoommtg_url(rebuilt)
+    except LauncherUnavailableError as exc:
+        _print_error(str(exc))
 
 
-def _launch_name(name):
+def _launch_name(name: str) -> None:
     contents = get_meeting_file_contents()
 
-    if name in contents:
-        if "url" in contents[name]:
-            url = contents[name]["url"]
-
-            # Extract id from URL: between "/j/" and either "?" or end-of-string.
-            id_start = url.index("/j/") + 3
-            query_idx = url.index("?") if "?" in url else len(url)
-            id = url[id_start:query_idx]
-            password = ""
-
-            if "pwd=" in url:
-                pwd_start = url.index("pwd=") + 4
-                pwd_end = url.index("&", pwd_start) if "&" in url[pwd_start:] else len(url)
-                password = url[pwd_start:pwd_end]
-
-            launch_zoommtg(id, contents[name].get("password", password))
-        elif "id" in contents[name]:
-            launch_zoommtg(contents[name]["id"], contents[name].get("password", ""))
-        else:
-            print(ConsoleColor.BOLD + "Error:" + ConsoleColor.END, end=" ")
-            print(
-                "No url or id found for meeting with title "
-                + ConsoleColor.BOLD
-                + name
-                + ConsoleColor.END
-                + "."
-            )
-    else:
-        print(ConsoleColor.BOLD + "Error:" + ConsoleColor.END, end=" ")
-        print(
+    if name not in contents:
+        _print_error(
             "Could not find meeting with title " + ConsoleColor.BOLD + name + ConsoleColor.END + "."
         )
+        return
+
+    entry = contents[name]
+
+    try:
+        if "url" in entry:
+            meeting_id, url_password = parse_meeting_url(entry["url"])
+            password = entry.get("password") or url_password
+
+            if meeting_id is not None:
+                launch_zoommtg(meeting_id, password)
+                return
+
+            # No /j/<id> path — likely a personal link (/s/<name>) or web-client URL.
+            # Pass it through the zoommtg:// launcher so the desktop client
+            # handles the resolution.
+            launch_zoommtg_url(f"zoommtg://{strip_url_scheme(entry['url'])}")
+            return
+
+        if "id" in entry:
+            launch_zoommtg(entry["id"], entry.get("password", ""))
+            return
+
+        _print_error(
+            "No url or id found for meeting with title "
+            + ConsoleColor.BOLD
+            + name
+            + ConsoleColor.END
+            + "."
+        )
+    except LauncherUnavailableError as exc:
+        _print_error(str(exc))
 
 
 def _save_url(name, url, password):

--- a/zoom_cli/commands.py
+++ b/zoom_cli/commands.py
@@ -9,9 +9,9 @@ from zoom_cli.utils import (
     get_meeting_file_contents,
     launch_zoommtg,
     launch_zoommtg_url,
+    meeting_file_transaction,
     parse_meeting_url,
     strip_url_scheme,
-    write_to_meeting_file,
 )
 
 
@@ -112,9 +112,11 @@ def _save_url(name, url, password):
     else:
         secrets.delete_password(name)
 
-    contents = get_meeting_file_contents()
-    contents[name] = {"url": url}
-    write_to_meeting_file(contents)
+    # `meeting_file_transaction` takes the exclusive lock, yields the
+    # current contents, and persists on exit (closes #39 — concurrent
+    # invocations no longer overwrite each other's updates).
+    with meeting_file_transaction() as contents:
+        contents[name] = {"url": url}
 
 
 def _save_id_password(name, id, password):
@@ -123,59 +125,56 @@ def _save_id_password(name, id, password):
     else:
         secrets.delete_password(name)
 
-    contents = get_meeting_file_contents()
-    contents[name] = {"id": id}
-    write_to_meeting_file(contents)
+    with meeting_file_transaction() as contents:
+        contents[name] = {"id": id}
 
 
 def _edit(name, url, id, password):
-    contents = get_meeting_file_contents()
-    new_dict: dict[str, str] = {}
     legacy_plaintext_password: str | None = None
 
-    if url:
-        new_dict["url"] = url
-    if id:
-        new_dict["id"] = id
+    with meeting_file_transaction() as contents:
+        new_dict: dict[str, str] = {}
+        if url:
+            new_dict["url"] = url
+        if id:
+            new_dict["id"] = id
 
-    # For each existing non-secret field, re-prompt with the new value (if a
-    # flag was passed) or the old value as the default. The user can clear a
-    # field by submitting an empty string; only Ctrl-C aborts. Passwords are
-    # NOT re-prompted here — they live in the keyring and are managed via
-    # the explicit ``--password`` flag.
-    for key, val in contents[name].items():
-        if key == "password":
-            # Legacy plaintext password from a pre-keyring entry. Capture it
-            # so we can migrate it into the keyring below — never just drop
-            # it (all three reviewers on #28 flagged the silent loss).
-            legacy_plaintext_password = val
-            continue
-        answer = questionary.text(key, default=new_dict.get(key, val)).ask()
-        if answer is None:
-            raise click.Abort
-        new_dict[key] = answer
+        # For each existing non-secret field, re-prompt with the new value (if a
+        # flag was passed) or the old value as the default. The user can clear a
+        # field by submitting an empty string; only Ctrl-C aborts. Passwords are
+        # NOT re-prompted here — they live in the keyring and are managed via
+        # the explicit ``--password`` flag.
+        for key, val in contents[name].items():
+            if key == "password":
+                # Legacy plaintext password from a pre-keyring entry. Capture it
+                # so we can migrate it into the keyring below — never just drop
+                # it (all three reviewers on #28 flagged the silent loss).
+                legacy_plaintext_password = val
+                continue
+            answer = questionary.text(key, default=new_dict.get(key, val)).ask()
+            if answer is None:
+                raise click.Abort
+            new_dict[key] = answer
 
-    # Password handling — keyring is the source of truth.
-    # Order matters: write keyring before rewriting JSON so a keyring-side
-    # failure leaves the user's prior state intact.
-    if password:
-        # Explicit --password flag wins.
-        secrets.set_password(name, password)
-    elif legacy_plaintext_password is not None and secrets.get_password(name) is None:
-        # Migrate legacy plaintext into the keyring on first edit. Only do
-        # this if there's no existing keyring entry — never overwrite a
-        # newer keyring value with stale legacy plaintext.
-        secrets.set_password(name, legacy_plaintext_password)
+        # Password handling — keyring is the source of truth.
+        # Order matters: write keyring before rewriting JSON so a keyring-side
+        # failure leaves the user's prior state intact.
+        if password:
+            # Explicit --password flag wins.
+            secrets.set_password(name, password)
+        elif legacy_plaintext_password is not None and secrets.get_password(name) is None:
+            # Migrate legacy plaintext into the keyring on first edit. Only do
+            # this if there's no existing keyring entry — never overwrite a
+            # newer keyring value with stale legacy plaintext.
+            secrets.set_password(name, legacy_plaintext_password)
 
-    del contents[name]
-    contents[name] = new_dict
-    write_to_meeting_file(contents)
+        del contents[name]
+        contents[name] = new_dict
 
 
 def _remove(name):
-    contents = get_meeting_file_contents()
-    del contents[name]
-    write_to_meeting_file(contents)
+    with meeting_file_transaction() as contents:
+        del contents[name]
     secrets.delete_password(name)
 
 

--- a/zoom_cli/commands.py
+++ b/zoom_cli/commands.py
@@ -46,7 +46,11 @@ def _launch_name(name: str) -> None:
     try:
         if "url" in entry:
             meeting_id, url_password = parse_meeting_url(entry["url"])
-            password = entry.get("password") or url_password
+            # Presence-check via dict.get: a deliberately empty saved password
+            # ({"password": ""}) returns "" — meaning "no password" — rather
+            # than falling back to url_password. Preserves the contract from
+            # PR #25 where `_edit` lets users intentionally clear a field.
+            password = entry.get("password", url_password)
 
             if meeting_id is not None:
                 launch_zoommtg(meeting_id, password)
@@ -54,8 +58,11 @@ def _launch_name(name: str) -> None:
 
             # No /j/<id> path — likely a personal link (/s/<name>) or web-client URL.
             # Pass it through the zoommtg:// launcher so the desktop client
-            # handles the resolution.
-            launch_zoommtg_url(f"zoommtg://{strip_url_scheme(entry['url'])}")
+            # handles the resolution. We append the password only if the URL
+            # does NOT already carry one, otherwise launch_zoommtg_url would
+            # double-append `&pwd=...`.
+            extra_pwd = "" if url_password else password
+            launch_zoommtg_url(f"zoommtg://{strip_url_scheme(entry['url'])}", extra_pwd)
             return
 
         if "id" in entry:

--- a/zoom_cli/commands.py
+++ b/zoom_cli/commands.py
@@ -5,6 +5,7 @@ from zoom_cli import secrets
 from zoom_cli.utils import (
     ConsoleColor,
     LauncherUnavailableError,
+    UntrustedHostError,
     get_meeting_file_contents,
     launch_zoommtg,
     launch_zoommtg_url,
@@ -40,14 +41,18 @@ def _print_error(message: str) -> None:
 def _launch_url(url: str) -> None:
     """Launch a Zoom meeting from any URL by rewriting the scheme to ``zoommtg://``.
 
-    Accepts URLs with or without an existing scheme. Only catches
-    ``LauncherUnavailableError`` so that genuine bugs propagate instead of
-    being swallowed by a bare ``except``.
+    Accepts URLs with or without an existing scheme. Only catches the
+    expected user-facing error types so that genuine bugs propagate instead
+    of being swallowed by a bare ``except``. ``UntrustedHostError`` is a
+    defense-in-depth catch — the ``launch`` CLI command pre-validates the
+    host, so this path normally only sees trusted URLs.
     """
     rebuilt = f"zoommtg://{strip_url_scheme(url)}"
     try:
         launch_zoommtg_url(rebuilt)
     except LauncherUnavailableError as exc:
+        _print_error(str(exc))
+    except UntrustedHostError as exc:
         _print_error(str(exc))
 
 
@@ -92,6 +97,8 @@ def _launch_name(name: str) -> None:
             + "."
         )
     except LauncherUnavailableError as exc:
+        _print_error(str(exc))
+    except UntrustedHostError as exc:
         _print_error(str(exc))
 
 

--- a/zoom_cli/commands.py
+++ b/zoom_cli/commands.py
@@ -96,28 +96,35 @@ def _launch_name(name: str) -> None:
 
 
 def _save_url(name, url, password):
+    # Write the keyring BEFORE writing the JSON. If the keyring write fails
+    # (e.g. backend unhealthy), the user's existing meetings.json is left
+    # untouched — they don't end up with a meeting that has no usable
+    # password anywhere. Codex review on #28 caught this ordering bug.
+    if password:
+        secrets.set_password(name, password)
+    else:
+        secrets.delete_password(name)
+
     contents = get_meeting_file_contents()
     contents[name] = {"url": url}
     write_to_meeting_file(contents)
-    if password:
-        secrets.set_password(name, password)
-    else:
-        secrets.delete_password(name)
 
 
 def _save_id_password(name, id, password):
-    contents = get_meeting_file_contents()
-    contents[name] = {"id": id}
-    write_to_meeting_file(contents)
     if password:
         secrets.set_password(name, password)
     else:
         secrets.delete_password(name)
+
+    contents = get_meeting_file_contents()
+    contents[name] = {"id": id}
+    write_to_meeting_file(contents)
 
 
 def _edit(name, url, id, password):
     contents = get_meeting_file_contents()
     new_dict: dict[str, str] = {}
+    legacy_plaintext_password: str | None = None
 
     if url:
         new_dict["url"] = url
@@ -131,22 +138,31 @@ def _edit(name, url, id, password):
     # the explicit ``--password`` flag.
     for key, val in contents[name].items():
         if key == "password":
-            # Legacy plaintext password from a pre-keyring entry. Skip the
-            # prompt; we'll migrate it to the keyring below.
+            # Legacy plaintext password from a pre-keyring entry. Capture it
+            # so we can migrate it into the keyring below — never just drop
+            # it (all three reviewers on #28 flagged the silent loss).
+            legacy_plaintext_password = val
             continue
         answer = questionary.text(key, default=new_dict.get(key, val)).ask()
         if answer is None:
             raise click.Abort
         new_dict[key] = answer
 
+    # Password handling — keyring is the source of truth.
+    # Order matters: write keyring before rewriting JSON so a keyring-side
+    # failure leaves the user's prior state intact.
+    if password:
+        # Explicit --password flag wins.
+        secrets.set_password(name, password)
+    elif legacy_plaintext_password is not None and secrets.get_password(name) is None:
+        # Migrate legacy plaintext into the keyring on first edit. Only do
+        # this if there's no existing keyring entry — never overwrite a
+        # newer keyring value with stale legacy plaintext.
+        secrets.set_password(name, legacy_plaintext_password)
+
     del contents[name]
     contents[name] = new_dict
     write_to_meeting_file(contents)
-
-    # Password updates go through the keyring. If --password was passed,
-    # update; otherwise leave whatever's already there alone.
-    if password:
-        secrets.set_password(name, password)
 
 
 def _remove(name):

--- a/zoom_cli/secrets.py
+++ b/zoom_cli/secrets.py
@@ -31,13 +31,17 @@ def get_password(meeting_name: str) -> str | None:
     Returns ``None`` (not the empty string) when the entry doesn't exist so
     callers can distinguish "not in keyring" from "saved as empty"; current
     callers don't rely on that distinction but future callers might.
+
+    Catches only the "no backend available" errors (``NoKeyringError``,
+    ``InitError``) so the CLI degrades gracefully on a headless Linux box
+    with no DBus. Locked-keyring errors and other failures are intentionally
+    NOT caught here — those mean the backend is present but refused, and a
+    silent fall-through would launch meetings with the wrong (or no)
+    password. The caller sees the exception and can decide what to do.
     """
     try:
         return keyring.get_password(SERVICE_NAME, meeting_name)
-    except keyring.errors.KeyringError:
-        # Backend unavailable (e.g. no DBus on a headless Linux box). Treat
-        # as "no stored password" so the CLI degrades gracefully — meetings
-        # without a stored password just prompt or fail at launch.
+    except (keyring.errors.NoKeyringError, keyring.errors.InitError):
         return None
 
 

--- a/zoom_cli/secrets.py
+++ b/zoom_cli/secrets.py
@@ -1,0 +1,56 @@
+"""OS keyring-backed password storage for saved meetings.
+
+Replaces the prior practice of writing meeting passwords as plaintext into
+``~/.zoom-cli/meetings.json``. Each saved meeting's password lives under the
+keyring service ``zoom-cli`` keyed by the meeting name.
+
+Storage layout
+--------------
+- macOS: Keychain
+- Linux: Secret Service (libsecret) / KWallet
+- Windows: Credential Manager
+
+The :data:`SERVICE_NAME` constant is the only thing other modules import.
+Tests can swap the keyring backend with ``keyring.set_keyring(...)`` for
+isolation; nothing in this module touches the real keyring at import time.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+import keyring
+import keyring.errors
+
+SERVICE_NAME = "zoom-cli"
+
+
+def get_password(meeting_name: str) -> str | None:
+    """Return the saved password for ``meeting_name`` or ``None`` if missing.
+
+    Returns ``None`` (not the empty string) when the entry doesn't exist so
+    callers can distinguish "not in keyring" from "saved as empty"; current
+    callers don't rely on that distinction but future callers might.
+    """
+    try:
+        return keyring.get_password(SERVICE_NAME, meeting_name)
+    except keyring.errors.KeyringError:
+        # Backend unavailable (e.g. no DBus on a headless Linux box). Treat
+        # as "no stored password" so the CLI degrades gracefully — meetings
+        # without a stored password just prompt or fail at launch.
+        return None
+
+
+def set_password(meeting_name: str, password: str) -> None:
+    """Store ``password`` under ``meeting_name``.
+
+    Empty strings are written through; callers that want "no password" should
+    call :func:`delete_password` instead.
+    """
+    keyring.set_password(SERVICE_NAME, meeting_name, password)
+
+
+def delete_password(meeting_name: str) -> None:
+    """Remove the entry for ``meeting_name``. No-op if it doesn't exist."""
+    with contextlib.suppress(keyring.errors.PasswordDeleteError):
+        keyring.delete_password(SERVICE_NAME, meeting_name)

--- a/zoom_cli/utils.py
+++ b/zoom_cli/utils.py
@@ -6,12 +6,19 @@ import os
 import shutil
 import subprocess
 import tempfile
-from urllib.parse import parse_qs, urlsplit
+from urllib.parse import parse_qs, quote, urlsplit
 
 __version__ = "1.1.6"
 
 ZOOM_CLI_DIR = os.path.expanduser("~/.zoom-cli")
 SAVE_FILE_PATH = f"{ZOOM_CLI_DIR}/meetings.json"
+
+#: Allowlist of trusted Zoom hosts. We accept these and any subdomain
+#: thereof (``us02web.zoom.us``, ``mydomain.zoom.us``, ``zoomgov.com``,
+#: ``us02.zoomgov.com``). Anything else is refused at the launch layer
+#: (closes #38). The list is intentionally short — Zoom only operates two
+#: top-level domains for joining meetings.
+TRUSTED_ZOOM_HOSTS: tuple[str, ...] = ("zoom.us", "zoomgov.com")
 
 
 # adopted from: https://stackoverflow.com/questions/8924173/how-do-i-print-bold-text-in-python
@@ -118,15 +125,76 @@ class LauncherUnavailableError(RuntimeError):
     """Neither `open` nor `xdg-open` is available on PATH."""
 
 
+class UntrustedHostError(ValueError):
+    """The URL's host is not in the trusted Zoom domain allowlist (#38)."""
+
+
+def is_trusted_zoom_host(host: str) -> bool:
+    """Return True if ``host`` is on the Zoom allowlist or a subdomain thereof.
+
+    Comparison is case-insensitive. Empty string returns False. Subdomain
+    match requires the suffix to be a proper subdomain (``foo.zoom.us``
+    matches; ``my-zoom.us-domain.com`` does NOT — the trailing ``.zoom.us``
+    must be a domain boundary, not a substring).
+    """
+    if not host:
+        return False
+    normalized = host.lower()
+    return any(
+        normalized == trusted or normalized.endswith("." + trusted)
+        for trusted in TRUSTED_ZOOM_HOSTS
+    )
+
+
+def looks_like_zoom_url(text: str) -> bool:
+    """Return True if ``text`` parses to a URL on a trusted Zoom host.
+
+    Used by the CLI to decide whether ``zoom <arg>`` should be treated as a
+    URL or as a saved-meeting name. Accepts inputs with or without a scheme
+    — ``zoom.us/j/123`` and ``https://zoom.us/j/123`` both return True.
+    Strings without a Zoom host (``meeting-name``, ``https://evil.example/zoom.us/j/1``)
+    return False.
+    """
+    candidate = text if "://" in text else f"https://{text}"
+    try:
+        parsed = urlsplit(candidate)
+    except ValueError:
+        return False
+    return is_trusted_zoom_host(parsed.hostname or "")
+
+
 def launch_zoommtg_url(url: str, password: str = "") -> None:
     """Launch the Zoom desktop client for ``url``.
 
     Uses argv-list ``subprocess.run`` (not the shell) so that meeting URLs and
     passwords containing shell metacharacters (``"``, `` ` ``, ``$``, ``;``)
-    cannot be interpreted as shell syntax. Closes #4.
+    cannot be interpreted as shell syntax (closes #4).
+
+    Validates the URL host against :data:`TRUSTED_ZOOM_HOSTS` before
+    launching; raises :class:`UntrustedHostError` for anything else
+    (closes #38). The Zoom desktop client itself would likely reject a
+    non-Zoom ``zoommtg://`` URL, but failing here gives the user a clear
+    error rather than a silent no-op or a confusing client-side dialog.
+
+    URL-encodes ``password`` when building the ``pwd=`` query parameter
+    (closes #37); passwords containing ``&``, ``=``, ``#``, ``+`` etc. now
+    round-trip correctly instead of corrupting the query string.
     """
-    decorator = "?" if "?" not in url else "&"
-    url_to_launch = f"{url}{decorator}pwd={password}" if password else url
+    parsed = urlsplit(url)
+    if not is_trusted_zoom_host(parsed.hostname or ""):
+        raise UntrustedHostError(
+            f"Refusing to launch URL with untrusted host: {parsed.hostname or url!r}"
+        )
+
+    if password:
+        # quote(safe="") percent-encodes every character outside the
+        # unreserved set (a-zA-Z0-9_.-~), which is exactly what we want
+        # for a query-string value.
+        decorator = "?" if "?" not in url else "&"
+        url_to_launch = f"{url}{decorator}pwd={quote(password, safe='')}"
+    else:
+        url_to_launch = url
+
     cmd = shutil.which("open") or shutil.which("xdg-open")
     if cmd is None:
         raise LauncherUnavailableError(

--- a/zoom_cli/utils.py
+++ b/zoom_cli/utils.py
@@ -35,16 +35,113 @@ class ConsoleColor:
     END = "\033[0m"
 
 
+#: Directory mode for ``~/.zoom-cli`` — owner only (closes #40).
+_DIR_MODE = 0o700
+#: File mode for ``meetings.json`` and the lock file — owner only.
+_FILE_MODE = 0o600
+
+
+def _is_owned_by_current_user(stat_result: os.stat_result) -> bool:
+    """POSIX: True if the file's owner uid matches the current process uid.
+
+    On Windows ``os.getuid`` doesn't exist; skip the ownership check since
+    Windows ACLs work differently and ``chmod`` is largely a no-op anyway.
+    """
+    try:
+        return stat_result.st_uid == os.getuid()
+    except AttributeError:
+        return True
+
+
 def _ensure_storage() -> None:
     """Create the storage dir and empty meetings file on first use.
 
     Done lazily so tests can monkeypatch the paths before any storage call.
+    The directory is created with ``0o700`` and the meetings file with
+    ``0o600`` (closes #40). Existing dirs/files are tightened on touch if
+    they're owned by us and currently group/world-readable — older
+    installations created them under the ambient umask.
     """
     if not os.path.isdir(ZOOM_CLI_DIR):
-        os.makedirs(ZOOM_CLI_DIR)
+        os.makedirs(ZOOM_CLI_DIR, mode=_DIR_MODE)
+    else:
+        with contextlib.suppress(OSError):
+            stat_result = os.stat(ZOOM_CLI_DIR)
+            if _is_owned_by_current_user(stat_result) and stat_result.st_mode & 0o077:
+                os.chmod(ZOOM_CLI_DIR, _DIR_MODE)
+
     if not os.path.exists(SAVE_FILE_PATH):
-        with open(SAVE_FILE_PATH, "w") as file:
+        # O_CREAT|O_EXCL is the standard atomic-create idiom; combined with
+        # mode=_FILE_MODE this avoids a TOCTOU window where the file
+        # briefly exists with the umask permissions.
+        fd = os.open(SAVE_FILE_PATH, os.O_WRONLY | os.O_CREAT | os.O_EXCL, _FILE_MODE)
+        with os.fdopen(fd, "w") as file:
             file.write("{}")
+    else:
+        with contextlib.suppress(OSError):
+            stat_result = os.stat(SAVE_FILE_PATH)
+            if _is_owned_by_current_user(stat_result) and stat_result.st_mode & 0o077:
+                os.chmod(SAVE_FILE_PATH, _FILE_MODE)
+
+
+@contextlib.contextmanager
+def _meeting_file_lock():
+    """Exclusive POSIX file lock around read-modify-write on ``meetings.json``.
+
+    Closes #39: prevents lost updates when two ``zoom save``/``edit``/``rm``
+    invocations interleave. Atomic ``os.replace`` only protects file
+    integrity; without a lock both processes can read the same snapshot
+    and the second write silently overwrites the first.
+
+    Locks a sibling ``meetings.json.lock`` file rather than
+    ``meetings.json`` itself, because we replace the meetings file
+    atomically on every write — its inode doesn't survive, so a lock on
+    it doesn't either. The lock file is created with ``_FILE_MODE``.
+
+    Best-effort on non-POSIX (Windows): ``fcntl`` isn't available, so the
+    lock is a no-op. Single-developer Windows use is fine; concurrent
+    Windows automation should add ``msvcrt.locking`` (out of scope here).
+    """
+    _ensure_storage()
+    try:
+        import fcntl
+    except ImportError:
+        yield
+        return
+
+    lock_path = SAVE_FILE_PATH + ".lock"
+    # Open with O_CREAT but no exclusive — the lock file is shared across
+    # invocations. mode applies on creation only.
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, _FILE_MODE)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
+
+
+@contextlib.contextmanager
+def meeting_file_transaction():
+    """Acquire the meeting-file lock, read the current contents, persist on exit.
+
+    Usage::
+
+        with meeting_file_transaction() as contents:
+            contents[name] = {...}
+
+    Combined with the lock from :func:`_meeting_file_lock`, this guarantees
+    that interleaved ``zoom save``/``edit``/``rm`` invocations cannot lose
+    each other's updates (closes #39). The atomic write semantics from
+    :func:`write_to_meeting_file` still apply, so a crash mid-write cannot
+    corrupt the file either.
+    """
+    with _meeting_file_lock():
+        contents = get_meeting_file_contents()
+        yield contents
+        write_to_meeting_file(contents)
 
 
 def dict_to_json_string(data) -> str:

--- a/zoom_cli/utils.py
+++ b/zoom_cli/utils.py
@@ -4,6 +4,7 @@ import json
 import os
 import shutil
 import subprocess
+from urllib.parse import parse_qs, urlsplit
 
 __version__ = "1.1.6"
 
@@ -97,3 +98,28 @@ def launch_zoommtg_url(url: str, password: str = "") -> None:
 def launch_zoommtg(id: str, password: str) -> None:
     url = "zoommtg://zoom.us/join?confno=" + id
     launch_zoommtg_url(url, password)
+
+
+def parse_meeting_url(url: str) -> tuple[str | None, str]:
+    """Extract ``(meeting_id, password)`` from a Zoom meeting URL.
+
+    Recognizes the standard ``/j/<id>`` meeting URL form. Personal links
+    (``/s/<name>``), web-client links (``/wc/<id>``), and unrecognized
+    formats return ``(None, "")`` so callers can fall back to launching
+    the URL as-is.
+
+    The ``pwd=`` query parameter is URL-decoded by ``parse_qs``, so
+    percent-encoded passwords (e.g. ``pwd=ab%23cd``) round-trip cleanly.
+    """
+    parsed = urlsplit(url)
+    path_segments = [seg for seg in parsed.path.split("/") if seg]
+    meeting_id: str | None = None
+    if len(path_segments) >= 2 and path_segments[0] == "j":
+        meeting_id = path_segments[1]
+    password = parse_qs(parsed.query).get("pwd", [""])[0]
+    return meeting_id, password
+
+
+def strip_url_scheme(url: str) -> str:
+    """Return ``url`` with any leading ``scheme://`` removed."""
+    return url.split("://", 1)[1] if "://" in url else url

--- a/zoom_cli/utils.py
+++ b/zoom_cli/utils.py
@@ -63,20 +63,29 @@ def get_meeting_names() -> list[str]:
 
 
 def write_to_meeting_file(contents: dict) -> None:
-    """Write the meetings JSON atomically.
+    """Write the meetings JSON atomically and durably.
 
-    Strategy: write the new content to a sibling tempfile, ``fsync`` to flush
-    the page cache, then ``os.replace`` (which is atomic on POSIX and on
-    Windows for files on the same filesystem) to swap it into place. This
-    prevents partial-write corruption if the process is killed mid-write or
-    the system crashes — readers will see either the old file or the new
-    file, never a half-written one.
+    Strategy:
+    1. Serialize the new content to a sibling tempfile (created via
+       ``tempfile.mkstemp`` so the name is unpredictable and exclusive).
+    2. ``flush()`` + ``os.fsync()`` the tempfile's fd so its contents reach
+       the disk before we swap it into place.
+    3. ``os.replace()`` it onto ``meetings.json``. The replace is atomic on
+       POSIX and on Windows for same-filesystem replacements, so readers
+       see either the old file or the new file — never a half-written one.
+    4. ``os.fsync()`` the parent directory so the directory entry update
+       (the rename) is also durable on POSIX. Skipped on platforms where
+       opening a directory raises ``PermissionError`` (Windows).
+
+    On any exception during the write, best-effort delete the tempfile so
+    we don't leak it, then re-raise the original error. ``meetings.json``
+    itself is never opened until the final replace, so a mid-write failure
+    cannot corrupt it.
     """
     _ensure_storage()
     payload = dict_to_json_string(contents)
     dir_name = os.path.dirname(SAVE_FILE_PATH) or "."
-    # delete=False because we hand the path to os.replace ourselves.
-    fd, tmp_path = _mkstemp_for(dir_name)
+    fd, tmp_path = tempfile.mkstemp(prefix=".meetings.", suffix=".tmp", dir=dir_name)
     try:
         with os.fdopen(fd, "w") as file:
             file.write(payload)
@@ -89,10 +98,15 @@ def write_to_meeting_file(contents: dict) -> None:
             os.unlink(tmp_path)
         raise
 
-
-def _mkstemp_for(directory: str) -> tuple[int, str]:
-    """Wrap ``tempfile.mkstemp`` for this module so tests can stub it cleanly."""
-    return tempfile.mkstemp(prefix=".meetings.", suffix=".tmp", dir=directory)
+    # Durability: fsync the parent dir so the new dirent survives a crash
+    # right after the rename. POSIX-only — Windows raises PermissionError
+    # when you try to open a directory.
+    with contextlib.suppress(OSError, PermissionError):
+        dir_fd = os.open(dir_name, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
 
 
 def is_command_available(command: str) -> bool:

--- a/zoom_cli/utils.py
+++ b/zoom_cli/utils.py
@@ -103,20 +103,39 @@ def launch_zoommtg(id: str, password: str) -> None:
 def parse_meeting_url(url: str) -> tuple[str | None, str]:
     """Extract ``(meeting_id, password)`` from a Zoom meeting URL.
 
-    Recognizes the standard ``/j/<id>`` meeting URL form. Personal links
-    (``/s/<name>``), web-client links (``/wc/<id>``), and unrecognized
-    formats return ``(None, "")`` so callers can fall back to launching
-    the URL as-is.
+    Recognizes:
+
+    - ``/j/<id>`` — the standard meeting URL form.
+    - ``?confno=<id>`` query parameter — Zoom's older click-to-join form,
+      sometimes still emitted (and the same form the ``zoommtg://`` scheme
+      uses internally).
+
+    Personal links (``/s/<name>``), web-client links (``/wc/<id>``), and
+    unrecognized formats return ``(None, password_if_any)`` so callers can
+    fall back to launching the URL as-is. Note: even for unrecognized
+    formats the ``pwd=`` parameter is still extracted, so a caller routing
+    a ``/wc/...?pwd=abc`` through the fallback launcher knows to add the
+    password if the URL doesn't already contain one.
 
     The ``pwd=`` query parameter is URL-decoded by ``parse_qs``, so
     percent-encoded passwords (e.g. ``pwd=ab%23cd``) round-trip cleanly.
+    If multiple ``pwd=`` parameters are present (malicious or buggy), the
+    **first** value wins; an attacker cannot override a legitimate first
+    value by appending ``&pwd=evil``.
     """
     parsed = urlsplit(url)
     path_segments = [seg for seg in parsed.path.split("/") if seg]
+    query = parse_qs(parsed.query)
+
     meeting_id: str | None = None
     if len(path_segments) >= 2 and path_segments[0] == "j":
         meeting_id = path_segments[1]
-    password = parse_qs(parsed.query).get("pwd", [""])[0]
+    else:
+        confno_values = query.get("confno", [])
+        if confno_values:
+            meeting_id = confno_values[0]
+
+    password = query.get("pwd", [""])[0]
     return meeting_id, password
 
 

--- a/zoom_cli/utils.py
+++ b/zoom_cli/utils.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import shutil
 import subprocess
+import tempfile
 from urllib.parse import parse_qs, urlsplit
 
 __version__ = "1.1.6"
@@ -61,9 +63,36 @@ def get_meeting_names() -> list[str]:
 
 
 def write_to_meeting_file(contents: dict) -> None:
+    """Write the meetings JSON atomically.
+
+    Strategy: write the new content to a sibling tempfile, ``fsync`` to flush
+    the page cache, then ``os.replace`` (which is atomic on POSIX and on
+    Windows for files on the same filesystem) to swap it into place. This
+    prevents partial-write corruption if the process is killed mid-write or
+    the system crashes — readers will see either the old file or the new
+    file, never a half-written one.
+    """
     _ensure_storage()
-    with open(SAVE_FILE_PATH, "w") as file:
-        file.write(dict_to_json_string(contents))
+    payload = dict_to_json_string(contents)
+    dir_name = os.path.dirname(SAVE_FILE_PATH) or "."
+    # delete=False because we hand the path to os.replace ourselves.
+    fd, tmp_path = _mkstemp_for(dir_name)
+    try:
+        with os.fdopen(fd, "w") as file:
+            file.write(payload)
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(tmp_path, SAVE_FILE_PATH)
+    except Exception:
+        # Best-effort cleanup; suppress errors so the original exception wins.
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
+
+
+def _mkstemp_for(directory: str) -> tuple[int, str]:
+    """Wrap ``tempfile.mkstemp`` for this module so tests can stub it cleanly."""
+    return tempfile.mkstemp(prefix=".meetings.", suffix=".tmp", dir=directory)
 
 
 def is_command_available(command: str) -> bool:


### PR DESCRIPTION
## Summary

Consolidated integration PR carrying the full phase-1 hardening + phase-2 OAuth/API stack into `develop` (PRs #26 → #31, since #25 is already in `main`/`develop`).

This is the squashed view of seven stacked PRs that were merged top-down through the cascade:

| #  | Title | Closes / refs |
|----|-------|---------------|
| #25 | chore: bootstrap CI, tests, lint, packaging, docs | #4 #7 #8 (already in `main`) |
| #26 | fix: robust URL parsing + typed exceptions | #6 |
| #27 | chore: atomic JSON writes + --dry-run/--yes on rm | partial #24 |
| #28 | feat: store meeting passwords in OS keyring | #5 |
| #29 | feat: zoom auth s2s credential storage | partial #11 |
| #30 | feat: zoom auth s2s test — OAuth token exchange | #11 |
| #31 | feat: ApiClient + zoom users me | partial #14 |

## What's in here (relative to `develop`)

### Phase 1 — Hardening
- **#6 closed**: `urllib.parse`-based meeting URL parsing replaces brittle slice-based code; supports `/j/<id>`, `?confno=<id>`, personal links (`/s/...`), web-client (`/wc/...`), URL fragments, percent-encoded passwords, and multi-param query strings. `_launch_url` no longer swallows unexpected exceptions with a bare `except Exception`.
- **#5 closed**: Meeting passwords now live in the OS keyring (Keychain / libsecret / Credential Manager) under service `zoom-cli`. `_launch_name` falls back to legacy plaintext-in-JSON for back-compat. `_edit` migrates legacy plaintext into the keyring on first touch instead of dropping it. `_ls` masks all passwords as `********`. New `zoom_cli/secrets.py` module.
- **partial #24**: `write_to_meeting_file` is now atomic + durable (tempfile + fsync + os.replace + parent-dir fsync on POSIX). `zoom rm` gains `--dry-run` and `--yes`/`-y`. Interactive `zoom rm` (no positional name) now confirms before deletion; `zoom rm <name>` stays prompt-free for script compatibility.

### Phase 2 — Zoom REST API
- **#11 closed**: New `zoom auth` subcommand group:
  - `zoom auth s2s set` saves Server-to-Server OAuth credentials to OS keyring (service `zoom-cli-auth`, separate namespace from meeting passwords). Client Secret prompt is masked.
  - `zoom auth s2s test` exchanges saved credentials for a 1-hour bearer token against `https://zoom.us/oauth/token` and reports back. Distinguishes credential failures (HTTP from Zoom) from network failures so users know whether to debug creds or connectivity.
  - `zoom auth status` / `zoom auth logout`.
  - New `zoom_cli/auth.py` (credential storage) and `zoom_cli/api/oauth.py` (token exchange + `AccessToken` dataclass with `is_expired`).
- **partial #14**: New `ApiClient` (`zoom_cli/api/client.py`) — wraps `httpx.Client`, injects `Authorization: Bearer`, caches the access token in-memory until expiry, raises `ZoomApiError` on non-2xx with the parsed Zoom `{code, message}` envelope.
- **partial #14**: New `zoom users me` subcommand calls `GET /users/me` and prints the authenticated user's profile. Three distinct error paths: `ZoomAuthError` (HTTP from token endpoint), `ZoomApiError` (HTTP from Users API), `httpx.HTTPError` (network).

### Tooling / CI
- CI workflow now runs on every PR regardless of base branch (so stacked PRs are covered).

## Tests
- **162 pytest tests** in this stack (was zero pre-#25), all green on the matrix Python 3.10/3.11/3.12/3.13 × Ubuntu+macOS.
- Every secret-touching code path runs against an autouse `_InMemoryKeyring` backend so tests cannot touch the developer's real Keychain.
- Every HTTP path uses `httpx.MockTransport` so production code is exercised end-to-end (auth headers, query params, JSON parsing) with zero socket I/O.
- Service-name constants (`zoom-cli`, `zoom-cli-auth`, `https://api.zoom.us/v2`, `https://zoom.us/oauth/token`) are pinned by tests so a future rename can't silently orphan every existing user's stored credentials.

## Verification

```
ruff check .          # clean
ruff format --check . # clean
mypy                  # clean (4 untyped-func notes, all pre-existing)
pytest -q             # 162 passed
```

## Review history

Each constituent PR went through the in-house review trio (codex, superpowers, python-idiom). Review feedback addressed via follow-up commits before merge. Notable fixes from review:

- PR #25: Ctrl-C handling in `save`/`edit`/`rm` (questionary returns `None`, not raises); `_edit`'s `ask() or val` silently restored cleared values; `os.system` shell injection swapped to argv-list `subprocess.run`.
- PR #26: `_launch_name` URL-fallback dropped saved password; empty-string password vs URL-pwd precedence regression; missing `?confno=` URL form.
- PR #27: parent-directory fsync for full POSIX durability; tests now actually pin `os.replace` is called; `_mkstemp_for` orphan helper inlined.
- PR #28: `_edit` migrates legacy plaintext into keyring instead of dropping; save-then-keyring-write reordered (keyring first, JSON second) to prevent password loss on backend failure; `get_password` exception narrowed to `NoKeyringError`/`InitError` so locked Keychain propagates instead of silently launching with no password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
