### PR TITLE
feat(api): close #16 (partial) — 429/Retry-After backoff + paginate() helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 > Bootstrap PR: [#25](https://github.com/jordan8037310/zoom-cli/pull/25) — closes #4, #7, #8 and partially addresses #9, #10.
-> Codex review follow-ups (PR #32): closes #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47 (all 14 findings from Codex's PR #32 review).
-> CC security setup (this branch): adds `.claude/settings.json`, `SECURITY.md`, `LOCAL-SECURITY.md`, `TASKS.md`, and three FACET developer skills.
+> Codex review follow-ups (PR #32): closes #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47.
+> CC security setup (PR #33): adds `.claude/settings.json`, `SECURITY.md`, `LOCAL-SECURITY.md`, `TASKS.md`, and three FACET developer skills.
+> Rate-limit + pagination (this branch): closes #16 (partial — per-tier token bucket deferred). 429/Retry-After backoff with jitter; `paginate()` generator helper; `users.list_users()` as the first paginated endpoint.
+
+### Added (issue #16)
+- New `zoom_cli/api/pagination.py` with `paginate(client, path, *, item_key, params, page_size)` generator. Walks Zoom's `next_page_token` cursor, yielding each item across all pages. Lazy — pages are fetched on demand.
+- `zoom_cli/api/users.py::list_users(client, *, status, page_size)` — first consumer of `paginate`. Yields user records across the `/users` endpoint; default `page_size=300` matches Zoom's per-endpoint cap.
+- `MAX_429_RETRIES` (3), `MAX_RETRY_DELAY_SECONDS` (60), `JITTER_RANGE` (0.2) constants exposed by `zoom_cli/api/client.py`.
+
+### Changed (issue #16)
+- `ApiClient.request` now retries 429 responses up to `MAX_429_RETRIES` times. Honours `Retry-After` (delta-seconds or HTTP-date per RFC 7231); falls back to exponential backoff (`2^attempt`) when the header is missing. Always caps any single sleep at `MAX_RETRY_DELAY_SECONDS` and applies ±20% jitter so cooperating processes don't thunder back together.
+- After `MAX_429_RETRIES` exhaustion, the 429 propagates as `ZoomApiError` so callers can decide what to do (skip, alert, defer).
+
+### Deferred (issue #16 follow-up)
+- Per-tier token-bucket rate limiting (Light 80/s, Medium 60/s, Heavy 40/s + 60k/day, Resource-intensive 20/s + 60k/day). Best done after more endpoints land so the per-endpoint tier mapping isn't speculative.
 
 ### Security (Codex review follow-ups)
 - **#34 (High)** — `zoom auth s2s set` no longer accepts `--client-secret` as a CLI flag. Values in argv landed in shell history and were visible via `ps`/proc to other users on the host. New contract: `ZOOM_CLIENT_SECRET` env var or masked `questionary.password()` prompt only. `--account-id` and `--client-id` still accept flags (public-ish identifiers) and pick up `ZOOM_ACCOUNT_ID` / `ZOOM_CLIENT_ID` env vars.

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -320,3 +320,207 @@ def test_request_does_not_retry_on_non_401_4xx(monkeypatch: pytest.MonkeyPatch) 
 
     assert request_count["n"] == 1  # no retry
     assert fetch_calls["n"] == 1
+
+
+# ---- #16: 429 / Retry-After handling ------------------------------------
+
+
+def test_request_retries_429_and_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """First response 429 with Retry-After: 0; second response 200."""
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token())
+    sleeps: list[float] = []
+    monkeypatch.setattr(client_mod.time, "sleep", lambda s: sleeps.append(s))
+
+    request_count = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        request_count["n"] += 1
+        if request_count["n"] == 1:
+            return httpx.Response(
+                429,
+                headers={"Retry-After": "0"},
+                json={"code": 429, "message": "Too many requests"},
+            )
+        return httpx.Response(200, json={"id": "u-ok"})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    with ApiClient(_creds(), http_client=http) as c:
+        result = c.get("/users/me")
+
+    assert result == {"id": "u-ok"}
+    assert request_count["n"] == 2
+    assert len(sleeps) == 1  # one sleep before the retry
+    assert sleeps[0] >= 0  # jittered around 0
+
+
+def test_request_honours_retry_after_seconds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retry-After: 5 should produce a sleep of ~5 (4-6 with ±20% jitter)."""
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token())
+    sleeps: list[float] = []
+    monkeypatch.setattr(client_mod.time, "sleep", lambda s: sleeps.append(s))
+
+    request_count = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        request_count["n"] += 1
+        if request_count["n"] == 1:
+            return httpx.Response(
+                429,
+                headers={"Retry-After": "5"},
+                json={"code": 429},
+            )
+        return httpx.Response(200, json={})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    with ApiClient(_creds(), http_client=http) as c:
+        c.get("/users/me")
+
+    assert len(sleeps) == 1
+    # JITTER_RANGE is 0.2 → sleep is 5 * (0.8 to 1.2) = 4.0 to 6.0
+    assert 4.0 <= sleeps[0] <= 6.0
+
+
+def test_request_caps_retry_at_max_delay(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A pathological Retry-After must not produce an unbounded sleep."""
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token())
+    sleeps: list[float] = []
+    monkeypatch.setattr(client_mod.time, "sleep", lambda s: sleeps.append(s))
+
+    request_count = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        request_count["n"] += 1
+        if request_count["n"] == 1:
+            return httpx.Response(
+                429,
+                headers={"Retry-After": "9999"},
+                json={"code": 429},
+            )
+        return httpx.Response(200, json={})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    with ApiClient(_creds(), http_client=http) as c:
+        c.get("/users/me")
+
+    # Capped at MAX_RETRY_DELAY_SECONDS (60s) ± jitter (0.8-1.2x) = 48-72.
+    # 60 * 1.2 = 72 is the upper bound.
+    assert sleeps[0] <= client_mod.MAX_RETRY_DELAY_SECONDS * (1.0 + client_mod.JITTER_RANGE)
+
+
+def test_request_falls_back_to_exponential_backoff_without_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two consecutive 429s with no Retry-After: backoff doubles."""
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token())
+    sleeps: list[float] = []
+    monkeypatch.setattr(client_mod.time, "sleep", lambda s: sleeps.append(s))
+
+    request_count = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        request_count["n"] += 1
+        if request_count["n"] <= 2:
+            return httpx.Response(429, json={"code": 429})
+        return httpx.Response(200, json={})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    with ApiClient(_creds(), http_client=http) as c:
+        c.get("/users/me")
+
+    assert request_count["n"] == 3  # two 429s + success
+    assert len(sleeps) == 2
+    # attempt 0: 2**0 = 1 → 0.8-1.2; attempt 1: 2**1 = 2 → 1.6-2.4
+    assert 0.8 <= sleeps[0] <= 1.2
+    assert 1.6 <= sleeps[1] <= 2.4
+
+
+def test_request_propagates_after_max_429_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If Zoom never relents, surface the 429 as ZoomApiError after
+    MAX_429_RETRIES attempts. No infinite loop."""
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token())
+    monkeypatch.setattr(client_mod.time, "sleep", lambda _s: None)
+
+    request_count = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        request_count["n"] += 1
+        return httpx.Response(429, json={"code": 429, "message": "still throttled"})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    with (
+        ApiClient(_creds(), http_client=http) as c,
+        pytest.raises(client_mod.ZoomApiError) as excinfo,
+    ):
+        c.get("/users/me")
+
+    assert excinfo.value.status_code == 429
+    # Initial attempt + MAX_429_RETRIES retries.
+    assert request_count["n"] == 1 + client_mod.MAX_429_RETRIES
+
+
+def test_request_handles_http_date_retry_after(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Retry-After can be an HTTP-date (RFC 7231)."""
+    import email.utils
+    from datetime import datetime, timedelta, timezone
+
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token())
+    sleeps: list[float] = []
+    monkeypatch.setattr(client_mod.time, "sleep", lambda s: sleeps.append(s))
+
+    target = datetime.now(timezone.utc) + timedelta(seconds=3)
+    http_date = email.utils.format_datetime(target)
+
+    request_count = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        request_count["n"] += 1
+        if request_count["n"] == 1:
+            return httpx.Response(429, headers={"Retry-After": http_date}, json={"code": 429})
+        return httpx.Response(200, json={})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    with ApiClient(_creds(), http_client=http) as c:
+        c.get("/users/me")
+
+    assert len(sleeps) == 1
+    # ~3 seconds ± jitter ± a fraction-of-a-second clock variance.
+    assert 1.5 <= sleeps[0] <= 4.5
+
+
+def test_request_does_not_retry_5xx_as_429(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 500/503 must not enter the 429 retry path — propagate immediately."""
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token())
+    sleeps: list[float] = []
+    monkeypatch.setattr(client_mod.time, "sleep", lambda s: sleeps.append(s))
+
+    request_count = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        request_count["n"] += 1
+        return httpx.Response(503, json={"code": 503, "message": "Service unavailable"})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    with (
+        ApiClient(_creds(), http_client=http) as c,
+        pytest.raises(client_mod.ZoomApiError) as excinfo,
+    ):
+        c.get("/users/me")
+
+    assert excinfo.value.status_code == 503
+    assert request_count["n"] == 1  # no retry on 503
+    assert sleeps == []
+
+
+# ---- #16 constants pinned -----------------------------------------------
+
+
+def test_max_429_retries_pinned() -> None:
+    assert client_mod.MAX_429_RETRIES == 3
+
+
+def test_max_retry_delay_pinned() -> None:
+    assert client_mod.MAX_RETRY_DELAY_SECONDS == 60.0
+
+
+def test_jitter_range_pinned() -> None:
+    assert client_mod.JITTER_RANGE == 0.2

--- a/tests/test_api_users.py
+++ b/tests/test_api_users.py
@@ -66,3 +66,36 @@ def test_get_me_is_alias_for_get_user_me() -> None:
     users.get_me(fake_client)
 
     fake_client.get.assert_called_once_with("/users/me")
+
+
+# ---- #16: list_users via paginate ---------------------------------------
+
+
+def test_list_users_yields_across_pages() -> None:
+    """list_users walks the next_page_token cursor end-to-end."""
+    pages = [
+        {"users": [{"id": "u1"}, {"id": "u2"}], "next_page_token": "tok-2"},
+        {"users": [{"id": "u3"}], "next_page_token": ""},
+    ]
+    fake_client = MagicMock()
+    fake_client.get.side_effect = pages
+
+    result = list(users.list_users(fake_client))
+
+    assert result == [{"id": "u1"}, {"id": "u2"}, {"id": "u3"}]
+    # Two GETs, both to /users with status=active.
+    assert fake_client.get.call_count == 2
+    first_call_args = fake_client.get.call_args_list[0]
+    assert first_call_args[0][0] == "/users"
+    assert first_call_args[1]["params"]["status"] == "active"
+    assert first_call_args[1]["params"]["page_size"] == 300
+
+
+def test_list_users_passes_status_filter() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"users": [], "next_page_token": ""}
+
+    list(users.list_users(fake_client, status="pending"))
+
+    params = fake_client.get.call_args_list[0][1]["params"]
+    assert params["status"] == "pending"

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,151 @@
+"""Tests for zoom_cli.api.pagination — paginate() generator helper."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import httpx
+import pytest
+from zoom_cli.api import oauth
+from zoom_cli.api import pagination as pagination_mod
+from zoom_cli.api.client import ApiClient
+from zoom_cli.auth import S2SCredentials
+
+
+def _creds() -> S2SCredentials:
+    return S2SCredentials(account_id="acc", client_id="cid", client_secret="csec")
+
+
+def _fresh_token() -> oauth.AccessToken:
+    return oauth.AccessToken(
+        value="tok",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        scopes=("user:read:list_users:admin",),
+    )
+
+
+def _api(handler, monkeypatch: pytest.MonkeyPatch) -> tuple[ApiClient, httpx.Client]:
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token())
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    return ApiClient(_creds(), http_client=http), http
+
+
+def test_paginate_single_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A response with empty next_page_token terminates after one fetch."""
+    requests_seen: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests_seen.append(dict(request.url.params))
+        return httpx.Response(
+            200,
+            json={
+                "page_size": 300,
+                "next_page_token": "",
+                "users": [{"id": "u1"}, {"id": "u2"}],
+            },
+        )
+
+    api, http = _api(handler, monkeypatch)
+    with http:
+        items = list(pagination_mod.paginate(api, "/users", item_key="users"))
+    assert items == [{"id": "u1"}, {"id": "u2"}]
+    assert len(requests_seen) == 1
+    # First request must omit next_page_token (or send empty).
+    assert requests_seen[0].get("next_page_token", "") == ""
+
+
+def test_paginate_multi_page_walks_cursor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Three pages: each request carries the prior page's next_page_token,
+    and the generator yields items in order across all pages."""
+    pages = [
+        {"users": [{"id": "u1"}, {"id": "u2"}], "next_page_token": "tok-page-2"},
+        {"users": [{"id": "u3"}], "next_page_token": "tok-page-3"},
+        {"users": [{"id": "u4"}, {"id": "u5"}], "next_page_token": ""},
+    ]
+    seen_tokens: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_tokens.append(request.url.params.get("next_page_token", ""))
+        return httpx.Response(200, json=pages[len(seen_tokens) - 1])
+
+    api, http = _api(handler, monkeypatch)
+    with http:
+        items = list(pagination_mod.paginate(api, "/users", item_key="users"))
+
+    assert items == [{"id": "u1"}, {"id": "u2"}, {"id": "u3"}, {"id": "u4"}, {"id": "u5"}]
+    # First request: empty token. Subsequent: cursor from prior response.
+    assert seen_tokens == ["", "tok-page-2", "tok-page-3"]
+
+
+def test_paginate_empty_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"users": [], "next_page_token": ""})
+
+    api, http = _api(handler, monkeypatch)
+    with http:
+        items = list(pagination_mod.paginate(api, "/users", item_key="users"))
+    assert items == []
+
+
+def test_paginate_handles_omitted_item_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Some endpoints omit the item key entirely on an empty page."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"next_page_token": ""})
+
+    api, http = _api(handler, monkeypatch)
+    with http:
+        items = list(pagination_mod.paginate(api, "/users", item_key="users"))
+    assert items == []
+
+
+def test_paginate_passes_page_size_and_user_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(dict(request.url.params))
+        return httpx.Response(200, json={"users": [], "next_page_token": ""})
+
+    api, http = _api(handler, monkeypatch)
+    with http:
+        list(
+            pagination_mod.paginate(
+                api,
+                "/users",
+                item_key="users",
+                params={"status": "active", "role_id": "admin"},
+                page_size=100,
+            )
+        )
+
+    assert captured[0]["status"] == "active"
+    assert captured[0]["role_id"] == "admin"
+    assert captured[0]["page_size"] == "100"
+
+
+def test_paginate_is_lazy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The generator must not pre-fetch; pulling one item should fetch one
+    page, not the entire dataset."""
+    pages = [
+        {"users": [{"id": "u1"}], "next_page_token": "tok-2"},
+        {"users": [{"id": "u2"}], "next_page_token": ""},
+    ]
+    fetch_count = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        n = fetch_count["n"]
+        fetch_count["n"] += 1
+        return httpx.Response(200, json=pages[n])
+
+    api, http = _api(handler, monkeypatch)
+    with http:
+        gen = pagination_mod.paginate(api, "/users", item_key="users")
+        first = next(gen)
+        # After yielding one item, only the first page should have been fetched.
+        assert fetch_count["n"] == 1
+        assert first == {"id": "u1"}
+        # Drain the rest.
+        rest = list(gen)
+        assert rest == [{"id": "u2"}]
+        assert fetch_count["n"] == 2

--- a/zoom_cli/api/client.py
+++ b/zoom_cli/api/client.py
@@ -12,19 +12,26 @@ that adds:
 - a single-shot 401 retry that force-refreshes the token and re-issues the
   request once (closes #47, partial) — covers the "Zoom revoked the token
   before our clock said it expired" race,
+- 429 / Retry-After handling with bounded retries and jitter (closes #16,
+  partial) — honours the server's ``Retry-After`` header when present,
+  falls back to exponential backoff otherwise; jitter spreads retries out
+  to avoid thundering-herd against the rate limiter,
 - a :class:`ZoomApiError` raised on non-2xx responses with the parsed
   Zoom error envelope (``{"code": ..., "message": ...}``).
 
-Out of scope here, deliberately:
+Out of scope here, deferred to issue #16 follow-up work:
 
-- Per-tier rate-limit handling and 429 retry — that's issue #16. The
-  shape of the client is stable enough that adding a token-bucket
-  decorator later will be additive.
-- Pagination helpers — folded into issue #16 alongside the limiter.
+- Per-tier token-bucket rate limiting (Light 80/s, Medium 60/s,
+  Heavy 40/s + 60k/day, Resource-intensive 20/s + 60k/day). Requires
+  per-endpoint tier mapping which is best done after more endpoints land.
 """
 
 from __future__ import annotations
 
+import email.utils
+import random
+import time
+from datetime import datetime, timezone
 from typing import Any
 
 import httpx
@@ -38,6 +45,56 @@ API_BASE_URL = "https://api.zoom.us/v2"
 #: Default request timeout in seconds. Higher than the OAuth timeout
 #: because some endpoints (recordings list, dashboards) are slower.
 DEFAULT_TIMEOUT_SECONDS = 30.0
+
+#: Maximum number of 429 retries before propagating. After ``MAX_429_RETRIES``
+#: attempts the client gives up and raises :class:`ZoomApiError`.
+MAX_429_RETRIES = 3
+
+#: Cap on any single retry sleep; protects against ``Retry-After`` headers
+#: that demand absurd waits (and against pathological exponential backoff).
+MAX_RETRY_DELAY_SECONDS = 60.0
+
+#: Jitter range applied to every computed retry delay (multiplier between
+#: ``1 - JITTER_RANGE`` and ``1 + JITTER_RANGE``). Spreads retries out
+#: across cooperating processes so they don't all thunder back at once.
+JITTER_RANGE = 0.2
+
+
+def _compute_retry_delay(response: httpx.Response, attempt: int) -> float:
+    """Compute the seconds-to-sleep before retrying a 429 response.
+
+    Honours ``Retry-After`` first (RFC 7231 — either delta-seconds or an
+    HTTP-date). Falls back to exponential backoff (``2 ** attempt``) when
+    the header is missing or unparseable. Always caps at
+    :data:`MAX_RETRY_DELAY_SECONDS` and applies ±:data:`JITTER_RANGE`
+    multiplicative jitter.
+    """
+    retry_after = response.headers.get("Retry-After", "").strip()
+    base_delay: float | None = None
+
+    if retry_after:
+        # Delta-seconds form: a non-negative integer (or float).
+        try:
+            base_delay = float(retry_after)
+        except ValueError:
+            # HTTP-date form: parse with email.utils (handles RFC 7231).
+            try:
+                target = email.utils.parsedate_to_datetime(retry_after)
+                if target is not None:
+                    if target.tzinfo is None:
+                        target = target.replace(tzinfo=timezone.utc)
+                    base_delay = max(0.0, (target - datetime.now(timezone.utc)).total_seconds())
+            except (ValueError, TypeError):
+                pass
+
+    if base_delay is None:
+        base_delay = float(2**attempt)
+
+    base_delay = min(base_delay, MAX_RETRY_DELAY_SECONDS)
+    # `random.random()` is fine here — this is retry-jitter spreading,
+    # not a security boundary; predictability would not let an attacker
+    # influence anything.
+    return base_delay * (1.0 - JITTER_RANGE + random.random() * 2 * JITTER_RANGE)  # noqa: S311
 
 
 class ZoomApiError(RuntimeError):
@@ -142,17 +199,37 @@ class ApiClient:
     ) -> dict[str, Any]:
         """Issue an authenticated request and return the parsed JSON body.
 
-        On a 401, force-refresh the token and retry once (closes #47,
-        partial) — covers the case where Zoom revoked the token before
-        our local clock said it expired (rotation, scope change). A second
-        401 propagates as :class:`ZoomApiError` so we never loop.
+        Retry behaviour:
+        - **401**: force-refresh the token and retry once (closes #47,
+          partial) — covers the case where Zoom revoked the token before
+          our local clock said it expired (rotation, scope change). A
+          second 401 propagates as :class:`ZoomApiError`.
+        - **429**: honour ``Retry-After`` (delta-seconds or HTTP-date),
+          sleep + retry, up to :data:`MAX_429_RETRIES` attempts. Falls
+          back to exponential backoff if the header is missing. Adds
+          jitter so cooperating processes don't thundering-herd back to
+          Zoom together. After ``MAX_429_RETRIES`` we propagate the 429
+          as :class:`ZoomApiError` so the caller can decide what to do.
 
-        Raises :class:`ZoomApiError` for any non-2xx response.
+        Raises :class:`ZoomApiError` for any non-2xx response that survives
+        the retry policy above.
         """
         url = f"{API_BASE_URL}{path}" if path.startswith("/") else f"{API_BASE_URL}/{path}"
         response = self._send(method, url, params=params, json=json)
         if response.status_code == 401:
             response = self._send(method, url, params=params, json=json, force_refresh=True)
+
+        # 429 handling — bounded retries with Retry-After + jitter.
+        # Closes #16 (partial; per-tier token bucket deferred to a
+        # follow-up). The 401 retry above runs first because a 401-then-
+        # 429 sequence still benefits from the token refresh.
+        attempt = 0
+        while response.status_code == 429 and attempt < MAX_429_RETRIES:
+            delay = _compute_retry_delay(response, attempt)
+            time.sleep(delay)
+            attempt += 1
+            response = self._send(method, url, params=params, json=json)
+
         if response.status_code >= 400:
             try:
                 payload = response.json()

--- a/zoom_cli/api/pagination.py
+++ b/zoom_cli/api/pagination.py
@@ -1,0 +1,78 @@
+"""Pagination helper for Zoom REST endpoints.
+
+Most Zoom list endpoints return a payload shaped like::
+
+    {
+      "page_size": 30,
+      "next_page_token": "abc...",
+      "users": [ {...}, {...}, ... ]
+    }
+
+An empty ``next_page_token`` means "no more pages." :func:`paginate` walks
+the cursor for you and yields each item across all pages, so callers can
+write straightforward generator pipelines instead of pagination boilerplate.
+
+Closes #16 (partial) — the per-tier token-bucket rate limiter is a
+follow-up; this module is the pagination half of that issue.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from zoom_cli.api.client import ApiClient
+
+#: Default items per page. Zoom caps vary per endpoint (commonly 300, some
+#: are 100 or 30); pass a lower ``page_size`` for endpoints with smaller
+#: caps. Higher values minimize round-trips when the caller iterates the
+#: full result.
+DEFAULT_PAGE_SIZE = 300
+
+
+def paginate(
+    client: ApiClient,
+    path: str,
+    *,
+    item_key: str,
+    params: dict[str, Any] | None = None,
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> Iterator[dict[str, Any]]:
+    """Yield each item from a paginated Zoom endpoint across all pages.
+
+    Args:
+        client: Authenticated :class:`~zoom_cli.api.client.ApiClient`.
+        path: Endpoint path (relative to the API base — e.g. ``"/users"``).
+        item_key: The key in each response that holds the page's items
+            (``"users"`` for ``/users``, ``"meetings"`` for ``/meetings``,
+            etc.). Required because Zoom uses different keys per endpoint.
+        params: Base query parameters merged into every page request.
+        page_size: Items per page. See :data:`DEFAULT_PAGE_SIZE`.
+
+    Yields:
+        Each item dict, in the order Zoom returns them. The generator
+        terminates when the server returns an empty ``next_page_token``.
+
+    Each request goes through :meth:`ApiClient.request`, so 401 token
+    refresh and 429 / Retry-After backoff happen transparently. A
+    :class:`~zoom_cli.api.client.ZoomApiError` from any single page
+    propagates immediately and stops iteration.
+
+    The generator is lazy — pages are fetched on demand as the caller
+    consumes items. Materialise into a list with ``list(paginate(...))``
+    if you need all results before processing.
+    """
+    page_params = dict(params or {})
+    page_params["page_size"] = page_size
+    next_page_token = ""
+
+    while True:
+        page_params["next_page_token"] = next_page_token
+        page = client.get(path, params=page_params)
+        # `.get(item_key, [])` rather than `[item_key]` — empty pages
+        # (zero items) return either an empty list or the key omitted
+        # entirely depending on endpoint. Both are valid "no items here."
+        yield from page.get(item_key, [])
+        next_page_token = page.get("next_page_token", "") or ""
+        if not next_page_token:
+            return

--- a/zoom_cli/api/users.py
+++ b/zoom_cli/api/users.py
@@ -18,17 +18,22 @@ API shape:
     #14 flagged that hardcoding the implicit "me" principal would make
     later target-user commands awkward).
 
-Out of scope here, deferred to issue #14:
-- ``GET /users`` listing with pagination.
+    :func:`list_users` paginates across the ``GET /users`` endpoint via
+    :func:`zoom_cli.api.pagination.paginate` (closes #16 first consumer).
+
+Still deferred to issue #14:
+- ``zoom users create`` / ``delete`` / ``settings`` CLI commands.
 - ``--json`` flag for raw output.
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from typing import Any
 from urllib.parse import quote
 
 from zoom_cli.api.client import ApiClient
+from zoom_cli.api.pagination import DEFAULT_PAGE_SIZE, paginate
 
 
 def get_user(client: ApiClient, user_id: str = "me") -> dict[str, Any]:
@@ -51,3 +56,34 @@ def get_me(client: ApiClient) -> dict[str, Any]:
     that imported it from PR #31. Prefer :func:`get_user` in new code.
     """
     return get_user(client, "me")
+
+
+def list_users(
+    client: ApiClient,
+    *,
+    status: str = "active",
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> Iterator[dict[str, Any]]:
+    """``GET /users`` — yield every user record across all pages.
+
+    Args:
+        client: Authenticated :class:`ApiClient`.
+        status: Account user status filter (``active``, ``inactive``,
+            ``pending``). Default matches Zoom's UI default.
+        page_size: Items per page; see :data:`DEFAULT_PAGE_SIZE`. The
+            ``/users`` endpoint accepts up to 300.
+
+    Yields:
+        One user dict per record. Lazy — additional pages are fetched
+        only as the caller iterates.
+
+    Required scopes: ``user:read:list_users:admin`` (or finer-grained
+    equivalent for the listed account).
+    """
+    return paginate(
+        client,
+        "/users",
+        item_key="users",
+        params={"status": status},
+        page_size=page_size,
+    )


### PR DESCRIPTION
## Summary

Closes #16 in two of three deliverables. Per-tier token-bucket rate limiting (Light/Medium/Heavy/Resource-intensive) is intentionally deferred to a follow-up so the per-endpoint tier mapping isn't speculative.

| Deliverable | Status |
|---|---|
| 429 / Retry-After backoff with jitter + bounded retries | ✅ landed |
| `paginate(client, path, *, item_key, ...)` generator helper | ✅ landed |
| `users.list_users()` — first paginated endpoint | ✅ landed |
| Per-tier token-bucket rate limiting (80/60/40/20 per second) | 🔜 follow-up |

## Changes

### `zoom_cli/api/client.py` — 429 handling

`ApiClient.request` now retries 429 responses up to `MAX_429_RETRIES` (3). New `_compute_retry_delay` helper:

- Honours `Retry-After` (delta-seconds **or** HTTP-date per RFC 7231).
- Falls back to exponential backoff (`2^attempt`) when the header is missing.
- Caps at `MAX_RETRY_DELAY_SECONDS` (60s) so a pathological `Retry-After: 9999` doesn't wedge the client.
- Applies ±20% jitter (`JITTER_RANGE`) so cooperating processes don't thunder back together.

Non-429 4xx/5xx responses **don't** enter the retry path — a 503 stays a 503; a 401 still uses its own one-shot refresh from #47. After exhaustion, the 429 propagates as `ZoomApiError` so callers can decide what to do.

### `zoom_cli/api/pagination.py` — new module

```python
def paginate(
    client: ApiClient,
    path: str,
    *,
    item_key: str,
    params: dict[str, Any] | None = None,
    page_size: int = DEFAULT_PAGE_SIZE,
) -> Iterator[dict[str, Any]]
```

Generator that walks Zoom's `next_page_token` cursor, yielding each item across all pages. Lazy — pages are fetched on demand. `item_key` is required because Zoom uses different keys per endpoint (`users` for `/users`, `meetings` for `/meetings`).

### `zoom_cli/api/users.py` — first consumer

```python
def list_users(client, *, status="active", page_size=300) -> Iterator[dict]
```

End-to-end proof that `paginate` works with `ApiClient`. No CLI surface yet — the `zoom users list` command lands with #14 follow-up work.

## Tests (+18 new)

| File | New | Covers |
|---|---|---|
| `tests/test_api_client.py` | +9 | 429 with `Retry-After: <seconds>`, HTTP-date `Retry-After`, missing header (exponential backoff), pathological `Retry-After` capped at max, max-retry exhaustion propagates, 503 not retried, three constants pinned |
| `tests/test_pagination.py` | +6 | Single page, multi-page cursor walk (3 pages), empty result, omitted item key, `params` + `page_size` forwarding, lazy fetch (only fetch first page until consumer asks for second) |
| `tests/test_api_users.py` | +2 | `list_users` walks pages and forwards `status` filter |

All `time.sleep` calls are monkeypatched so the 429 tests don't actually wait. All HTTP via `httpx.MockTransport` — no socket I/O, no Zoom API calls (the project's no-Zoom-API-keys deny rule from PR #33 also blocks them at the permission layer).

## Verification

```
ruff check .          # All checks passed!
ruff format --check . # 23 files already formatted
mypy                  # Success: no issues found in 11 source files
pytest -q             # 250 passed (was 232; +18)
```

## Cross-links

- #47 (Codex review) explicitly deferred 429/backoff to this issue. The 401 retry from #47 stays in place; the new 429 retry is layered after it (so a 401-then-429 sequence still benefits from the token refresh).
- The deferred per-tier rate limiting will need: per-endpoint tier mapping table, in-memory token bucket per tier, `acquire()` before every `_send`, daily-reset for the heavy/resource-intensive 60k/day cap. That all benefits from having more endpoints in flight first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)