### PR TITLE
feat(cli): close #14 (read-only) — zoom users list + get commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Bootstrap PR: [#25](https://github.com/jordan8037310/zoom-cli/pull/25) — closes #4, #7, #8 and partially addresses #9, #10.
 > Codex review follow-ups (PR #32): closes #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47.
 > CC security setup (PR #33): adds `.claude/settings.json`, `SECURITY.md`, `LOCAL-SECURITY.md`, `TASKS.md`, and three FACET developer skills.
-> Rate-limit + pagination (this branch): closes #16 (partial — per-tier token bucket deferred). 429/Retry-After backoff with jitter; `paginate()` generator helper; `users.list_users()` as the first paginated endpoint.
+> Rate-limit + pagination (PR #48): closes #16 (partial — per-tier token bucket tracked at #49). 429/Retry-After backoff with jitter; `paginate()` generator helper; `users.list_users()` as the first paginated endpoint.
+> Users CLI surface (this branch): closes #14 (read-only piece). New `zoom users list` and `zoom users get <user-id>` commands.
+
+### Added (issue #14, read-only)
+- New `zoom users list` CLI command — paginates `GET /users` via the helper from PR #48. Tab-separated output (`user_id\temail\ttype\tstatus`) with a header line; pipes cleanly into `cut`/`awk`/`column`. `--status active|inactive|pending` (default `active`) and `--page-size` (1–300, default 300) flags.
+- New `zoom users get <user-id>` CLI command — `GET /users/<user-id>`. Accepts a Zoom user ID or email address. Same field-per-line output format as `zoom users me`.
+- Refactored `__main__.py`: extracted `_print_user_profile`, `_load_creds_or_exit`, and `_exit_on_api_error` helpers so the three users commands share their boilerplate. The original `zoom users me` behaviour is unchanged.
+
+### Deferred (issue #14 follow-up)
+- `zoom users create` / `delete` / `settings` (write commands). Each needs separate confirmation-flow design (e.g. `--yes` for delete, scope warnings for create) so they're better as a separate PR.
+
+
 
 ### Added (issue #16)
 - New `zoom_cli/api/pagination.py` with `paginate(client, path, *, item_key, params, page_size)` generator. Walks Zoom's `next_page_token` cursor, yielding each item across all pages. Lazy — pages are fetched on demand.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -741,3 +741,154 @@ def test_s2s_set_translates_keyring_save_error(
     assert "may be locked" in result.output.lower()
     # Restore for fixture teardown.
     monkeypatch.setattr(keyring, "set_password", real_set)
+
+
+# ---- #14: zoom users get / list CLI ------------------------------------
+
+
+def test_users_get_bails_when_no_credentials(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["users", "get", "u-123"])
+    assert result.exit_code == 1
+    assert "No Server-to-Server" in result.output
+
+
+def test_users_get_prints_well_known_fields(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+
+    captured = {}
+
+    def fake_get_user(_client, user_id):
+        captured["user_id"] = user_id
+        return {
+            "id": "u-target",
+            "email": "bob@example.com",
+            "display_name": "Bob Example",
+            "type": 1,
+            "status": "active",
+        }
+
+    monkeypatch.setattr(main_mod.users, "get_user", fake_get_user)
+    monkeypatch.setattr(
+        main_mod.oauth,
+        "fetch_access_token",
+        lambda *_a, **_k: _fake_access_token(),
+    )
+
+    result = runner.invoke(main, ["users", "get", "u-target"])
+    assert result.exit_code == 0, result.output
+    assert captured["user_id"] == "u-target"
+    assert "bob@example.com" in result.output
+    assert "Bob Example" in result.output
+
+
+def test_users_get_passes_email_through_unmodified(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Zoom accepts an email as `user_id` for `GET /users/<email>`."""
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+
+    captured = {}
+
+    def fake_get_user(_client, user_id):
+        captured["user_id"] = user_id
+        return {"id": "u-1", "email": "alice@example.com"}
+
+    monkeypatch.setattr(main_mod.users, "get_user", fake_get_user)
+    monkeypatch.setattr(
+        main_mod.oauth, "fetch_access_token", lambda *_a, **_k: _fake_access_token()
+    )
+
+    result = runner.invoke(main, ["users", "get", "alice@example.com"])
+    assert result.exit_code == 0, result.output
+    assert captured["user_id"] == "alice@example.com"
+
+
+def test_users_list_bails_when_no_credentials(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["users", "list"])
+    assert result.exit_code == 1
+    assert "No Server-to-Server" in result.output
+
+
+def test_users_list_prints_tab_separated_with_header(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+
+    captured = {}
+
+    def fake_list_users(_client, *, status, page_size):
+        captured["status"] = status
+        captured["page_size"] = page_size
+        return iter(
+            [
+                {"id": "u-1", "email": "alice@example.com", "type": 1, "status": "active"},
+                {"id": "u-2", "email": "bob@example.com", "type": 2, "status": "active"},
+            ]
+        )
+
+    monkeypatch.setattr(main_mod.users, "list_users", fake_list_users)
+    monkeypatch.setattr(
+        main_mod.oauth, "fetch_access_token", lambda *_a, **_k: _fake_access_token()
+    )
+
+    result = runner.invoke(main, ["users", "list"])
+    assert result.exit_code == 0, result.output
+
+    lines = result.output.strip().split("\n")
+    assert lines[0] == "user_id\temail\ttype\tstatus"
+    assert lines[1] == "u-1\talice@example.com\t1\tactive"
+    assert lines[2] == "u-2\tbob@example.com\t2\tactive"
+
+    # Default filter values flow through.
+    assert captured["status"] == "active"
+    assert captured["page_size"] == 300
+
+
+def test_users_list_forwards_status_and_page_size(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+
+    captured = {}
+
+    def fake_list_users(_client, *, status, page_size):
+        captured["status"] = status
+        captured["page_size"] = page_size
+        return iter([])
+
+    monkeypatch.setattr(main_mod.users, "list_users", fake_list_users)
+    monkeypatch.setattr(
+        main_mod.oauth, "fetch_access_token", lambda *_a, **_k: _fake_access_token()
+    )
+
+    result = runner.invoke(main, ["users", "list", "--status", "pending", "--page-size", "50"])
+    assert result.exit_code == 0, result.output
+    assert captured["status"] == "pending"
+    assert captured["page_size"] == 50
+
+
+def test_users_list_rejects_invalid_status(runner: CliRunner) -> None:
+    """click.Choice should reject anything outside active/inactive/pending."""
+    result = runner.invoke(main, ["users", "list", "--status", "garbage"])
+    assert result.exit_code != 0
+    assert "garbage" in result.output.lower() or "invalid" in result.output.lower()
+
+
+def test_users_list_rejects_oversize_page(runner: CliRunner) -> None:
+    """click.IntRange should cap at 300 (Zoom's per-endpoint maximum)."""
+    result = runner.invoke(main, ["users", "list", "--page-size", "5000"])
+    assert result.exit_code != 0

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -328,33 +328,113 @@ def users_cmd():
     """Group for ``zoom users ...``."""
 
 
-@users_cmd.command("me", help="Print the authenticated user's profile (GET /users/me).")
-@_translate_keyring_errors
-def users_me():
+# Fields printed by `zoom users me` and `zoom users get`. The full Zoom
+# user payload has many dozen fields; users who want all of them can pipe
+# the underlying call through `jq` once we add `--json` (separate issue).
+_USER_PROFILE_FIELDS = ("display_name", "email", "id", "account_id", "type", "status")
+
+
+def _print_user_profile(profile: dict) -> None:
+    """Print the well-known subset of a Zoom user payload, one field per line."""
+    for field in _USER_PROFILE_FIELDS:
+        if field in profile:
+            click.echo(f"{field}: {profile[field]}")
+
+
+def _load_creds_or_exit():
+    """Load S2S creds, exit cleanly with a friendly message if not configured."""
     creds = auth.load_s2s_credentials()
     if creds is None:
         click.echo("No Server-to-Server OAuth credentials saved. Run `zoom auth s2s set` first.")
         raise click.exceptions.Exit(code=1)
+    return creds
 
+
+def _exit_on_api_error(exc: Exception) -> None:
+    """Print a typed message for Zoom API / network errors, then exit 1.
+
+    Centralises the three-way error handling that every API CLI command
+    needs: ``ZoomAuthError`` (HTTP from token endpoint), ``ZoomApiError``
+    (HTTP from the API endpoint), ``httpx.HTTPError`` (network / TLS /
+    timeout). Callers should ``raise`` the result so type checkers and
+    readers see the control flow.
+    """
+    if isinstance(exc, oauth.ZoomAuthError):
+        click.echo(f"Authentication failed (HTTP {exc.status_code}): {exc}")
+    elif isinstance(exc, ZoomApiError):
+        click.echo(f"Zoom API error (HTTP {exc.status_code}): {exc}")
+    elif isinstance(exc, httpx.HTTPError):
+        click.echo(f"Could not reach Zoom API: {exc}")
+    else:
+        # Should never happen — caller filters before delegating.
+        raise exc
+    raise click.exceptions.Exit(code=1) from exc
+
+
+@users_cmd.command("me", help="Print the authenticated user's profile (GET /users/me).")
+@_translate_keyring_errors
+def users_me():
+    creds = _load_creds_or_exit()
     try:
         with ApiClient(creds) as client:
             profile = users.get_me(client)
-    except oauth.ZoomAuthError as exc:
-        click.echo(f"Authentication failed (HTTP {exc.status_code}): {exc}")
-        raise click.exceptions.Exit(code=1) from exc
-    except ZoomApiError as exc:
-        click.echo(f"Zoom API error (HTTP {exc.status_code}): {exc}")
-        raise click.exceptions.Exit(code=1) from exc
-    except httpx.HTTPError as exc:
-        click.echo(f"Could not reach Zoom API: {exc}")
-        raise click.exceptions.Exit(code=1) from exc
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    _print_user_profile(profile)
 
-    # Print a few well-known fields. The full payload is many dozen
-    # fields; users who want all of them can pipe the underlying call
-    # through `jq` once we add `--json` (out of scope for this PR).
-    for field in ("display_name", "email", "id", "account_id", "type", "status"):
-        if field in profile:
-            click.echo(f"{field}: {profile[field]}")
+
+@users_cmd.command("get", help="Print a specific user's profile (GET /users/<user-id>).")
+@click.argument("user_id")
+@_translate_keyring_errors
+def users_get(user_id):
+    """``user_id`` is either a Zoom user ID or an email address. Closes #14
+    (read-only piece) — write commands (create/delete/settings) are a
+    follow-up that needs separate confirmation-flow design."""
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            profile = users.get_user(client, user_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    _print_user_profile(profile)
+
+
+@users_cmd.command("list", help="List users in the account (paginates GET /users).")
+@click.option(
+    "--status",
+    type=click.Choice(["active", "inactive", "pending"]),
+    default="active",
+    show_default=True,
+    help="Filter by Zoom user status.",
+)
+@click.option(
+    "--page-size",
+    type=click.IntRange(1, 300),
+    default=300,
+    show_default=True,
+    help="Items per page request (Zoom caps `/users` at 300).",
+)
+@_translate_keyring_errors
+def users_list(status, page_size):
+    """Output is tab-separated (id\\temail\\ttype\\tstatus) so it pipes into
+    ``cut``/``awk``/``column``. Pagination is handled transparently;
+    multi-page accounts may take a few seconds.
+
+    Closes #14 (read-only piece) — uses the ``paginate()`` helper from
+    PR #48 / issue #16."""
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            click.echo("user_id\temail\ttype\tstatus")
+            for user in users.list_users(client, status=status, page_size=page_size):
+                click.echo(
+                    f"{user.get('id', '')}\t"
+                    f"{user.get('email', '')}\t"
+                    f"{user.get('type', '')}\t"
+                    f"{user.get('status', '')}"
+                )
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes the read-only half of #14. Adds two new CLI commands that build directly on the helpers from PR #32 (`get_user`) and PR #48 (`list_users` + `paginate`).

| Command | Underlying helper | Endpoint |
|---|---|---|
| `zoom users list` | `users.list_users()` → `paginate()` | `GET /users` |
| `zoom users get <user-id>` | `users.get_user(user_id)` | `GET /users/<user-id>` |

The write half (`create` / `delete` / `settings`) is **deferred** — each needs its own confirmation-flow design and the design questions deserve a separate PR.

## What's new

### `zoom users list`

Tab-separated output with one header row so it pipes cleanly into `cut`/`awk`/`column`:

```
$ zoom users list --status active
user_id        email                type    status
abc123def456   alice@example.com    1       active
xyz789ghi012   bob@example.com      2       active
...
```

Pagination via the helper from PR #48 is transparent — accounts with thousands of users may take a few seconds to drain but never duplicate or drop records. The 429 retry from PR #48 also kicks in if Zoom throttles us mid-walk.

**Flags:**
- `--status` — `active` / `inactive` / `pending` (default `active`). Validated by `click.Choice`.
- `--page-size` — 1–300 (default 300). Capped at Zoom's per-endpoint maximum via `click.IntRange`.

### `zoom users get <user-id>`

Accepts a Zoom user ID **or** an email address — Zoom treats both as valid path params on `GET /users/<user-id>`. Same six-field output as `zoom users me` so they're visually consistent. The path segment is percent-encoded by `users.get_user()` (from #36) so caller-supplied IDs can't inject path metacharacters.

### Refactor: shared helpers in `__main__.py`

Extracted three small helpers so the three users commands (`me`, `get`, `list`) share their boilerplate:

- `_print_user_profile(profile)` — six-field output.
- `_load_creds_or_exit()` — load + bail with the standard friendly message.
- `_exit_on_api_error(exc)` — typed translation for `ZoomAuthError` / `ZoomApiError` / `httpx.HTTPError`.

`zoom users me` now uses the same helpers; behaviour unchanged.

## Tests (+8 new)

| Test | Covers |
|---|---|
| `test_users_get_bails_when_no_credentials` | exit 1 + friendly message |
| `test_users_get_prints_well_known_fields` | passes user_id, prints six fields |
| `test_users_get_passes_email_through_unmodified` | email-as-id still works |
| `test_users_list_bails_when_no_credentials` | exit 1 + friendly message |
| `test_users_list_prints_tab_separated_with_header` | header + TSV format, default flag values |
| `test_users_list_forwards_status_and_page_size` | `--status pending --page-size 50` |
| `test_users_list_rejects_invalid_status` | `click.Choice` rejects `garbage` |
| `test_users_list_rejects_oversize_page` | `click.IntRange` rejects `5000` |

## Verification

```
ruff check .          # All checks passed!
ruff format --check . # 23 files already formatted
mypy                  # Success: no issues found in 11 source files
pytest -q             # 258 passed (was 250; +8)
```

## Deferred to issue #14 follow-up

- `zoom users create` — needs `--type` validation + scope warnings (creating users requires `user:write:admin`).
- `zoom users delete` — needs `--yes` / `--dry-run` (mirroring the pattern from `zoom rm`).
- `zoom users settings` — needs design for what's read-only vs settable, and how to surface the (massive) settings payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)