### PR TITLE
feat(api,cli): close #15 — recordings list/get/download/delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Users CLI surface (PR #50): closes #14 (read-only piece). New `zoom users list` and `zoom users get <user-id>` commands.
 > Meetings CLI surface (PR #51): closes #13 (read-only piece). New `zoom meetings list` and `zoom meetings get <meeting-id>` commands; `zoom_cli/api/meetings.py` mirrors the structure of `users.py`.
 > Meetings write surface (PR #52): closes #13 (write piece). New `zoom meetings create / update / delete / end` commands. `ApiClient` gains `post`/`patch`/`put`/`delete` convenience wrappers.
-> Users write surface (this branch): closes #14 (write + settings-read piece). New `zoom users create / delete / settings get` commands.
+> Users write surface (PR #53): closes #14 (write + settings-read piece). New `zoom users create / delete / settings get` commands.
+> Recordings surface (this branch): closes #15. New `zoom recordings list / get / download / delete` commands; `zoom_cli/api/recordings.py`; `ApiClient.stream_download` for atomic streamed downloads.
+
+### Added (issue #15)
+- `zoom recordings list [--user-id me] [--from YYYY-MM-DD] [--to YYYY-MM-DD] [--page-size N]` — paginates `GET /users/<user-id>/recordings`. TSV output: `uuid\tmeeting_id\ttopic\tstart_time\tfile_count`.
+- `zoom recordings get <meeting-id>` — `GET /meetings/<meeting-id>/recordings`. Pretty-printed JSON for piping through `jq`.
+- `zoom recordings download <meeting-id> [--out-dir DIR] [--file-type TYPE ...]` — fetches the meeting's recording metadata, then streams each file to disk via the new `ApiClient.stream_download`. Atomic per-file writes (sibling tempfile + `os.replace`) so a network drop never leaves half a file at the destination. `--file-type` is repeatable to filter to MP4/M4A/CHAT/etc. Filename convention: `<meeting_id>-<recording_type>.<ext>` (collision-disambiguated by recording_id).
+- `zoom recordings delete <meeting-id> [--file-id ID] [--action trash|delete] [--yes] [--dry-run]` — `DELETE /meetings/<id>/recordings` (or `/recordings/<file-id>` if `--file-id`). Always confirms unless `--yes`; louder prompt for `--action delete` (permanent) than the default `trash` (recoverable for 30 days).
+- API helpers: `recordings.list_recordings / get_recordings / delete_recordings / delete_recording_file`. `ALLOWED_DELETE_ACTIONS` constant pinned by tests.
+- `ApiClient.stream_download(url, dest_path)` — bearer-authenticated streamed GET with atomic tempfile-then-replace write semantics. Single-shot 401 retry with force-refresh (same policy as `request`); 429 on Zoom's download host is uncommon enough that it's deferred to issue #49.
 
 ### Added (issue #14, write piece)
 - `zoom users create --email ... --type N [--first-name ...] [--last-name ...] [--display-name ...] [--password ...] [--action create|autoCreate|custCreate|ssoCreate]` — `POST /users`. Builds Zoom's `{action, user_info}` envelope from flat flags.

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -599,3 +599,116 @@ def test_delete_delegates_to_request(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert captured["method"] == "DELETE"
     assert "foo=bar" in captured["url"]
+
+
+# ---- stream_download ---------------------------------------------------
+
+
+def test_stream_download_writes_bytes_to_dest_atomically(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Body is streamed to tempfile + os.replace; auth header is the bearer."""
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token("tok-X"))
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, content=b"hello world\n")
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    dest = tmp_path / "out.bin"
+    with ApiClient(_creds(), http_client=http) as c:
+        n = c.stream_download("https://files.zoom.us/rec/abc", str(dest))
+
+    assert dest.read_bytes() == b"hello world\n"
+    assert n == len(b"hello world\n")
+    assert captured["url"] == "https://files.zoom.us/rec/abc"
+    assert captured["auth"] == "Bearer tok-X"
+
+
+def test_stream_download_retries_once_on_401(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """First 401 → cache invalidated → fresh token → retry succeeds."""
+    fetch_calls = {"n": 0}
+
+    def fake_fetch(*_a, **_k):
+        fetch_calls["n"] += 1
+        return _fresh_token(f"tok-{fetch_calls['n']}")
+
+    monkeypatch.setattr(oauth, "fetch_access_token", fake_fetch)
+
+    request_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        request_count["n"] += 1
+        if request_count["n"] == 1:
+            return httpx.Response(401, content=b"")
+        return httpx.Response(200, content=b"second-attempt-body")
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    dest = tmp_path / "out.bin"
+    with ApiClient(_creds(), http_client=http) as c:
+        n = c.stream_download("https://files.zoom.us/rec/abc", str(dest))
+
+    assert dest.read_bytes() == b"second-attempt-body"
+    assert n == len(b"second-attempt-body")
+    assert fetch_calls["n"] == 2  # initial + force-refresh
+    assert request_count["n"] == 2  # original 401 + retry
+
+
+def test_stream_download_raises_on_404(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token())
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, content=b"file not found")
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    dest = tmp_path / "out.bin"
+    with (
+        ApiClient(_creds(), http_client=http) as c,
+        pytest.raises(client_mod.ZoomApiError) as excinfo,
+    ):
+        c.stream_download("https://files.zoom.us/rec/abc", str(dest))
+
+    assert excinfo.value.status_code == 404
+    assert not dest.exists()  # no partial file left behind
+
+
+def test_stream_download_cleans_up_tempfile_on_partial(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """If the body iteration raises mid-stream, the tempfile is unlinked
+    so dest_path stays untouched and there's no orphan file in dest_dir."""
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token())
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        # Body that raises mid-iteration is hard to fake with MockTransport,
+        # so we simulate by having the handler return enormous Content-Length
+        # but then close. Simpler: just monkeypatch iter_bytes to raise.
+        return httpx.Response(200, content=b"start")
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    dest = tmp_path / "out.bin"
+
+    # Patch iter_bytes on every Response to raise once we've started.
+    real_iter = httpx.Response.iter_bytes
+
+    def boom(self, *_a, **_kw):
+        # Yield one chunk then raise, so the file is created but partial.
+        for chunk in real_iter(self):
+            yield chunk
+            raise RuntimeError("simulated mid-stream failure")
+
+    monkeypatch.setattr(httpx.Response, "iter_bytes", boom)
+
+    with (
+        ApiClient(_creds(), http_client=http) as c,
+        pytest.raises(RuntimeError, match="simulated"),
+    ):
+        c.stream_download("https://files.zoom.us/rec/abc", str(dest))
+
+    # dest_path must not exist (we never reached os.replace).
+    assert not dest.exists()
+    # And no .zoom-dl.* tempfile should be left in tmp_path.
+    leftovers = list(tmp_path.glob(".zoom-dl.*"))
+    assert leftovers == []

--- a/tests/test_api_recordings.py
+++ b/tests/test_api_recordings.py
@@ -1,0 +1,128 @@
+"""Tests for zoom_cli.api.recordings — Cloud Recording endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from zoom_cli.api import recordings
+
+
+def test_get_recordings_targets_meeting_path() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"recording_files": []}
+
+    recordings.get_recordings(fake_client, 12345)
+
+    fake_client.get.assert_called_once_with("/meetings/12345/recordings")
+
+
+def test_get_recordings_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {}
+
+    recordings.get_recordings(fake_client, "evil/../admin")
+
+    arg = fake_client.get.call_args[0][0]
+    assert "/.." not in arg
+    assert "%2F" in arg
+
+
+def test_list_recordings_default_user_me_no_date_filters() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"meetings": [], "next_page_token": ""}
+
+    list(recordings.list_recordings(fake_client))
+
+    call = fake_client.get.call_args
+    assert call[0][0] == "/users/me/recordings"
+    # No `from`/`to` should be in params (apart from page_size + next_page_token).
+    params = call[1]["params"]
+    assert "from" not in params
+    assert "to" not in params
+
+
+def test_list_recordings_forwards_date_filters() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"meetings": [], "next_page_token": ""}
+
+    list(
+        recordings.list_recordings(
+            fake_client, user_id="alice@example.com", from_="2026-04-01", to="2026-04-30"
+        )
+    )
+
+    call = fake_client.get.call_args
+    assert call[0][0] == "/users/alice%40example.com/recordings"
+    assert call[1]["params"]["from"] == "2026-04-01"
+    assert call[1]["params"]["to"] == "2026-04-30"
+
+
+def test_list_recordings_walks_pagination_cursor() -> None:
+    fake_client = MagicMock()
+    fake_client.get.side_effect = [
+        {"meetings": [{"id": 1}, {"id": 2}], "next_page_token": "tok-2"},
+        {"meetings": [{"id": 3}], "next_page_token": ""},
+    ]
+
+    result = list(recordings.list_recordings(fake_client))
+
+    assert result == [{"id": 1}, {"id": 2}, {"id": 3}]
+    assert fake_client.get.call_count == 2
+
+
+def test_delete_recordings_default_action_is_trash() -> None:
+    fake_client = MagicMock()
+    fake_client.delete.return_value = {}
+
+    recordings.delete_recordings(fake_client, 12345)
+
+    fake_client.delete.assert_called_once_with(
+        "/meetings/12345/recordings", params={"action": "trash"}
+    )
+
+
+def test_delete_recordings_permanent() -> None:
+    fake_client = MagicMock()
+    fake_client.delete.return_value = {}
+
+    recordings.delete_recordings(fake_client, 12345, action="delete")
+
+    assert fake_client.delete.call_args[1]["params"]["action"] == "delete"
+
+
+def test_delete_recordings_rejects_unknown_action() -> None:
+    fake_client = MagicMock()
+    with pytest.raises(ValueError, match="action"):
+        recordings.delete_recordings(fake_client, 12345, action="bogus")
+
+
+def test_delete_recording_file_targets_file_path() -> None:
+    fake_client = MagicMock()
+    fake_client.delete.return_value = {}
+
+    recordings.delete_recording_file(fake_client, 12345, "rec-abc")
+
+    fake_client.delete.assert_called_once_with(
+        "/meetings/12345/recordings/rec-abc", params={"action": "trash"}
+    )
+
+
+def test_delete_recording_file_url_encodes_recording_id() -> None:
+    fake_client = MagicMock()
+    fake_client.delete.return_value = {}
+
+    recordings.delete_recording_file(fake_client, 12345, "rec/../bad")
+
+    arg = fake_client.delete.call_args[0][0]
+    assert "/recordings/rec%2F" in arg
+
+
+def test_delete_recording_file_rejects_unknown_action() -> None:
+    fake_client = MagicMock()
+    with pytest.raises(ValueError, match="action"):
+        recordings.delete_recording_file(fake_client, 12345, "rec", action="bogus")
+
+
+def test_allowed_delete_actions_pinned() -> None:
+    assert recordings.ALLOWED_DELETE_ACTIONS == ("trash", "delete")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1587,3 +1587,300 @@ def test_users_settings_get_specific_user(
     result = runner.invoke(main, ["users", "settings", "get", "u-42"])
     assert result.exit_code == 0, result.output
     assert captured["user_id"] == "u-42"
+
+
+# ---- #15: zoom recordings list / get / download / delete ----------------
+
+
+def _patch_recordings_module(monkeypatch: pytest.MonkeyPatch, **funcs):
+    import zoom_cli.__main__ as main_mod
+
+    for name, fn in funcs.items():
+        monkeypatch.setattr(main_mod.recordings, name, fn)
+    monkeypatch.setattr(
+        main_mod.oauth, "fetch_access_token", lambda *_a, **_k: _fake_access_token()
+    )
+
+
+# list
+
+
+def test_recordings_list_bails_when_no_credentials(runner: CliRunner) -> None:
+    result = runner.invoke(main, ["recordings", "list"])
+    assert result.exit_code == 1
+    assert "No Server-to-Server" in result.output
+
+
+def test_recordings_list_prints_tab_separated_with_header(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured = {}
+
+    def fake_list_recordings(_client, *, user_id, from_, to, page_size):
+        captured.update({"user_id": user_id, "from_": from_, "to": to, "page_size": page_size})
+        return iter(
+            [
+                {
+                    "uuid": "uuid-1",
+                    "id": 11,
+                    "topic": "M1",
+                    "start_time": "2026-04-28T10:00:00Z",
+                    "recording_files": [{"id": "f1"}, {"id": "f2"}],
+                },
+                {
+                    "uuid": "uuid-2",
+                    "id": 22,
+                    "topic": "M2",
+                    "start_time": "2026-04-29T11:00:00Z",
+                    "recording_files": [],
+                },
+            ]
+        )
+
+    _patch_recordings_module(monkeypatch, list_recordings=fake_list_recordings)
+
+    result = runner.invoke(main, ["recordings", "list"])
+    assert result.exit_code == 0, result.output
+    lines = result.output.strip().split("\n")
+    assert lines[0] == "uuid\tmeeting_id\ttopic\tstart_time\tfile_count"
+    assert lines[1] == "uuid-1\t11\tM1\t2026-04-28T10:00:00Z\t2"
+    assert lines[2] == "uuid-2\t22\tM2\t2026-04-29T11:00:00Z\t0"
+
+    assert captured["user_id"] == "me"
+    assert captured["from_"] is None
+    assert captured["to"] is None
+    assert captured["page_size"] == 300
+
+
+def test_recordings_list_forwards_date_filters(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured = {}
+
+    def fake_list_recordings(_client, *, user_id, from_, to, page_size):
+        captured.update({"from_": from_, "to": to})
+        return iter([])
+
+    _patch_recordings_module(monkeypatch, list_recordings=fake_list_recordings)
+    result = runner.invoke(
+        main,
+        ["recordings", "list", "--from", "2026-04-01", "--to", "2026-04-30"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["from_"] == "2026-04-01"
+    assert captured["to"] == "2026-04-30"
+
+
+# get
+
+
+def test_recordings_get_prints_json(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    _save_creds()
+
+    def fake_get_recordings(_client, meeting_id):
+        return {"id": meeting_id, "recording_files": [{"id": "f1", "file_type": "MP4"}]}
+
+    _patch_recordings_module(monkeypatch, get_recordings=fake_get_recordings)
+    result = runner.invoke(main, ["recordings", "get", "12345"])
+    assert result.exit_code == 0, result.output
+    import json as _json
+
+    parsed = _json.loads(result.output)
+    assert parsed["id"] == "12345"
+    assert parsed["recording_files"][0]["file_type"] == "MP4"
+
+
+# download
+
+
+def test_recordings_download_writes_each_file(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+
+    def fake_get(_client, meeting_id):
+        return {
+            "recording_files": [
+                {
+                    "id": "f1",
+                    "file_type": "MP4",
+                    "file_extension": "MP4",
+                    "recording_type": "shared_screen_with_speaker_view",
+                    "download_url": "https://files.zoom.us/rec/f1",
+                },
+                {
+                    "id": "f2",
+                    "file_type": "M4A",
+                    "file_extension": "M4A",
+                    "recording_type": "audio_only",
+                    "download_url": "https://files.zoom.us/rec/f2",
+                },
+            ]
+        }
+
+    written = []
+
+    def fake_stream(self, url, dest):
+        # Mirror stream_download: write something and return bytes.
+        with open(dest, "wb") as f:
+            f.write(b"data-for:" + url.encode())
+        written.append((url, dest))
+        return 99
+
+    _patch_recordings_module(monkeypatch, get_recordings=fake_get)
+    monkeypatch.setattr("zoom_cli.api.client.ApiClient.stream_download", fake_stream)
+
+    out_dir = tmp_path / "downloads"
+    result = runner.invoke(main, ["recordings", "download", "12345", "--out-dir", str(out_dir)])
+    assert result.exit_code == 0, result.output
+    assert len(written) == 2
+    # Filename convention: <meeting_id>-<recording_type>.<ext>
+    paths = sorted(p for _u, p in written)
+    assert paths[0].endswith("12345-audio_only.m4a")
+    assert paths[1].endswith("12345-shared_screen_with_speaker_view.mp4")
+
+
+def test_recordings_download_filter_by_file_type(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+
+    def fake_get(_client, _meeting_id):
+        return {
+            "recording_files": [
+                {
+                    "id": "f1",
+                    "file_type": "MP4",
+                    "file_extension": "MP4",
+                    "recording_type": "x",
+                    "download_url": "https://x",
+                },
+                {
+                    "id": "f2",
+                    "file_type": "CHAT",
+                    "file_extension": "TXT",
+                    "recording_type": "y",
+                    "download_url": "https://y",
+                },
+            ]
+        }
+
+    written: list = []
+
+    def fake_stream(self, url, dest):
+        with open(dest, "wb") as f:
+            f.write(b"x")
+        written.append(url)
+        return 1
+
+    _patch_recordings_module(monkeypatch, get_recordings=fake_get)
+    monkeypatch.setattr("zoom_cli.api.client.ApiClient.stream_download", fake_stream)
+
+    result = runner.invoke(
+        main,
+        [
+            "recordings",
+            "download",
+            "12345",
+            "--out-dir",
+            str(tmp_path),
+            "--file-type",
+            "MP4",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert written == ["https://x"]
+
+
+def test_recordings_download_handles_no_files(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+    _patch_recordings_module(monkeypatch, get_recordings=lambda _c, _id: {"recording_files": []})
+    result = runner.invoke(main, ["recordings", "download", "12345", "--out-dir", str(tmp_path)])
+    assert result.exit_code == 0, result.output
+    assert "No recording files" in result.output
+
+
+# delete
+
+
+def test_recordings_delete_dry_run_no_api_call(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    called = {"n": 0}
+
+    def fake_delete(*_a, **_k):
+        called["n"] += 1
+
+    _patch_recordings_module(monkeypatch, delete_recordings=fake_delete)
+    result = runner.invoke(main, ["recordings", "delete", "12345", "--dry-run"])
+    assert result.exit_code == 0, result.output
+    assert "[dry-run]" in result.output
+    assert called["n"] == 0
+
+
+def test_recordings_delete_default_trash_confirm(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    _patch_recordings_module(monkeypatch, delete_recordings=lambda *_a, **_k: None)
+    result = runner.invoke(main, ["recordings", "delete", "12345"], input="n\n")
+    assert result.exit_code == 0, result.output
+    assert "Move" in result.output and "trash" in result.output
+    assert "Aborted" in result.output
+
+
+def test_recordings_delete_action_delete_louder_prompt(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    _patch_recordings_module(monkeypatch, delete_recordings=lambda *_a, **_k: None)
+    result = runner.invoke(
+        main, ["recordings", "delete", "12345", "--action", "delete"], input="n\n"
+    )
+    assert result.exit_code == 0, result.output
+    assert "Permanently delete" in result.output
+    assert "cannot be undone" in result.output
+
+
+def test_recordings_delete_yes_skips_confirmation(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured = {}
+
+    def fake_delete(_client, meeting_id, *, action):
+        captured.update({"meeting_id": meeting_id, "action": action})
+
+    _patch_recordings_module(monkeypatch, delete_recordings=fake_delete)
+    result = runner.invoke(main, ["recordings", "delete", "12345", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert captured == {"meeting_id": "12345", "action": "trash"}
+    assert "Trashed" in result.output
+
+
+def test_recordings_delete_single_file_with_file_id(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured = {}
+
+    def fake_delete_file(_client, meeting_id, recording_id, *, action):
+        captured.update({"meeting_id": meeting_id, "recording_id": recording_id, "action": action})
+
+    # Patch the single-file delete; the bulk delete should NOT be called.
+    bulk_called = {"n": 0}
+    _patch_recordings_module(
+        monkeypatch,
+        delete_recording_file=fake_delete_file,
+        delete_recordings=lambda *_a, **_k: bulk_called.__setitem__("n", bulk_called["n"] + 1),
+    )
+
+    result = runner.invoke(main, ["recordings", "delete", "12345", "--file-id", "rec-abc", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert captured == {"meeting_id": "12345", "recording_id": "rec-abc", "action": "trash"}
+    assert bulk_called["n"] == 0

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -8,7 +8,7 @@ import questionary
 from click_default_group import DefaultGroup
 
 from zoom_cli import auth
-from zoom_cli.api import meetings, oauth, users
+from zoom_cli.api import meetings, oauth, recordings, users
 from zoom_cli.api.client import ApiClient, ZoomApiError
 from zoom_cli.commands import (
     _edit,
@@ -932,6 +932,219 @@ def meetings_end(meeting_id, yes):
     except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
         _exit_on_api_error(exc)
     click.echo(f"Ended meeting {meeting_id}.")
+
+
+# ---- Zoom Cloud Recordings ----------------------------------------------
+#
+# Closes #15. Same confirmation-flow design as `meetings delete`:
+#   - delete always confirms unless --yes
+#   - --action delete (permanent) gets a louder prompt than the default
+#     trash (recoverable for 30 days)
+#   - --dry-run for previews
+#
+# `download` is read-only on Zoom's side (just fetches files) so no
+# confirmation needed. By default it writes one file per recording asset
+# into --out-dir; --file-type filters to just MP4, M4A, etc.
+
+
+@main.group(
+    "recordings",
+    help="Zoom Cloud Recordings API (https://developers.zoom.us/docs/api/cloud-recording/).",
+)
+def recordings_cmd():
+    """Group for ``zoom recordings ...``."""
+
+
+@recordings_cmd.command("list", help="List recorded meetings (paginated).")
+@click.option(
+    "--user-id",
+    default="me",
+    show_default=True,
+    help="Whose recordings to list. Default 'me'.",
+)
+@click.option(
+    "--from",
+    "from_",
+    metavar="YYYY-MM-DD",
+    help="Lower bound on meeting start (ISO date).",
+)
+@click.option("--to", metavar="YYYY-MM-DD", help="Upper bound on meeting start (ISO date).")
+@click.option(
+    "--page-size",
+    type=click.IntRange(1, 300),
+    default=300,
+    show_default=True,
+    help="Items per page request.",
+)
+@_translate_keyring_errors
+def recordings_list(user_id, from_, to, page_size):
+    """Output is tab-separated (uuid\\tmeeting_id\\ttopic\\tstart_time\\tfile_count)
+    so it pipes into cut/awk/column."""
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            click.echo("uuid\tmeeting_id\ttopic\tstart_time\tfile_count")
+            for meeting in recordings.list_recordings(
+                client,
+                user_id=user_id,
+                from_=from_,
+                to=to,
+                page_size=page_size,
+            ):
+                click.echo(
+                    f"{meeting.get('uuid', '')}\t"
+                    f"{meeting.get('id', '')}\t"
+                    f"{meeting.get('topic', '')}\t"
+                    f"{meeting.get('start_time', '')}\t"
+                    f"{len(meeting.get('recording_files', []))}"
+                )
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+
+
+@recordings_cmd.command(
+    "get",
+    help="Print a meeting's recording metadata as JSON (GET /meetings/<id>/recordings).",
+)
+@click.argument("meeting_id")
+@_translate_keyring_errors
+def recordings_get(meeting_id):
+    """Output is the raw JSON envelope (sort_keys for diff-friendly).
+    Pipe through `jq` to extract download URLs or filter by file_type."""
+    import json as _json
+
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            envelope = recordings.get_recordings(client, meeting_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(_json.dumps(envelope, indent=2, sort_keys=True))
+
+
+@recordings_cmd.command(
+    "download",
+    help="Download recording files for a meeting to disk.",
+)
+@click.argument("meeting_id")
+@click.option(
+    "--out-dir",
+    type=click.Path(file_okay=False, writable=True, resolve_path=True),
+    default=".",
+    show_default=True,
+    help="Directory to write files into. Created automatically if missing.",
+)
+@click.option(
+    "--file-type",
+    multiple=True,
+    metavar="TYPE",
+    help=(
+        "Filter by file_type (MP4, M4A, CHAT, TRANSCRIPT, TIMELINE, CC, CSV). "
+        "May be repeated to include multiple types. Omit to download all."
+    ),
+)
+@_translate_keyring_errors
+def recordings_download(meeting_id, out_dir, file_type):
+    """Streams each file to disk via tempfile + os.replace, so a network
+    drop mid-download leaves no half-written file at the target path.
+
+    Filename convention: <meeting_id>-<recording_type>.<file_extension>.
+    Conflicts (same recording_type appearing twice) are disambiguated by
+    appending the recording_id."""
+    import os
+    import pathlib
+
+    pathlib.Path(out_dir).mkdir(parents=True, exist_ok=True)
+    type_filter = {t.upper() for t in file_type} if file_type else None
+
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            envelope = recordings.get_recordings(client, meeting_id)
+            files = envelope.get("recording_files", []) or []
+            if type_filter is not None:
+                files = [f for f in files if (f.get("file_type") or "").upper() in type_filter]
+            if not files:
+                click.echo(f"No recording files for meeting {meeting_id}.")
+                return
+
+            seen_names: set[str] = set()
+            for f in files:
+                ext = (f.get("file_extension") or "bin").lower()
+                rtype = (f.get("recording_type") or f.get("file_type") or "file").lower()
+                base = f"{meeting_id}-{rtype}.{ext}"
+                if base in seen_names:
+                    base = f"{meeting_id}-{rtype}-{f.get('id', '')}.{ext}"
+                seen_names.add(base)
+                dest = os.path.join(out_dir, base)
+                url = f.get("download_url")
+                if not url:
+                    click.echo(f"Skipping {base} — no download_url in payload.", err=True)
+                    continue
+                bytes_written = client.stream_download(url, dest)
+                click.echo(f"Downloaded {dest} ({bytes_written} bytes)")
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+
+
+@recordings_cmd.command(
+    "delete",
+    help="Delete a meeting's recordings (DELETE /meetings/<id>/recordings).",
+)
+@click.argument("meeting_id")
+@click.option(
+    "--file-id",
+    help="Delete a single recording file. Omit to delete ALL files for the meeting.",
+)
+@click.option(
+    "--action",
+    type=click.Choice(list(recordings.ALLOWED_DELETE_ACTIONS)),
+    default="trash",
+    show_default=True,
+    help=(
+        "trash: move to Zoom's trash (recoverable for 30 days); delete: permanent, irreversible."
+    ),
+)
+@click.option("--yes", "-y", is_flag=True, default=False, help="Skip the confirmation prompt.")
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Show what would happen without calling the API.",
+)
+@_translate_keyring_errors
+def recordings_delete(meeting_id, file_id, action, yes, dry_run):
+    """Always confirms unless --yes. The prompt is louder for
+    `--action delete` (permanent) than for the default trash."""
+    target = (
+        f"recording file {file_id} of meeting {meeting_id}"
+        if file_id
+        else f"all recordings for meeting {meeting_id}"
+    )
+    if dry_run:
+        click.echo(f"[dry-run] Would {action} {target}.")
+        return
+
+    if not yes:
+        if action == "delete":
+            prompt = f"Permanently delete {target}? This cannot be undone."
+        else:
+            prompt = f"Move {target} to trash? (Recoverable for 30 days.)"
+        if not click.confirm(prompt, default=False):
+            click.echo("Aborted.")
+            return
+
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            if file_id:
+                recordings.delete_recording_file(client, meeting_id, file_id, action=action)
+            else:
+                recordings.delete_recordings(client, meeting_id, action=action)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    verb = "Deleted" if action == "delete" else "Trashed"
+    click.echo(f"{verb} {target}.")
 
 
 if __name__ == "__main__":

--- a/zoom_cli/api/client.py
+++ b/zoom_cli/api/client.py
@@ -297,3 +297,67 @@ class ApiClient:
         """Convenience wrapper for ``DELETE``. Most Zoom delete endpoints
         respond with ``204 No Content`` (returns ``{}``)."""
         return self.request("DELETE", path, params=params)
+
+    # ---- streaming download ------------------------------------------
+
+    def stream_download(self, url: str, dest_path: str) -> int:
+        """Stream a download URL to ``dest_path``; return bytes written.
+
+        Used for Zoom recording files (and any other downloadable that
+        isn't on the JSON API). Authenticates via the same bearer token
+        as :meth:`request`. Does NOT go through the JSON parsing path —
+        the body is binary, not JSON.
+
+        Streams the body so a 1.5 GB MP4 doesn't load into memory. Writes
+        via a sibling tempfile + ``os.replace`` so a partial download
+        (network drop) doesn't leave half a file at ``dest_path``.
+
+        On a 401 the cached token is force-refreshed and the stream
+        retried once (same policy as :meth:`request`). 429s on Zoom's
+        download host are uncommon; deferred to issue #49 if needed.
+
+        Raises:
+            ZoomApiError: any non-2xx response, with the response body
+                surfaced as the message.
+        """
+        import os
+        import tempfile
+
+        for force_refresh in (False, True):
+            token = self._access_token(force_refresh=force_refresh)
+            with self._http.stream(
+                "GET",
+                url,
+                headers={"Authorization": f"Bearer {token.value}"},
+            ) as response:
+                if response.status_code == 401 and not force_refresh:
+                    # Drain so the connection can be reused for the retry.
+                    response.read()
+                    continue
+                if response.status_code >= 400:
+                    response.read()
+                    raise ZoomApiError(
+                        response.text or f"HTTP {response.status_code}",
+                        status_code=response.status_code,
+                    )
+                # Stream the body to a tempfile in the same directory as
+                # dest_path so os.replace is atomic.
+                dest_dir = os.path.dirname(os.path.abspath(dest_path)) or "."
+                fd, tmp_path = tempfile.mkstemp(prefix=".zoom-dl.", dir=dest_dir)
+                bytes_written = 0
+                try:
+                    with os.fdopen(fd, "wb") as f:
+                        for chunk in response.iter_bytes():
+                            f.write(chunk)
+                            bytes_written += len(chunk)
+                    os.replace(tmp_path, dest_path)
+                except BaseException:
+                    import contextlib as _ctx
+
+                    with _ctx.suppress(OSError):
+                        os.unlink(tmp_path)
+                    raise
+                return bytes_written
+
+        # Defensive — the for-loop above always returns or raises.
+        raise RuntimeError("unreachable")

--- a/zoom_cli/api/recordings.py
+++ b/zoom_cli/api/recordings.py
@@ -1,0 +1,139 @@
+"""Zoom Cloud Recordings API helpers.
+
+Reference: https://developers.zoom.us/docs/api/cloud-recording/
+
+Endpoints covered:
+
+  list_recordings(client, *, user_id="me", from_=None, to=None,
+                  page_size=DEFAULT_PAGE_SIZE)
+      → GET /users/{user_id}/recordings (paginated)
+
+  get_recordings(client, meeting_id)
+      → GET /meetings/{meeting_id}/recordings
+
+  delete_recordings(client, meeting_id, *, action="trash")
+      → DELETE /meetings/{meeting_id}/recordings
+
+  delete_recording_file(client, meeting_id, recording_id, *, action="trash")
+      → DELETE /meetings/{meeting_id}/recordings/{recording_id}
+
+Downloads use :meth:`zoom_cli.api.client.ApiClient.stream_download`
+directly — the download URL on the recording_file object isn't a normal
+JSON endpoint.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from urllib.parse import quote
+
+from zoom_cli.api.client import ApiClient
+from zoom_cli.api.pagination import DEFAULT_PAGE_SIZE, paginate
+
+#: Allowed values for ``delete_recordings(..., action=...)``. ``trash``
+#: (default) moves the recording to Zoom's trash (recoverable for 30
+#: days); ``delete`` is a permanent, immediate delete.
+ALLOWED_DELETE_ACTIONS: tuple[str, ...] = ("trash", "delete")
+
+
+def get_recordings(client: ApiClient, meeting_id: str | int) -> dict[str, Any]:
+    """``GET /meetings/{meeting_id}/recordings`` — return all recording
+    files for a single meeting.
+
+    The returned envelope contains the meeting's metadata plus a
+    ``recording_files`` array (each entry has ``id``, ``file_type``,
+    ``file_extension``, ``file_size``, ``download_url``,
+    ``recording_type``).
+
+    Required scopes: ``recording:read:recording`` (or any scope that
+    includes it).
+    """
+    return client.get(f"/meetings/{quote(str(meeting_id), safe='')}/recordings")
+
+
+def list_recordings(
+    client: ApiClient,
+    *,
+    user_id: str = "me",
+    from_: str | None = None,
+    to: str | None = None,
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> Iterator[dict[str, Any]]:
+    """``GET /users/{user_id}/recordings`` — yield recorded meetings
+    across all pages.
+
+    Args:
+        client: Authenticated :class:`ApiClient`.
+        user_id: Whose recordings to list. Default ``"me"``.
+        from_: ISO date (YYYY-MM-DD) lower bound on meeting start.
+            Zoom's parameter name is just ``from``, but Python reserves
+            that, so the kwarg is ``from_``.
+        to: ISO date upper bound on meeting start.
+        page_size: Items per page; see
+            :data:`~zoom_cli.api.pagination.DEFAULT_PAGE_SIZE`.
+
+    Yields:
+        One meeting dict per recorded meeting (each contains a
+        ``recording_files`` array with the actual files).
+
+    Required scopes: ``recording:read:list_user_recordings``.
+    """
+    params: dict[str, Any] = {}
+    if from_ is not None:
+        params["from"] = from_
+    if to is not None:
+        params["to"] = to
+    return paginate(
+        client,
+        f"/users/{quote(user_id, safe='')}/recordings",
+        item_key="meetings",
+        params=params,
+        page_size=page_size,
+    )
+
+
+def delete_recordings(
+    client: ApiClient,
+    meeting_id: str | int,
+    *,
+    action: str = "trash",
+) -> dict[str, Any]:
+    """``DELETE /meetings/{meeting_id}/recordings`` — delete ALL
+    recordings for a meeting.
+
+    ``action="trash"`` (default) is recoverable; ``action="delete"`` is
+    permanent. Returns ``{}`` (Zoom responds with ``204 No Content``).
+
+    Required scopes: ``recording:write:recording``.
+    """
+    if action not in ALLOWED_DELETE_ACTIONS:
+        raise ValueError(f"action must be one of {ALLOWED_DELETE_ACTIONS!r}, got {action!r}")
+    return client.delete(
+        f"/meetings/{quote(str(meeting_id), safe='')}/recordings",
+        params={"action": action},
+    )
+
+
+def delete_recording_file(
+    client: ApiClient,
+    meeting_id: str | int,
+    recording_id: str,
+    *,
+    action: str = "trash",
+) -> dict[str, Any]:
+    """``DELETE /meetings/{meeting_id}/recordings/{recording_id}`` —
+    delete a single recording file (one entry of the recording_files
+    array).
+
+    Same ``action`` semantics as :func:`delete_recordings`.
+
+    Required scopes: ``recording:write:recording``.
+    """
+    if action not in ALLOWED_DELETE_ACTIONS:
+        raise ValueError(f"action must be one of {ALLOWED_DELETE_ACTIONS!r}, got {action!r}")
+    return client.delete(
+        f"/meetings/{quote(str(meeting_id), safe='')}/recordings/"
+        f"{quote(str(recording_id), safe='')}",
+        params={"action": action},
+    )


### PR DESCRIPTION
## Summary

Closes #15 — adds the full recordings surface (list/get/download/delete) plus the underlying `stream_download` plumbing.

| Command | Endpoint | Notes |
|---|---|---|
| `zoom recordings list` | paginated `GET /users/<id>/recordings` | TSV with file count per meeting |
| `zoom recordings get <id>` | `GET /meetings/<id>/recordings` | JSON for jq pipelines |
| `zoom recordings download <id>` | binary stream of each `download_url` | atomic per-file write |
| `zoom recordings delete <id>` | `DELETE /meetings/<id>/recordings[/<file-id>]` | trash vs permanent; --yes/--dry-run |

## What's new

### `zoom_cli/api/client.py` — `ApiClient.stream_download`

```python
def stream_download(self, url: str, dest_path: str) -> int
```

Bearer-authenticated streamed GET. Body iterates to a sibling tempfile (`.zoom-dl.*`) and `os.replace`s onto `dest_path` atomically — a network drop mid-download leaves nothing at the destination, no orphan tempfile in the directory. Single-shot 401 retry with force-refresh (same policy as `.request()`). 429 on Zoom's download host is uncommon; deferred to #49.

### `zoom_cli/api/recordings.py` (new module)

```python
list_recordings(client, *, user_id="me", from_=None, to=None, page_size=300) -> Iterator[dict]
get_recordings(client, meeting_id) -> dict
delete_recordings(client, meeting_id, *, action="trash") -> dict
delete_recording_file(client, meeting_id, recording_id, *, action="trash") -> dict
ALLOWED_DELETE_ACTIONS = ("trash", "delete")
```

`list_recordings` uses `from_=` (not `from`, which is reserved). `delete_*` validate `action` against the pinned tuple.

### CLI

- **`zoom recordings list`** — TSV: `uuid\tmeeting_id\ttopic\tstart_time\tfile_count`. `--user-id` (default `me`), `--from YYYY-MM-DD`, `--to YYYY-MM-DD`, `--page-size 1..300`.
- **`zoom recordings get <meeting-id>`** — pretty-printed JSON (sort_keys for diff-friendly).
- **`zoom recordings download <meeting-id>`** — `--out-dir` (default `.`, created if missing), `--file-type` (repeatable: MP4, M4A, CHAT, TRANSCRIPT, TIMELINE, CC, CSV). Filename convention: `<meeting_id>-<recording_type>.<ext>` (collision-disambiguated by recording_id). Echoes `Downloaded <path> (N bytes)` per file.
- **`zoom recordings delete <meeting-id>`** — `--file-id` for single-file delete (omit to delete all); `--action trash|delete` (default trash); `--yes` skips confirm; `--dry-run` previews. Confirmation phrasing differs:
  - default trash: `"Move <target> to trash? (Recoverable for 30 days.)"`
  - `--action delete`: `"Permanently delete <target>? This cannot be undone."`

## Tests (+28 new)

| File | New | Covers |
|---|---|---|
| `tests/test_api_recordings.py` | +12 | each verb's path; URL-encoding for both meeting_id and recording_id; list date-filter forwarding; pagination cursor walk; action allowlist validation; constant pinned |
| `tests/test_api_client.py` | +4 | `stream_download` writes bytes atomically with bearer auth; single-shot 401 retry with token refresh; 404 raises `ZoomApiError` and leaves no partial file; mid-stream failure cleans up the tempfile |
| `tests/test_cli.py` | +12 | list bails-no-creds + TSV header + date filter forwarding; get JSON; download writes each file with the right filename + `--file-type` filtering + no-files case; delete `--dry-run`, default-trash confirm phrasing, louder permanent-delete prompt, `--yes` skips confirm, `--file-id` targets single-file endpoint |

All HTTP via `httpx.MockTransport` (or `MagicMock` for API helpers). No socket I/O, no real Zoom API calls. The download tests run against `tmp_path` so they leave nothing behind.

## Verification

```
ruff check .          # All checks passed!
ruff format --check . # 27 files already formatted
mypy                  # Success: no issues found in 13 source files
pytest -q             # 354 passed (was 326; +28)
```

## Out of scope (deferred)

- 429 / Retry-After on the download host (Zoom rarely throttles downloads — covered by #49 if it becomes a problem in practice).
- Progress bar for large downloads — current output is one line per file with byte count; sufficient for scripted use, can add `--progress` later.
- Resume of partial downloads (HTTP `Range`) — current behaviour is full re-download on retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)