### PR TITLE
feat(api,cli): close #13 (write) — meetings create/update/delete/end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > CC security setup (PR #33): adds `.claude/settings.json`, `SECURITY.md`, `LOCAL-SECURITY.md`, `TASKS.md`, and three FACET developer skills.
 > Rate-limit + pagination (PR #48): closes #16 (partial — per-tier token bucket tracked at #49). 429/Retry-After backoff with jitter; `paginate()` generator helper; `users.list_users()` as the first paginated endpoint.
 > Users CLI surface (PR #50): closes #14 (read-only piece). New `zoom users list` and `zoom users get <user-id>` commands.
-> Meetings CLI surface (this branch): closes #13 (read-only piece). New `zoom meetings list` and `zoom meetings get <meeting-id>` commands; `zoom_cli/api/meetings.py` mirrors the structure of `users.py`.
+> Meetings CLI surface (PR #51): closes #13 (read-only piece). New `zoom meetings list` and `zoom meetings get <meeting-id>` commands; `zoom_cli/api/meetings.py` mirrors the structure of `users.py`.
+> Meetings write surface (this branch): closes #13 (write piece). New `zoom meetings create / update / delete / end` commands. `ApiClient` gains `post`/`patch`/`put`/`delete` convenience wrappers.
+
+### Added (issue #13, write piece)
+- `zoom meetings create --topic ... [--type] [--start-time] [--duration] [--timezone] [--password] [--agenda] [--user-id me]` — `POST /users/<user-id>/meetings`. Topic is required; everything else is optional. Recurrence + settings sub-objects are out of scope here (use the API directly until a follow-up adds flags).
+- `zoom meetings update <meeting-id> [--topic ...] [...]` — `PATCH /meetings/<id>`. Partial update; only flags you pass are sent. Errors out with exit 1 if no fields were provided.
+- `zoom meetings delete <meeting-id> [--yes] [--dry-run] [--notify-host] [--notify-registrants]` — `DELETE /meetings/<id>`. Confirmation-flow mirrors `zoom rm` (positional id is scripted-friendly; `--yes` skips confirm; `--dry-run` previews without calling the API; notification flags default to silent delete).
+- `zoom meetings end <meeting-id> [--yes]` — `PUT /meetings/<id>/status` with `action=end`. **Always** confirms unless `--yes` because kicking live participants is irreversible.
+- `ApiClient.post(...)`, `.patch(...)`, `.put(...)`, `.delete(...)` convenience wrappers (the underlying `request()` already supported all methods; the wrappers just save callers from typing the method string).
+- `meetings.create_meeting`, `update_meeting`, `delete_meeting`, `end_meeting` API helpers.
 
 ### Added (issue #14, read-only)
 - New `zoom users list` CLI command — paginates `GET /users` via the helper from PR #48. Tab-separated output (`user_id\temail\ttype\tstatus`) with a header line; pipes cleanly into `cut`/`awk`/`column`. `--status active|inactive|pending` (default `active`) and `--page-size` (1–300, default 300) flags.

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -524,3 +524,78 @@ def test_max_retry_delay_pinned() -> None:
 
 def test_jitter_range_pinned() -> None:
     assert client_mod.JITTER_RANGE == 0.2
+
+
+# ---- HTTP convenience wrappers ------------------------------------------
+
+
+def test_post_delegates_to_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token())
+
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        captured["body"] = request.content
+        return httpx.Response(201, json={"id": "new"})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    with ApiClient(_creds(), http_client=http) as c:
+        result = c.post("/users", json={"email": "x@y"})
+
+    assert captured["method"] == "POST"
+    assert captured["url"].endswith("/users")
+    assert b"x@y" in captured["body"]
+    assert result == {"id": "new"}
+
+
+def test_patch_delegates_to_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token())
+
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        return httpx.Response(204)  # no content
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    with ApiClient(_creds(), http_client=http) as c:
+        result = c.patch("/meetings/123", json={"topic": "x"})
+
+    assert captured["method"] == "PATCH"
+    assert result == {}  # 204 → empty dict
+
+
+def test_put_delegates_to_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token())
+
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        return httpx.Response(204)
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    with ApiClient(_creds(), http_client=http) as c:
+        c.put("/meetings/123/status", json={"action": "end"})
+
+    assert captured["method"] == "PUT"
+
+
+def test_delete_delegates_to_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token())
+
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        return httpx.Response(204)
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    with ApiClient(_creds(), http_client=http) as c:
+        c.delete("/meetings/123", params={"foo": "bar"})
+
+    assert captured["method"] == "DELETE"
+    assert "foo=bar" in captured["url"]

--- a/tests/test_api_meetings.py
+++ b/tests/test_api_meetings.py
@@ -100,3 +100,94 @@ def test_allowed_list_types_constant_pinned() -> None:
     assert "live" in meetings.ALLOWED_LIST_TYPES
     assert "upcoming" in meetings.ALLOWED_LIST_TYPES
     assert "previous_meetings" in meetings.ALLOWED_LIST_TYPES
+
+
+# ---- write surface (closes #13 write piece) -----------------------------
+
+
+def test_create_meeting_posts_to_user_endpoint() -> None:
+    fake_client = MagicMock()
+    fake_client.post.return_value = {"id": 999, "join_url": "https://zoom.us/j/999"}
+
+    payload = {"topic": "T", "type": 2, "duration": 30}
+    result = meetings.create_meeting(fake_client, payload)
+
+    fake_client.post.assert_called_once_with("/users/me/meetings", json=payload)
+    assert result == {"id": 999, "join_url": "https://zoom.us/j/999"}
+
+
+def test_create_meeting_url_encodes_user_id() -> None:
+    fake_client = MagicMock()
+    fake_client.post.return_value = {}
+
+    meetings.create_meeting(fake_client, {"topic": "T"}, user_id="alice@example.com")
+
+    assert fake_client.post.call_args[0][0] == "/users/alice%40example.com/meetings"
+
+
+def test_update_meeting_patches_meeting_path() -> None:
+    fake_client = MagicMock()
+    fake_client.patch.return_value = {}
+
+    meetings.update_meeting(fake_client, 123, {"topic": "New title"})
+
+    fake_client.patch.assert_called_once_with("/meetings/123", json={"topic": "New title"})
+
+
+def test_update_meeting_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.patch.return_value = {}
+
+    meetings.update_meeting(fake_client, "evil/../admin", {})
+
+    arg = fake_client.patch.call_args[0][0]
+    assert "/.." not in arg
+    assert "%2F" in arg
+
+
+def test_delete_meeting_uses_DELETE_with_default_silent_params() -> None:
+    fake_client = MagicMock()
+    fake_client.delete.return_value = {}
+
+    meetings.delete_meeting(fake_client, 123)
+
+    fake_client.delete.assert_called_once_with(
+        "/meetings/123",
+        params={
+            "schedule_for_reminder": "false",
+            "cancel_meeting_reminder": "false",
+        },
+    )
+
+
+def test_delete_meeting_forwards_notify_flags() -> None:
+    fake_client = MagicMock()
+    fake_client.delete.return_value = {}
+
+    meetings.delete_meeting(
+        fake_client, 123, schedule_for_reminder=True, cancel_meeting_reminder=True
+    )
+
+    params = fake_client.delete.call_args[1]["params"]
+    assert params["schedule_for_reminder"] == "true"
+    assert params["cancel_meeting_reminder"] == "true"
+
+
+def test_end_meeting_puts_status_with_action_end() -> None:
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+
+    meetings.end_meeting(fake_client, 123)
+
+    fake_client.put.assert_called_once_with("/meetings/123/status", json={"action": "end"})
+
+
+def test_end_meeting_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+
+    meetings.end_meeting(fake_client, "evil/../admin")
+
+    arg = fake_client.put.call_args[0][0]
+    assert "/.." not in arg
+    assert "%2F" in arg

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1047,3 +1047,246 @@ def test_meetings_list_rejects_unknown_type(runner: CliRunner) -> None:
 def test_meetings_list_rejects_oversize_page(runner: CliRunner) -> None:
     result = runner.invoke(main, ["meetings", "list", "--page-size", "5000"])
     assert result.exit_code != 0
+
+
+# ---- #13 (write): zoom meetings create / update / delete / end -----------
+
+
+def _patch_meetings_module(monkeypatch: pytest.MonkeyPatch, **funcs):
+    """Helper: patch zoom_cli.api.meetings functions and OAuth fetch."""
+    import zoom_cli.__main__ as main_mod
+
+    for name, fn in funcs.items():
+        monkeypatch.setattr(main_mod.meetings, name, fn)
+    monkeypatch.setattr(
+        main_mod.oauth, "fetch_access_token", lambda *_a, **_k: _fake_access_token()
+    )
+
+
+def _save_creds():
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+
+
+# create
+
+
+def test_meetings_create_requires_topic(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["meetings", "create"])
+    assert result.exit_code != 0
+    assert "topic" in result.output.lower() or "missing" in result.output.lower()
+
+
+def test_meetings_create_builds_payload_and_prints_result(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured = {}
+
+    def fake_create(_client, payload, *, user_id):
+        captured["payload"] = payload
+        captured["user_id"] = user_id
+        return {
+            "id": 555,
+            "topic": payload.get("topic"),
+            "type": payload.get("type"),
+            "join_url": "https://zoom.us/j/555",
+        }
+
+    _patch_meetings_module(monkeypatch, create_meeting=fake_create)
+
+    result = runner.invoke(
+        main,
+        [
+            "meetings",
+            "create",
+            "--topic",
+            "Standup",
+            "--type",
+            "2",
+            "--start-time",
+            "2026-04-29T15:00:00Z",
+            "--duration",
+            "30",
+            "--password",
+            "abc",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["user_id"] == "me"
+    assert captured["payload"] == {
+        "topic": "Standup",
+        "type": 2,
+        "start_time": "2026-04-29T15:00:00Z",
+        "duration": 30,
+        "password": "abc",
+    }
+    assert "555" in result.output
+    assert "Standup" in result.output
+
+
+# update
+
+
+def test_meetings_update_rejects_no_fields(runner: CliRunner) -> None:
+    _save_creds()
+    result = runner.invoke(main, ["meetings", "update", "12345"])
+    assert result.exit_code == 1
+    assert "Nothing to update" in result.output
+
+
+def test_meetings_update_sends_only_provided_fields(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured = {}
+
+    def fake_update(_client, meeting_id, payload):
+        captured["meeting_id"] = meeting_id
+        captured["payload"] = payload
+        return {}
+
+    _patch_meetings_module(monkeypatch, update_meeting=fake_update)
+
+    result = runner.invoke(
+        main,
+        ["meetings", "update", "12345", "--topic", "New title", "--duration", "45"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["meeting_id"] == "12345"
+    assert captured["payload"] == {"topic": "New title", "duration": 45}
+    assert "Updated meeting 12345" in result.output
+
+
+# delete
+
+
+def test_meetings_delete_dry_run_does_not_call_api(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    called = {"n": 0}
+
+    def fake_delete(*_a, **_k):
+        called["n"] += 1
+        return {}
+
+    _patch_meetings_module(monkeypatch, delete_meeting=fake_delete)
+
+    result = runner.invoke(main, ["meetings", "delete", "12345", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "[dry-run]" in result.output
+    assert "12345" in result.output
+    assert called["n"] == 0
+
+
+def test_meetings_delete_confirms_before_deleting(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without --yes, the user must type 'y' to confirm."""
+    _save_creds()
+    called = {"n": 0}
+
+    def fake_delete(*_a, **_k):
+        called["n"] += 1
+        return {}
+
+    _patch_meetings_module(monkeypatch, delete_meeting=fake_delete)
+
+    # Decline the prompt.
+    result = runner.invoke(main, ["meetings", "delete", "12345"], input="n\n")
+    assert result.exit_code == 0, result.output
+    assert "Aborted" in result.output
+    assert called["n"] == 0
+
+
+def test_meetings_delete_yes_skips_confirmation(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured = {}
+
+    def fake_delete(_client, meeting_id, *, schedule_for_reminder, cancel_meeting_reminder):
+        captured["meeting_id"] = meeting_id
+        captured["schedule_for_reminder"] = schedule_for_reminder
+        captured["cancel_meeting_reminder"] = cancel_meeting_reminder
+        return {}
+
+    _patch_meetings_module(monkeypatch, delete_meeting=fake_delete)
+
+    result = runner.invoke(main, ["meetings", "delete", "12345", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert captured["meeting_id"] == "12345"
+    assert captured["schedule_for_reminder"] is False
+    assert captured["cancel_meeting_reminder"] is False
+    assert "Deleted meeting 12345" in result.output
+
+
+def test_meetings_delete_forwards_notify_flags(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured = {}
+
+    def fake_delete(_client, meeting_id, *, schedule_for_reminder, cancel_meeting_reminder):
+        captured["schedule_for_reminder"] = schedule_for_reminder
+        captured["cancel_meeting_reminder"] = cancel_meeting_reminder
+        return {}
+
+    _patch_meetings_module(monkeypatch, delete_meeting=fake_delete)
+
+    result = runner.invoke(
+        main,
+        [
+            "meetings",
+            "delete",
+            "12345",
+            "--yes",
+            "--notify-host",
+            "--notify-registrants",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["schedule_for_reminder"] is True
+    assert captured["cancel_meeting_reminder"] is True
+
+
+# end
+
+
+def test_meetings_end_confirms_before_ending(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    called = {"n": 0}
+
+    def fake_end(*_a, **_k):
+        called["n"] += 1
+        return {}
+
+    _patch_meetings_module(monkeypatch, end_meeting=fake_end)
+
+    result = runner.invoke(main, ["meetings", "end", "12345"], input="n\n")
+    assert result.exit_code == 0, result.output
+    assert "Aborted" in result.output
+    assert "kicks all participants" in result.output
+    assert called["n"] == 0
+
+
+def test_meetings_end_yes_skips_confirmation(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured = {}
+
+    def fake_end(_client, meeting_id):
+        captured["meeting_id"] = meeting_id
+        return {}
+
+    _patch_meetings_module(monkeypatch, end_meeting=fake_end)
+
+    result = runner.invoke(main, ["meetings", "end", "12345", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert captured["meeting_id"] == "12345"
+    assert "Ended meeting 12345" in result.output

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -535,6 +535,223 @@ def meetings_list(user_id, meeting_type, page_size):
         _exit_on_api_error(exc)
 
 
+# ---- Zoom Meetings — write commands -------------------------------------
+#
+# Closes #13 (write piece). Confirmation-flow design mirrors `zoom rm`:
+#   - positional id with no prompt = scripted use OK
+#   - `--yes` / `-y` skips any confirmation
+#   - `--dry-run` (delete only) shows what would happen without acting
+#   - `end` always requires confirmation unless `--yes` — kicking live
+#     participants is disruptive and there's no recovery
+
+
+def _build_meeting_payload(
+    *,
+    topic: str | None,
+    meeting_type: int | None,
+    start_time: str | None,
+    duration: int | None,
+    timezone: str | None,
+    password: str | None,
+    agenda: str | None,
+) -> dict:
+    """Drop None-valued fields so we don't clobber defaults on PATCH or
+    send junk on POST."""
+    payload: dict = {}
+    if topic is not None:
+        payload["topic"] = topic
+    if meeting_type is not None:
+        payload["type"] = meeting_type
+    if start_time is not None:
+        payload["start_time"] = start_time
+    if duration is not None:
+        payload["duration"] = duration
+    if timezone is not None:
+        payload["timezone"] = timezone
+    if password is not None:
+        payload["password"] = password
+    if agenda is not None:
+        payload["agenda"] = agenda
+    return payload
+
+
+@meetings_cmd.command("create", help="Schedule a new meeting (POST /users/<user-id>/meetings).")
+@click.option("--topic", required=True, help="Meeting topic / title.")
+@click.option(
+    "--type",
+    "meeting_type",
+    type=click.IntRange(1, 8),
+    default=2,
+    show_default=True,
+    help="1=instant, 2=scheduled, 3=recurring no-fixed-time, 8=recurring fixed-time.",
+)
+@click.option("--start-time", help="ISO 8601 (required for type 2 / 8). e.g. 2026-04-29T15:00:00Z")
+@click.option(
+    "--duration",
+    type=click.IntRange(1, 1440),
+    default=60,
+    show_default=True,
+    help="Minutes.",
+)
+@click.option("--timezone", "tz", help="IANA tz, e.g. America/New_York.")
+@click.option("--password", help="Meeting password. If omitted Zoom auto-generates one.")
+@click.option("--agenda", help="Optional agenda body.")
+@click.option(
+    "--user-id",
+    default="me",
+    show_default=True,
+    help="Whose calendar to create on. Default 'me'.",
+)
+@_translate_keyring_errors
+def meetings_create(topic, meeting_type, start_time, duration, tz, password, agenda, user_id):
+    """Closes #13 (write piece). Settings (massive sub-object) and
+    recurrence (also complex sub-object) are out of scope for this PR —
+    use the JSON API directly for those until a follow-up adds flags."""
+    payload = _build_meeting_payload(
+        topic=topic,
+        meeting_type=meeting_type,
+        start_time=start_time,
+        duration=duration,
+        timezone=tz,
+        password=password,
+        agenda=agenda,
+    )
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            created = meetings.create_meeting(client, payload, user_id=user_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    _print_meeting_detail(created)
+
+
+@meetings_cmd.command("update", help="Update an existing meeting (PATCH /meetings/<meeting-id>).")
+@click.argument("meeting_id")
+@click.option("--topic", help="New topic.")
+@click.option(
+    "--type",
+    "meeting_type",
+    type=click.IntRange(1, 8),
+    help="Change meeting type.",
+)
+@click.option("--start-time", help="ISO 8601.")
+@click.option("--duration", type=click.IntRange(1, 1440), help="Minutes.")
+@click.option("--timezone", "tz", help="IANA tz.")
+@click.option("--password", help="New password.")
+@click.option("--agenda", help="New agenda body.")
+@_translate_keyring_errors
+def meetings_update(meeting_id, topic, meeting_type, start_time, duration, tz, password, agenda):
+    """Partial update — only flags you pass are sent. Zoom leaves omitted
+    fields untouched (PATCH semantics)."""
+    payload = _build_meeting_payload(
+        topic=topic,
+        meeting_type=meeting_type,
+        start_time=start_time,
+        duration=duration,
+        timezone=tz,
+        password=password,
+        agenda=agenda,
+    )
+    if not payload:
+        click.echo("Nothing to update — pass at least one --field.", err=True)
+        raise click.exceptions.Exit(code=1)
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            meetings.update_meeting(client, meeting_id, payload)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Updated meeting {meeting_id}.")
+
+
+@meetings_cmd.command("delete", help="Delete a meeting (DELETE /meetings/<meeting-id>).")
+@click.argument("meeting_id")
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Show what would be deleted without calling the API.",
+)
+@click.option(
+    "--notify-host",
+    is_flag=True,
+    default=False,
+    help="Send the host an email reminder of the deletion (Zoom default is silent).",
+)
+@click.option(
+    "--notify-registrants",
+    is_flag=True,
+    default=False,
+    help="Send registrants a cancellation notice.",
+)
+@_translate_keyring_errors
+def meetings_delete(meeting_id, yes, dry_run, notify_host, notify_registrants):
+    """Mirrors the `zoom rm` confirmation-flow pattern: positional id +
+    interactive confirm unless --yes; --dry-run for a no-op preview."""
+    if dry_run:
+        click.echo(f"[dry-run] Would delete meeting {meeting_id}")
+        if notify_host or notify_registrants:
+            click.echo(
+                f"[dry-run] notify_host={notify_host} notify_registrants={notify_registrants}"
+            )
+        return
+
+    if not yes and not click.confirm(f"Delete meeting {meeting_id}?", default=False):
+        click.echo("Aborted.")
+        return
+
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            meetings.delete_meeting(
+                client,
+                meeting_id,
+                schedule_for_reminder=notify_host,
+                cancel_meeting_reminder=notify_registrants,
+            )
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Deleted meeting {meeting_id}.")
+
+
+@meetings_cmd.command(
+    "end",
+    help="End an in-progress meeting (PUT /meetings/<meeting-id>/status, action=end).",
+)
+@click.argument("meeting_id")
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@_translate_keyring_errors
+def meetings_end(meeting_id, yes):
+    """Kicking live participants is disruptive and irreversible — always
+    confirm unless --yes."""
+    if not yes and not click.confirm(
+        f"End meeting {meeting_id}? This kicks all participants.", default=False
+    ):
+        click.echo("Aborted.")
+        return
+
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            meetings.end_meeting(client, meeting_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Ended meeting {meeting_id}.")
+
+
 if __name__ == "__main__":
     main()
 

--- a/zoom_cli/api/client.py
+++ b/zoom_cli/api/client.py
@@ -258,3 +258,42 @@ class ApiClient:
     def get(self, path: str, *, params: dict[str, Any] | None = None) -> dict[str, Any]:
         """Convenience wrapper for ``GET``."""
         return self.request("GET", path, params=params)
+
+    def post(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Convenience wrapper for ``POST`` with a JSON body."""
+        return self.request("POST", path, params=params, json=json)
+
+    def patch(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Convenience wrapper for ``PATCH`` with a JSON body.
+
+        Most Zoom partial-update endpoints respond with ``204 No Content``
+        (returns ``{}`` from :meth:`request`).
+        """
+        return self.request("PATCH", path, params=params, json=json)
+
+    def put(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Convenience wrapper for ``PUT`` with a JSON body."""
+        return self.request("PUT", path, params=params, json=json)
+
+    def delete(self, path: str, *, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Convenience wrapper for ``DELETE``. Most Zoom delete endpoints
+        respond with ``204 No Content`` (returns ``{}``)."""
+        return self.request("DELETE", path, params=params)

--- a/zoom_cli/api/meetings.py
+++ b/zoom_cli/api/meetings.py
@@ -4,14 +4,14 @@ Reference: https://developers.zoom.us/docs/api/meetings/
 
 Mirrors the structure of :mod:`zoom_cli.api.users`:
 
-- :func:`get_meeting` is the durable single-meeting helper, paralleling
-  :func:`zoom_cli.api.users.get_user`.
-- :func:`list_meetings` paginates ``GET /users/<user_id>/meetings`` via
-  the helper from :mod:`zoom_cli.api.pagination`.
+- :func:`get_meeting` / :func:`list_meetings` — read surface.
+- :func:`create_meeting` / :func:`update_meeting` /
+  :func:`delete_meeting` / :func:`end_meeting` — write surface.
 
-The write surface (``create``, ``update``, ``delete``, ``end``) is a
-follow-up — it needs confirmation-flow design (mirror ``zoom rm``) before
-the CLI surface can land safely.
+Each function maps 1:1 to a Zoom endpoint and returns the parsed JSON
+envelope (or ``{}`` for 204 No Content responses). Higher-level concerns
+(confirmation prompts, --dry-run, --yes) live in the CLI layer in
+``__main__.py``; the API layer is intentionally side-effect-only.
 """
 
 from __future__ import annotations
@@ -48,6 +48,81 @@ def get_meeting(client: ApiClient, meeting_id: str | int) -> dict[str, Any]:
     includes it).
     """
     return client.get(f"/meetings/{quote(str(meeting_id), safe='')}")
+
+
+def create_meeting(
+    client: ApiClient, payload: dict[str, Any], *, user_id: str = "me"
+) -> dict[str, Any]:
+    """``POST /users/{user_id}/meetings`` — schedule a new meeting.
+
+    ``payload`` is the full Zoom create-meeting body (``topic``, ``type``,
+    ``start_time``, etc.). The CLI ``zoom meetings create`` builds this
+    from individual flags; programmatic callers can pass any subset Zoom
+    accepts. Returns the created meeting's full detail object (Zoom
+    responds with the new resource, including ``id`` and ``join_url``).
+
+    Required scopes: ``meeting:write:meeting`` (or admin equivalent for
+    creating on another user's behalf).
+    """
+    return client.post(f"/users/{quote(user_id, safe='')}/meetings", json=payload)
+
+
+def update_meeting(
+    client: ApiClient, meeting_id: str | int, payload: dict[str, Any]
+) -> dict[str, Any]:
+    """``PATCH /meetings/{meeting_id}`` — partial update.
+
+    ``payload`` should contain only the fields being changed; Zoom's
+    PATCH semantics leave omitted fields untouched. Returns ``{}`` (Zoom
+    responds with ``204 No Content``).
+
+    Required scopes: ``meeting:write:meeting``.
+    """
+    return client.patch(f"/meetings/{quote(str(meeting_id), safe='')}", json=payload)
+
+
+def delete_meeting(
+    client: ApiClient,
+    meeting_id: str | int,
+    *,
+    schedule_for_reminder: bool = False,
+    cancel_meeting_reminder: bool = False,
+) -> dict[str, Any]:
+    """``DELETE /meetings/{meeting_id}`` — remove the meeting.
+
+    ``schedule_for_reminder``: send the host a reminder email about the
+    deletion. ``cancel_meeting_reminder``: send registrants a cancellation
+    notice. Both default ``False`` (silent delete) so scripted use is
+    quiet by default.
+
+    Returns ``{}`` (Zoom responds with ``204 No Content``).
+
+    Required scopes: ``meeting:write:meeting``.
+    """
+    return client.delete(
+        f"/meetings/{quote(str(meeting_id), safe='')}",
+        params={
+            "schedule_for_reminder": "true" if schedule_for_reminder else "false",
+            "cancel_meeting_reminder": "true" if cancel_meeting_reminder else "false",
+        },
+    )
+
+
+def end_meeting(client: ApiClient, meeting_id: str | int) -> dict[str, Any]:
+    """``PUT /meetings/{meeting_id}/status`` with ``action=end`` — kick
+    all participants and end an in-progress meeting.
+
+    Returns ``{}`` (Zoom responds with ``204 No Content``). The CLI
+    requires explicit confirmation before calling this — kicking
+    participants mid-meeting is disruptive enough that ``--yes`` is the
+    only way to skip the prompt.
+
+    Required scopes: ``meeting:write:meeting``.
+    """
+    return client.put(
+        f"/meetings/{quote(str(meeting_id), safe='')}/status",
+        json={"action": "end"},
+    )
 
 
 def list_meetings(


### PR DESCRIPTION
## Summary

Closes the write half of #13. Builds on PR #51's read-only shape + four new \`ApiClient\` HTTP-method convenience wrappers.

| Command | Endpoint | Confirmation flow |
|---|---|---|
| \`zoom meetings create --topic ...\` | \`POST /users/<id>/meetings\` | none (creating a draft is reversible — \`delete\` is right there) |
| \`zoom meetings update <id> [--field ...]\` | \`PATCH /meetings/<id>\` | none (rejects no-op with exit 1) |
| \`zoom meetings delete <id>\` | \`DELETE /meetings/<id>\` | mirrors \`zoom rm\` — \`--yes\` skips, \`--dry-run\` previews |
| \`zoom meetings end <id>\` | \`PUT /meetings/<id>/status {action:end}\` | **always** confirms unless \`--yes\` |

## What's new

### \`zoom_cli/api/client.py\` — HTTP method wrappers

\`ApiClient\` already handled all methods via \`.request()\`; added \`.post()\`, \`.patch()\`, \`.put()\`, \`.delete()\` for ergonomics. 204 No Content responses still return \`{}\` (was already in \`request()\`).

### \`zoom_cli/api/meetings.py\` — write helpers

Each function maps 1:1 to a Zoom endpoint, percent-encodes the path segment (defense-in-depth from #36), and returns the parsed JSON envelope:

\`\`\`python
create_meeting(client, payload, *, user_id="me") -> dict
update_meeting(client, meeting_id, payload) -> dict
delete_meeting(client, meeting_id, *,
               schedule_for_reminder=False,
               cancel_meeting_reminder=False) -> dict
end_meeting(client, meeting_id) -> dict
\`\`\`

### CLI (\`zoom_cli/__main__.py\`)

**\`zoom meetings create --topic ...\`** — \`--topic\` is required; \`--type\` (1/2/3/8, default 2), \`--start-time\` (ISO 8601), \`--duration\` (1–1440 min, default 60), \`--timezone\`, \`--password\`, \`--agenda\`, \`--user-id\` (default \`me\`). Prints the new meeting's id + topic + join_url on success.

**\`zoom meetings update <id>\`** — partial update; only flags you pass are sent. Rejects empty calls with exit 1 + \"Nothing to update — pass at least one --field.\"

**\`zoom meetings delete <id>\`** — confirmation-flow mirrors \`zoom rm\`:
- positional id is scripted-friendly (no prompt by default? *yes* — see below).
- Actually wait: \`zoom rm\` prompts only when picked interactively, **not** when given positionally. \`meetings delete\` is stricter: **always** prompts unless \`--yes\` (deleting a Zoom meeting affects scheduled invitees too — higher blast radius than a local bookmark).
- \`--dry-run\` previews without calling the API.
- \`--notify-host\` / \`--notify-registrants\` flip Zoom's notification flags (default silent).

**\`zoom meetings end <id>\`** — kicks all live participants. Always confirms unless \`--yes\`; the prompt explicitly says \"This kicks all participants.\"

## Tests (+22 new)

| File | New | Covers |
|---|---|---|
| \`tests/test_api_meetings.py\` | +8 | each verb's path/payload/URL-encoding; delete default-silent params; delete forwards notify flags |
| \`tests/test_api_client.py\` | +4 | post/patch/put/delete wrappers each delegate to request with the right method |
| \`tests/test_cli.py\` | +10 | create requires --topic, builds payload from flags; update rejects empty; delete --dry-run is no-op + skips API; delete confirms (n aborts); --yes skips; --notify-* forwards; end confirms with kick-warning; end --yes skips |

All HTTP via \`httpx.MockTransport\` and \`unittest.mock.MagicMock\` for the API helpers. No socket I/O, no real Zoom API calls.

## Verification

\`\`\`
ruff check .          # All checks passed!
ruff format --check . # 25 files already formatted
mypy                  # Success: no issues found in 12 source files
pytest -q             # 299 passed (was 277; +22)
\`\`\`

## Out of scope (deferred)

- **Settings sub-object** (massive — \`approval_type\`, \`waiting_room\`, \`mute_upon_entry\`, ~50 fields). Too many to map to flags coherently in this PR.
- **Recurrence sub-object** (complex — \`type\`, \`repeat_interval\`, \`weekly_days\`, \`monthly_day\`, \`end_times\`/\`end_date_time\`). Same reasoning.
- Both can be exercised via \`ApiClient.post/patch\` directly until a follow-up adds dedicated flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)