### PR TITLE
feat(api,cli): close #13 (read-only) — zoom meetings list + get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Codex review follow-ups (PR #32): closes #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47.
 > CC security setup (PR #33): adds `.claude/settings.json`, `SECURITY.md`, `LOCAL-SECURITY.md`, `TASKS.md`, and three FACET developer skills.
 > Rate-limit + pagination (PR #48): closes #16 (partial — per-tier token bucket tracked at #49). 429/Retry-After backoff with jitter; `paginate()` generator helper; `users.list_users()` as the first paginated endpoint.
-> Users CLI surface (this branch): closes #14 (read-only piece). New `zoom users list` and `zoom users get <user-id>` commands.
+> Users CLI surface (PR #50): closes #14 (read-only piece). New `zoom users list` and `zoom users get <user-id>` commands.
+> Meetings CLI surface (this branch): closes #13 (read-only piece). New `zoom meetings list` and `zoom meetings get <meeting-id>` commands; `zoom_cli/api/meetings.py` mirrors the structure of `users.py`.
 
 ### Added (issue #14, read-only)
 - New `zoom users list` CLI command — paginates `GET /users` via the helper from PR #48. Tab-separated output (`user_id\temail\ttype\tstatus`) with a header line; pipes cleanly into `cut`/`awk`/`column`. `--status active|inactive|pending` (default `active`) and `--page-size` (1–300, default 300) flags.

--- a/tests/test_api_meetings.py
+++ b/tests/test_api_meetings.py
@@ -1,0 +1,102 @@
+"""Tests for zoom_cli.api.meetings — Meetings endpoint helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from zoom_cli.api import meetings
+
+
+def test_get_meeting_targets_correct_path() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"id": 123, "topic": "Daily standup"}
+
+    result = meetings.get_meeting(fake_client, 123)
+
+    fake_client.get.assert_called_once_with("/meetings/123")
+    assert result == {"id": 123, "topic": "Daily standup"}
+
+
+def test_get_meeting_accepts_string_id() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {}
+
+    meetings.get_meeting(fake_client, "98765")
+
+    fake_client.get.assert_called_once_with("/meetings/98765")
+
+
+def test_get_meeting_url_encodes_special_chars() -> None:
+    """Defense-in-depth: even if a future caller passes untrusted input,
+    path metacharacters can't break out of the segment."""
+    fake_client = MagicMock()
+    fake_client.get.return_value = {}
+
+    meetings.get_meeting(fake_client, "evil/../admin?x=1")
+
+    arg = fake_client.get.call_args[0][0]
+    assert "/.." not in arg
+    assert "?" not in arg
+    assert "%2F" in arg
+
+
+def test_list_meetings_default_user_is_me() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"meetings": [], "next_page_token": ""}
+
+    list(meetings.list_meetings(fake_client))
+
+    fake_client.get.assert_called_once_with(
+        "/users/me/meetings",
+        params={"type": "scheduled", "page_size": 300, "next_page_token": ""},
+    )
+
+
+def test_list_meetings_walks_pagination_cursor() -> None:
+    fake_client = MagicMock()
+    fake_client.get.side_effect = [
+        {"meetings": [{"id": 1}, {"id": 2}], "next_page_token": "tok-2"},
+        {"meetings": [{"id": 3}], "next_page_token": ""},
+    ]
+
+    result = list(meetings.list_meetings(fake_client))
+
+    assert result == [{"id": 1}, {"id": 2}, {"id": 3}]
+    assert fake_client.get.call_count == 2
+
+
+def test_list_meetings_forwards_user_id_and_type() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"meetings": [], "next_page_token": ""}
+
+    list(meetings.list_meetings(fake_client, user_id="user-42", meeting_type="upcoming"))
+
+    call = fake_client.get.call_args_list[0]
+    assert call[0][0] == "/users/user-42/meetings"
+    assert call[1]["params"]["type"] == "upcoming"
+
+
+def test_list_meetings_url_encodes_user_id() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"meetings": [], "next_page_token": ""}
+
+    list(meetings.list_meetings(fake_client, user_id="alice@example.com"))
+
+    call_path = fake_client.get.call_args_list[0][0][0]
+    assert call_path == "/users/alice%40example.com/meetings"
+
+
+@pytest.mark.parametrize("bad_type", ["bogus", "", "deleted", "scheduled "])
+def test_list_meetings_rejects_unknown_type(bad_type: str) -> None:
+    fake_client = MagicMock()
+    with pytest.raises(ValueError, match="meeting_type"):
+        list(meetings.list_meetings(fake_client, meeting_type=bad_type))
+
+
+def test_allowed_list_types_constant_pinned() -> None:
+    """Future renames would silently change CLI behaviour — pin the set."""
+    assert "scheduled" in meetings.ALLOWED_LIST_TYPES
+    assert "live" in meetings.ALLOWED_LIST_TYPES
+    assert "upcoming" in meetings.ALLOWED_LIST_TYPES
+    assert "previous_meetings" in meetings.ALLOWED_LIST_TYPES

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -892,3 +892,158 @@ def test_users_list_rejects_oversize_page(runner: CliRunner) -> None:
     """click.IntRange should cap at 300 (Zoom's per-endpoint maximum)."""
     result = runner.invoke(main, ["users", "list", "--page-size", "5000"])
     assert result.exit_code != 0
+
+
+# ---- #13 (read-only): zoom meetings get / list CLI ----------------------
+
+
+def test_meetings_get_bails_when_no_credentials(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["meetings", "get", "12345"])
+    assert result.exit_code == 1
+    assert "No Server-to-Server" in result.output
+
+
+def test_meetings_get_prints_well_known_fields(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+
+    captured = {}
+
+    def fake_get_meeting(_client, meeting_id):
+        captured["meeting_id"] = meeting_id
+        return {
+            "id": 12345,
+            "topic": "Daily standup",
+            "type": 2,
+            "status": "started",
+            "start_time": "2026-04-28T15:00:00Z",
+            "duration": 30,
+            "timezone": "UTC",
+            "host_email": "alice@example.com",
+            "join_url": "https://zoom.us/j/12345",
+            # Fields we don't print:
+            "agenda": "🚀 launch",
+            "settings": {"approval_type": 0},
+        }
+
+    monkeypatch.setattr(main_mod.meetings, "get_meeting", fake_get_meeting)
+    monkeypatch.setattr(
+        main_mod.oauth, "fetch_access_token", lambda *_a, **_k: _fake_access_token()
+    )
+
+    result = runner.invoke(main, ["meetings", "get", "12345"])
+    assert result.exit_code == 0, result.output
+    assert captured["meeting_id"] == "12345"
+    assert "Daily standup" in result.output
+    assert "alice@example.com" in result.output
+    assert "agenda" not in result.output  # not in the printed subset
+    assert "settings" not in result.output
+
+
+def test_meetings_list_bails_when_no_credentials(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["meetings", "list"])
+    assert result.exit_code == 1
+    assert "No Server-to-Server" in result.output
+
+
+def test_meetings_list_prints_tab_separated_with_header(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+
+    captured = {}
+
+    def fake_list_meetings(_client, *, user_id, meeting_type, page_size):
+        captured["user_id"] = user_id
+        captured["meeting_type"] = meeting_type
+        captured["page_size"] = page_size
+        return iter(
+            [
+                {
+                    "id": 11,
+                    "topic": "M1",
+                    "type": 2,
+                    "start_time": "2026-04-28T10:00:00Z",
+                    "duration": 30,
+                },
+                {
+                    "id": 22,
+                    "topic": "M2",
+                    "type": 8,
+                    "start_time": "2026-04-29T11:00:00Z",
+                    "duration": 60,
+                },
+            ]
+        )
+
+    monkeypatch.setattr(main_mod.meetings, "list_meetings", fake_list_meetings)
+    monkeypatch.setattr(
+        main_mod.oauth, "fetch_access_token", lambda *_a, **_k: _fake_access_token()
+    )
+
+    result = runner.invoke(main, ["meetings", "list"])
+    assert result.exit_code == 0, result.output
+    lines = result.output.strip().split("\n")
+    assert lines[0] == "id\ttopic\ttype\tstart_time\tduration"
+    assert lines[1] == "11\tM1\t2\t2026-04-28T10:00:00Z\t30"
+    assert lines[2] == "22\tM2\t8\t2026-04-29T11:00:00Z\t60"
+
+    # Defaults flow through.
+    assert captured["user_id"] == "me"
+    assert captured["meeting_type"] == "scheduled"
+    assert captured["page_size"] == 300
+
+
+def test_meetings_list_forwards_user_id_type_page_size(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+
+    captured = {}
+
+    def fake_list_meetings(_client, *, user_id, meeting_type, page_size):
+        captured.update({"user_id": user_id, "meeting_type": meeting_type, "page_size": page_size})
+        return iter([])
+
+    monkeypatch.setattr(main_mod.meetings, "list_meetings", fake_list_meetings)
+    monkeypatch.setattr(
+        main_mod.oauth, "fetch_access_token", lambda *_a, **_k: _fake_access_token()
+    )
+
+    result = runner.invoke(
+        main,
+        [
+            "meetings",
+            "list",
+            "--user-id",
+            "alice@example.com",
+            "--type",
+            "live",
+            "--page-size",
+            "50",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["user_id"] == "alice@example.com"
+    assert captured["meeting_type"] == "live"
+    assert captured["page_size"] == 50
+
+
+def test_meetings_list_rejects_unknown_type(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["meetings", "list", "--type", "garbage"])
+    assert result.exit_code != 0
+
+
+def test_meetings_list_rejects_oversize_page(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["meetings", "list", "--page-size", "5000"])
+    assert result.exit_code != 0

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -8,7 +8,7 @@ import questionary
 from click_default_group import DefaultGroup
 
 from zoom_cli import auth
-from zoom_cli.api import oauth, users
+from zoom_cli.api import meetings, oauth, users
 from zoom_cli.api.client import ApiClient, ZoomApiError
 from zoom_cli.commands import (
     _edit,
@@ -432,6 +432,104 @@ def users_list(status, page_size):
                     f"{user.get('email', '')}\t"
                     f"{user.get('type', '')}\t"
                     f"{user.get('status', '')}"
+                )
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+
+
+# ---- Zoom Meetings REST API ---------------------------------------------
+
+
+@main.group(
+    "meetings",
+    help="Zoom Meetings API (https://developers.zoom.us/docs/api/meetings/).",
+)
+def meetings_cmd():
+    """Group for ``zoom meetings ...``."""
+
+
+# Fields printed by ``zoom meetings get``. Same one-per-line shape as
+# ``zoom users me`` for visual consistency.
+_MEETING_DETAIL_FIELDS = (
+    "id",
+    "topic",
+    "type",
+    "status",
+    "start_time",
+    "duration",
+    "timezone",
+    "host_email",
+    "join_url",
+)
+
+
+def _print_meeting_detail(meeting: dict) -> None:
+    for field in _MEETING_DETAIL_FIELDS:
+        if field in meeting:
+            click.echo(f"{field}: {meeting[field]}")
+
+
+@meetings_cmd.command("get", help="Print one meeting's details (GET /meetings/<meeting-id>).")
+@click.argument("meeting_id")
+@_translate_keyring_errors
+def meetings_get(meeting_id):
+    """``meeting_id`` is the numeric Zoom meeting ID. Closes #13 (read-only
+    piece) — write commands (create / update / delete / end) are a follow-up
+    that needs separate confirmation-flow design."""
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            meeting = meetings.get_meeting(client, meeting_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    _print_meeting_detail(meeting)
+
+
+@meetings_cmd.command(
+    "list", help="List meetings for a user (paginates GET /users/<user-id>/meetings)."
+)
+@click.option(
+    "--user-id",
+    default="me",
+    show_default=True,
+    help="Whose meetings to list. Default 'me' (the authenticated user).",
+)
+@click.option(
+    "--type",
+    "meeting_type",
+    type=click.Choice(list(meetings.ALLOWED_LIST_TYPES)),
+    default="scheduled",
+    show_default=True,
+    help="Zoom's `type` filter.",
+)
+@click.option(
+    "--page-size",
+    type=click.IntRange(1, 300),
+    default=300,
+    show_default=True,
+    help="Items per page request (Zoom caps `/users/{userId}/meetings` at 300).",
+)
+@_translate_keyring_errors
+def meetings_list(user_id, meeting_type, page_size):
+    """Output is tab-separated (id\\ttopic\\ttype\\tstart_time\\tduration) so
+    it pipes into cut/awk/column. Pagination is handled transparently
+    (PR #48 / #16). Closes #13 (read-only piece)."""
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            click.echo("id\ttopic\ttype\tstart_time\tduration")
+            for meeting in meetings.list_meetings(
+                client,
+                user_id=user_id,
+                meeting_type=meeting_type,
+                page_size=page_size,
+            ):
+                click.echo(
+                    f"{meeting.get('id', '')}\t"
+                    f"{meeting.get('topic', '')}\t"
+                    f"{meeting.get('type', '')}\t"
+                    f"{meeting.get('start_time', '')}\t"
+                    f"{meeting.get('duration', '')}"
                 )
     except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
         _exit_on_api_error(exc)

--- a/zoom_cli/api/meetings.py
+++ b/zoom_cli/api/meetings.py
@@ -1,0 +1,90 @@
+"""Zoom Meetings API helpers.
+
+Reference: https://developers.zoom.us/docs/api/meetings/
+
+Mirrors the structure of :mod:`zoom_cli.api.users`:
+
+- :func:`get_meeting` is the durable single-meeting helper, paralleling
+  :func:`zoom_cli.api.users.get_user`.
+- :func:`list_meetings` paginates ``GET /users/<user_id>/meetings`` via
+  the helper from :mod:`zoom_cli.api.pagination`.
+
+The write surface (``create``, ``update``, ``delete``, ``end``) is a
+follow-up — it needs confirmation-flow design (mirror ``zoom rm``) before
+the CLI surface can land safely.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from urllib.parse import quote
+
+from zoom_cli.api.client import ApiClient
+from zoom_cli.api.pagination import DEFAULT_PAGE_SIZE, paginate
+
+#: Allowed values for ``list_meetings(meeting_type=...)``.
+#: Mirrors Zoom's ``type`` query param. The server also accepts
+#: ``previous_meetings`` (snake_case) — kept for callers that already use
+#: it. ``upcoming_meetings`` is Zoom's newer alias for ``upcoming``.
+ALLOWED_LIST_TYPES: tuple[str, ...] = (
+    "scheduled",
+    "live",
+    "upcoming",
+    "upcoming_meetings",
+    "previous_meetings",
+)
+
+
+def get_meeting(client: ApiClient, meeting_id: str | int) -> dict[str, Any]:
+    """``GET /meetings/{meeting_id}`` — return one meeting's details.
+
+    ``meeting_id`` accepts either an int (numeric Zoom meeting ID) or a
+    str. The path segment is percent-encoded so caller-supplied IDs
+    cannot inject path/query metacharacters even if a future CLI threads
+    user input straight through.
+
+    Required scopes: ``meeting:read:meeting`` (or any scope that
+    includes it).
+    """
+    return client.get(f"/meetings/{quote(str(meeting_id), safe='')}")
+
+
+def list_meetings(
+    client: ApiClient,
+    *,
+    user_id: str = "me",
+    meeting_type: str = "scheduled",
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> Iterator[dict[str, Any]]:
+    """``GET /users/{user_id}/meetings`` — yield meetings across all pages.
+
+    Args:
+        client: Authenticated :class:`ApiClient`.
+        user_id: Whose meetings to list. Default ``"me"`` (the
+            authenticated principal). Pass a Zoom user ID or email for
+            any other user the caller has scope to see.
+        meeting_type: Zoom's ``type`` filter; one of
+            :data:`ALLOWED_LIST_TYPES`. Default ``"scheduled"``.
+        page_size: Items per page; see
+            :data:`~zoom_cli.api.pagination.DEFAULT_PAGE_SIZE`. The
+            ``/users/{userId}/meetings`` endpoint accepts up to 300.
+
+    Yields:
+        One meeting dict per record. Lazy — additional pages are fetched
+        only as the caller iterates.
+
+    Required scopes: ``meeting:read:list_meetings`` (or finer-grained
+    equivalent for the listed user).
+    """
+    if meeting_type not in ALLOWED_LIST_TYPES:
+        raise ValueError(
+            f"meeting_type must be one of {ALLOWED_LIST_TYPES!r}, got {meeting_type!r}"
+        )
+    return paginate(
+        client,
+        f"/users/{quote(user_id, safe='')}/meetings",
+        item_key="meetings",
+        params={"type": meeting_type},
+        page_size=page_size,
+    )


### PR DESCRIPTION
## Summary

Closes the read-only half of #13. Mirrors PR #50's structure for users, dropping a new `meetings.py` module + CLI surface in place. The write half (`create` / `update` / `delete` / `end`) is **deferred** — each needs its own confirmation-flow design and the design questions deserve a separate PR.

| Command | Underlying helper | Endpoint |
|---|---|---|
| `zoom meetings list` | `meetings.list_meetings()` → `paginate()` | `GET /users/<user-id>/meetings` |
| `zoom meetings get <meeting-id>` | `meetings.get_meeting(meeting_id)` | `GET /meetings/<meeting-id>` |

## What's new

### `zoom_cli/api/meetings.py` (new module)

```python
def get_meeting(client, meeting_id) -> dict
def list_meetings(client, *, user_id="me", meeting_type="scheduled", page_size=300) -> Iterator[dict]
ALLOWED_LIST_TYPES = ("scheduled", "live", "upcoming", "upcoming_meetings", "previous_meetings")
```

`get_meeting` accepts either an int or str and percent-encodes the path segment. `list_meetings` defaults `user_id="me"`, validates `meeting_type` against the pinned tuple, and yields lazily via the helper from PR #48.

### `zoom meetings list`

```
$ zoom meetings list
id        topic         type   start_time              duration
83001234  Daily         2      2026-04-28T15:00:00Z    30
83005678  Eng review    8      2026-04-29T16:00:00Z    60
```

Tab-separated with one header row; pipes cleanly through `cut`/`awk`/`column`.

**Flags:** `--user-id` (default `me`), `--type` (`scheduled`/`live`/`upcoming`/`upcoming_meetings`/`previous_meetings`, default `scheduled`), `--page-size` 1–300 (default 300).

### `zoom meetings get <meeting-id>`

Same field-per-line shape as `zoom users me` for visual consistency. Prints `id`, `topic`, `type`, `status`, `start_time`, `duration`, `timezone`, `host_email`, `join_url` when present.

## Tests (+19 new)

| File | New | Covers |
|---|---|---|
| `tests/test_api_meetings.py` | +9 | `get_meeting` path, str+int IDs, URL-encoding defense, `list_meetings` default user-me, cursor walk across pages, user_id forwarding, URL-encoded user_id, `meeting_type` validation, constant pinned |
| `tests/test_cli.py` | +7 | both commands bail with friendly message when no creds, `get` prints fields + omits non-printed ones, `list` TSV format + header, `list` flag forwarding, `list --type` / `--page-size` validation |
| (cumulative) | +3 | (test counts also include parametrized cases) |

All HTTP via `httpx.MockTransport` and the autouse `_InMemoryKeyring`. No socket I/O, no real Zoom API calls.

## Verification

```
ruff check .          # All checks passed!
ruff format --check . # 25 files already formatted
mypy                  # Success: no issues found in 12 source files
pytest -q             # 277 passed (was 258; +19)
```

## Deferred to issue #13 follow-up

- `zoom meetings create` — needs `--topic`, `--start-time`, `--duration`, `--type`, `--password` design + scope warnings.
- `zoom meetings update` — needs partial-update semantics design.
- `zoom meetings delete` — needs `--yes` / `--dry-run` (mirror `zoom rm`).
- `zoom meetings end` — needs confirmation prompt for live meetings (kicks all participants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)