### PR TITLE
feat(auth,cli): close #12 — user OAuth 2.0 + PKCE (zoom auth login)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Meetings CLI surface (PR #51): closes #13 (read-only piece). New `zoom meetings list` and `zoom meetings get <meeting-id>` commands; `zoom_cli/api/meetings.py` mirrors the structure of `users.py`.
 > Meetings write surface (PR #52): closes #13 (write piece). New `zoom meetings create / update / delete / end` commands. `ApiClient` gains `post`/`patch`/`put`/`delete` convenience wrappers.
 > Users write surface (PR #53): closes #14 (write + settings-read piece). New `zoom users create / delete / settings get` commands.
-> Recordings surface (this branch): closes #15. New `zoom recordings list / get / download / delete` commands; `zoom_cli/api/recordings.py`; `ApiClient.stream_download` for atomic streamed downloads.
+> Recordings surface (PR #54): closes #15. New `zoom recordings list / get / download / delete` commands; `zoom_cli/api/recordings.py`; `ApiClient.stream_download` for atomic streamed downloads.
+> User OAuth + PKCE (this branch): closes #12. New `zoom auth login` 3-legged OAuth flow with loopback callback; `zoom_cli/api/user_oauth.py`; refresh-token storage in keyring service `zoom-cli-user-auth`; extended `auth status` and `auth logout` to cover both surfaces.
+
+### Added (issue #12)
+- `zoom_cli/api/user_oauth.py` — PKCE primitives (`_pkce_pair`, `_random_state`), `build_authorize_url`, `exchange_code_for_tokens`, `refresh_user_tokens`, end-to-end `run_pkce_flow` with loopback HTTP server + browser launch + state-mismatch CSRF check + 5-minute timeout.
+- `zoom_cli.auth.UserOAuthCredentials` (refresh_token + client_id) plus `save_user_oauth_credentials` / `load_user_oauth_credentials` / `clear_user_oauth_credentials` / `has_user_oauth_credentials`. Best-effort transactional save (mirrors #35 pattern); load propagates `NoKeyringError` (#41 pattern). Stored under service `zoom-cli-user-auth`, distinct from `zoom-cli-auth` (S2S) so `zoom auth logout` can clear one without touching the other.
+- `zoom auth login --client-id <id> [--port N] [--timeout S] [--no-browser]` CLI command. Picks up `ZOOM_USER_CLIENT_ID` env var. Prints the auth URL before launching the browser so headless / SSH sessions can paste it. `--no-browser` skips the launch (useful when the URL just needs to be shared).
+
+### Changed (issue #12)
+- `zoom auth status` now reports both surfaces (S2S and User OAuth) with separate "configured / not configured" lines plus the right "run X to configure" hint for each.
+- `zoom auth logout` clears both stores (S2S and User OAuth) and reports both clears.
 
 ### Added (issue #15)
 - `zoom recordings list [--user-id me] [--from YYYY-MM-DD] [--to YYYY-MM-DD] [--page-size N]` — paginates `GET /users/<user-id>/recordings`. TSV output: `uuid\tmeeting_id\ttopic\tstart_time\tfile_count`.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -151,3 +151,95 @@ def test_save_rolls_back_to_empty_when_no_prior_state(monkeypatch: pytest.Monkey
 
     # No prior creds → rollback should delete what was written → load returns None.
     assert auth.load_s2s_credentials() is None
+
+
+# ---- user OAuth credential storage (closes #12 storage layer) ----------
+
+
+def _user_creds() -> auth.UserOAuthCredentials:
+    return auth.UserOAuthCredentials(refresh_token="rt-1", client_id="cid-A")
+
+
+def test_user_oauth_save_then_load_round_trips() -> None:
+    creds = _user_creds()
+    auth.save_user_oauth_credentials(creds)
+    assert auth.load_user_oauth_credentials() == creds
+
+
+def test_user_oauth_load_returns_none_when_nothing_saved() -> None:
+    assert auth.load_user_oauth_credentials() is None
+    assert auth.has_user_oauth_credentials() is False
+
+
+def test_user_oauth_clear_removes_all_keys() -> None:
+    auth.save_user_oauth_credentials(_user_creds())
+    auth.clear_user_oauth_credentials()
+    assert auth.load_user_oauth_credentials() is None
+    for key in ("user.refresh_token", "user.client_id"):
+        assert keyring.get_password(auth.SERVICE_NAME_USER, key) is None
+
+
+def test_user_oauth_clear_is_idempotent() -> None:
+    auth.clear_user_oauth_credentials()
+    auth.clear_user_oauth_credentials()
+
+
+def test_user_oauth_load_returns_none_when_only_partial() -> None:
+    """Both keys are required; presence of just one means 'not configured'."""
+    keyring.set_password(auth.SERVICE_NAME_USER, "user.refresh_token", "only-this")
+    assert auth.load_user_oauth_credentials() is None
+
+
+def test_user_oauth_has_swallows_no_keyring_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def boom(*_a, **_kw):
+        raise keyring.errors.NoKeyringError("no backend")
+
+    monkeypatch.setattr(keyring, "get_password", boom)
+    assert auth.has_user_oauth_credentials() is False
+
+
+def test_user_oauth_load_propagates_no_keyring_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same #41 policy as S2S: load_* propagates so the CLI can show a
+    distinct exit code; has_* swallows for probe-style use."""
+
+    def boom(*_a, **_kw):
+        raise keyring.errors.NoKeyringError("no backend")
+
+    monkeypatch.setattr(keyring, "get_password", boom)
+    with pytest.raises(keyring.errors.NoKeyringError):
+        auth.load_user_oauth_credentials()
+
+
+@pytest.mark.parametrize("fail_on_call", [1, 2])
+def test_user_oauth_save_rolls_back_on_partial_failure(
+    monkeypatch: pytest.MonkeyPatch, fail_on_call: int
+) -> None:
+    """Same #35 transactional pattern as S2S save."""
+    old = auth.UserOAuthCredentials(refresh_token="OLD-rt", client_id="OLD-cid")
+    auth.save_user_oauth_credentials(old)
+
+    new = auth.UserOAuthCredentials(refresh_token="NEW-rt", client_id="NEW-cid")
+    real_set = keyring.set_password
+    counter = {"calls": 0}
+
+    def flaky(service, username, password):
+        counter["calls"] += 1
+        if counter["calls"] == fail_on_call:
+            raise keyring.errors.KeyringError(f"sim fail call {fail_on_call}")
+        real_set(service, username, password)
+
+    monkeypatch.setattr(keyring, "set_password", flaky)
+    with pytest.raises(keyring.errors.KeyringError):
+        auth.save_user_oauth_credentials(new)
+
+    # Old creds intact after rollback.
+    assert auth.load_user_oauth_credentials() == old
+
+
+def test_user_service_name_pinned() -> None:
+    """Future rename would orphan every existing user's saved refresh."""
+    assert auth.SERVICE_NAME_USER == "zoom-cli-user-auth"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -232,13 +232,15 @@ def test_auth_s2s_set_reads_account_and_client_id_from_env(runner: CliRunner) ->
 
 
 def test_auth_status_when_configured(runner: CliRunner) -> None:
+    """S2S configured + user-OAuth not configured. The output now reports
+    both surfaces (closes #12 status integration), so we just assert the
+    S2S half is shown as configured."""
     from zoom_cli import auth
 
     auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
     result = runner.invoke(main, ["auth", "status"])
     assert result.exit_code == 0, result.output
-    assert "configured" in result.output
-    assert "not configured" not in result.output
+    assert "Server-to-Server OAuth: configured" in result.output
 
 
 def test_auth_logout_clears_keyring(runner: CliRunner) -> None:
@@ -1884,3 +1886,131 @@ def test_recordings_delete_single_file_with_file_id(
     assert result.exit_code == 0, result.output
     assert captured == {"meeting_id": "12345", "recording_id": "rec-abc", "action": "trash"}
     assert bulk_called["n"] == 0
+
+
+# ---- #12: zoom auth login (PKCE) ----------------------------------------
+
+
+def test_auth_login_requires_client_id(runner: CliRunner) -> None:
+    """--client-id has no default — must come from flag or env."""
+    result = runner.invoke(main, ["auth", "login"])
+    assert result.exit_code != 0
+    # Either the env-var path also must be empty, or click reports missing.
+    assert "client-id" in result.output.lower() or "missing" in result.output.lower()
+
+
+def test_auth_login_persists_refresh_token_to_keyring(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Stub run_pkce_flow to return tokens directly; assert refresh +
+    client_id land in the keyring."""
+    from datetime import datetime, timedelta, timezone
+
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+    from zoom_cli.api.user_oauth import UserOAuthTokens
+
+    fake_tokens = UserOAuthTokens(
+        access_token="acc-123",
+        refresh_token="ref-XYZ",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        scopes=("user:read", "meeting:read"),
+    )
+
+    captured = {}
+
+    def fake_flow(client_id, **kwargs):
+        captured["client_id"] = client_id
+        captured["kwargs"] = kwargs
+        return fake_tokens
+
+    monkeypatch.setattr(main_mod.user_oauth, "run_pkce_flow", fake_flow)
+
+    result = runner.invoke(main, ["auth", "login", "--client-id", "MY-CID", "--no-browser"])
+    assert result.exit_code == 0, result.output
+    assert captured["client_id"] == "MY-CID"
+    # Browser was suppressed.
+    browser = captured["kwargs"]["browser"]
+    assert callable(browser)
+    assert browser("https://example.com") is False  # the no-op no-browser
+
+    saved = auth.load_user_oauth_credentials()
+    assert saved is not None
+    assert saved.refresh_token == "ref-XYZ"
+    assert saved.client_id == "MY-CID"
+
+    assert "Logged in" in result.output
+    assert "ref-XYZ" not in result.output  # never echo the secret
+
+
+def test_auth_login_reports_oauth_error_distinctly(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli.api.user_oauth import ZoomUserAuthError
+
+    def fake_flow(*_a, **_kw):
+        raise ZoomUserAuthError("Code expired", status_code=400, error_code="invalid_grant")
+
+    monkeypatch.setattr(main_mod.user_oauth, "run_pkce_flow", fake_flow)
+
+    result = runner.invoke(main, ["auth", "login", "--client-id", "MY-CID", "--no-browser"])
+    assert result.exit_code == 1
+    assert "OAuth failed" in result.output
+    assert "Code expired" in result.output
+
+
+def test_auth_login_reports_timeout_distinctly(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import zoom_cli.__main__ as main_mod
+
+    def fake_flow(*_a, **_kw):
+        raise TimeoutError("user took too long")
+
+    monkeypatch.setattr(main_mod.user_oauth, "run_pkce_flow", fake_flow)
+    result = runner.invoke(main, ["auth", "login", "--client-id", "MY-CID", "--no-browser"])
+    assert result.exit_code == 1
+    assert "Timed out" in result.output
+
+
+def test_auth_status_reports_both_surfaces(runner: CliRunner) -> None:
+    """Both S2S configured + user OAuth configured."""
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+    auth.save_user_oauth_credentials(
+        auth.UserOAuthCredentials(refresh_token="rt", client_id="cid-X")
+    )
+    result = runner.invoke(main, ["auth", "status"])
+    assert result.exit_code == 0, result.output
+    assert "Server-to-Server OAuth: configured" in result.output
+    assert "User OAuth (PKCE): configured" in result.output
+
+
+def test_auth_status_reports_user_oauth_unconfigured_separately(runner: CliRunner) -> None:
+    """S2S configured + user OAuth NOT configured → shows the user-side
+    'not configured' line so users know how to add it."""
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+    result = runner.invoke(main, ["auth", "status"])
+    assert "Server-to-Server OAuth: configured" in result.output
+    assert "User OAuth (PKCE): not configured" in result.output
+
+
+def test_auth_logout_clears_both_stores(runner: CliRunner) -> None:
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+    auth.save_user_oauth_credentials(auth.UserOAuthCredentials(refresh_token="rt", client_id="cid"))
+    assert auth.has_s2s_credentials() is True
+    assert auth.has_user_oauth_credentials() is True
+
+    result = runner.invoke(main, ["auth", "logout"])
+    assert result.exit_code == 0, result.output
+    assert "Cleared Server-to-Server OAuth" in result.output
+    assert "Cleared User OAuth" in result.output
+
+    assert auth.has_s2s_credentials() is False
+    assert auth.has_user_oauth_credentials() is False

--- a/tests/test_user_oauth.py
+++ b/tests/test_user_oauth.py
@@ -1,0 +1,239 @@
+"""Tests for zoom_cli.api.user_oauth — PKCE flow components.
+
+The end-to-end ``run_pkce_flow`` is integration territory (real socket +
+real browser) so we test the components individually:
+
+- PKCE pair generation (charset, length, challenge derivation).
+- Authorize URL construction (pure).
+- Token exchange (httpx.MockTransport).
+- Refresh token (httpx.MockTransport).
+- Error paths on both (4xx + non-JSON 2xx).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from datetime import datetime, timezone
+from urllib.parse import parse_qs, urlsplit
+
+import httpx
+import pytest
+from zoom_cli.api import user_oauth
+
+# ---- PKCE primitives ----------------------------------------------------
+
+
+def test_pkce_pair_verifier_in_rfc7636_range() -> None:
+    """RFC 7636 requires 43..128 chars from [A-Z / a-z / 0-9 / "-" / "." /
+    "_" / "~"]. token_urlsafe(48) yields ~64 base64url chars; pin both
+    bounds + the charset."""
+    verifier, _challenge = user_oauth._pkce_pair()
+    assert 43 <= len(verifier) <= 128
+    allowed = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+    assert set(verifier) <= allowed
+
+
+def test_pkce_pair_challenge_is_sha256_of_verifier() -> None:
+    verifier, challenge = user_oauth._pkce_pair()
+    expected = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("ascii")).digest())
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    assert challenge == expected
+
+
+def test_pkce_pair_is_random() -> None:
+    pairs = {user_oauth._pkce_pair() for _ in range(5)}
+    # 5 calls should give 5 distinct pairs.
+    assert len(pairs) == 5
+
+
+def test_random_state_is_url_safe_and_random() -> None:
+    states = {user_oauth._random_state() for _ in range(5)}
+    assert len(states) == 5
+    for s in states:
+        assert s and not any(c in s for c in "+/=")
+
+
+# ---- authorize URL ------------------------------------------------------
+
+
+def test_build_authorize_url_has_required_params() -> None:
+    url = user_oauth.build_authorize_url(
+        client_id="cid-123",
+        redirect_uri="http://127.0.0.1:8765/callback",
+        code_challenge="abc",
+        state="state-xyz",
+    )
+    parsed = urlsplit(url)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "zoom.us"
+    assert parsed.path == "/oauth/authorize"
+    qs = parse_qs(parsed.query)
+    assert qs["response_type"] == ["code"]
+    assert qs["client_id"] == ["cid-123"]
+    assert qs["redirect_uri"] == ["http://127.0.0.1:8765/callback"]
+    assert qs["code_challenge"] == ["abc"]
+    assert qs["code_challenge_method"] == ["S256"]
+    assert qs["state"] == ["state-xyz"]
+
+
+def test_build_authorize_url_url_encodes_redirect_with_port() -> None:
+    """Redirect URIs always end up percent-encoded by urlencode."""
+    url = user_oauth.build_authorize_url(
+        client_id="cid",
+        redirect_uri="http://127.0.0.1:55555/callback?extra=1",
+        code_challenge="c",
+        state="s",
+    )
+    # The colon and slashes inside redirect_uri are percent-encoded.
+    assert "%3A" in url and "%2F" in url
+
+
+# ---- token exchange ----------------------------------------------------
+
+
+def _ok_token_response(**overrides) -> dict:
+    base = {
+        "access_token": "access-tok-1",
+        "refresh_token": "refresh-tok-1",
+        "expires_in": 3600,
+        "scope": "user:read meeting:read",
+        "token_type": "bearer",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_exchange_code_for_tokens_round_trips() -> None:
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = bytes(request.content).decode()
+        return httpx.Response(200, json=_ok_token_response())
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http:
+        tokens = user_oauth.exchange_code_for_tokens(
+            client_id="cid",
+            redirect_uri="http://127.0.0.1:1234/callback",
+            code="auth-code",
+            code_verifier="verifier",
+            http=http,
+        )
+
+    assert tokens.access_token == "access-tok-1"
+    assert tokens.refresh_token == "refresh-tok-1"
+    assert tokens.scopes == ("user:read", "meeting:read")
+    assert tokens.expires_at > datetime.now(timezone.utc)
+    # Body is form-encoded.
+    body = parse_qs(captured["body"])
+    assert body["grant_type"] == ["authorization_code"]
+    assert body["code"] == ["auth-code"]
+    assert body["redirect_uri"] == ["http://127.0.0.1:1234/callback"]
+    assert body["client_id"] == ["cid"]
+    assert body["code_verifier"] == ["verifier"]
+
+
+def test_exchange_code_raises_on_4xx_with_zoom_error_envelope() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400,
+            json={"error": "invalid_grant", "reason": "Code expired"},
+        )
+
+    with (
+        httpx.Client(transport=httpx.MockTransport(handler)) as http,
+        pytest.raises(user_oauth.ZoomUserAuthError) as excinfo,
+    ):
+        user_oauth.exchange_code_for_tokens(
+            client_id="c", redirect_uri="r", code="c", code_verifier="v", http=http
+        )
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.error_code == "invalid_grant"
+    assert "Code expired" in str(excinfo.value)
+
+
+def test_exchange_code_raises_on_2xx_without_access_token() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"refresh_token": "r"})  # missing access_token
+
+    with (
+        httpx.Client(transport=httpx.MockTransport(handler)) as http,
+        pytest.raises(user_oauth.ZoomUserAuthError),
+    ):
+        user_oauth.exchange_code_for_tokens(
+            client_id="c", redirect_uri="r", code="c", code_verifier="v", http=http
+        )
+
+
+def test_exchange_code_raises_on_2xx_html_body() -> None:
+    """Captive-portal / proxy returning HTML on a 200."""
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, text="<html>captive portal</html>", headers={"Content-Type": "text/html"}
+        )
+
+    with (
+        httpx.Client(transport=httpx.MockTransport(handler)) as http,
+        pytest.raises(user_oauth.ZoomUserAuthError) as excinfo,
+    ):
+        user_oauth.exchange_code_for_tokens(
+            client_id="c", redirect_uri="r", code="c", code_verifier="v", http=http
+        )
+    assert "non-JSON" in str(excinfo.value)
+
+
+# ---- refresh ------------------------------------------------------------
+
+
+def test_refresh_user_tokens_round_trips() -> None:
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = bytes(request.content).decode()
+        return httpx.Response(
+            200,
+            json=_ok_token_response(refresh_token="rotated-refresh"),
+        )
+
+    with httpx.Client(transport=httpx.MockTransport(handler)) as http:
+        tokens = user_oauth.refresh_user_tokens(
+            refresh_token="old-refresh",
+            client_id="cid",
+            http=http,
+        )
+
+    body = parse_qs(captured["body"])
+    assert body["grant_type"] == ["refresh_token"]
+    assert body["refresh_token"] == ["old-refresh"]
+    assert body["client_id"] == ["cid"]
+    # Refresh tokens are rotated — caller must persist the new value.
+    assert tokens.refresh_token == "rotated-refresh"
+
+
+def test_refresh_user_tokens_raises_on_4xx() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            400, json={"error": "invalid_grant", "reason": "Refresh token expired"}
+        )
+
+    with (
+        httpx.Client(transport=httpx.MockTransport(handler)) as http,
+        pytest.raises(user_oauth.ZoomUserAuthError) as excinfo,
+    ):
+        user_oauth.refresh_user_tokens(refresh_token="r", client_id="c", http=http)
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.error_code == "invalid_grant"
+
+
+# ---- module constants --------------------------------------------------
+
+
+def test_authorize_and_token_urls_pinned() -> None:
+    """Future URL renames would silently break every existing user."""
+    assert user_oauth.AUTHORIZE_URL == "https://zoom.us/oauth/authorize"
+    assert user_oauth.TOKEN_URL == "https://zoom.us/oauth/token"

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -8,7 +8,7 @@ import questionary
 from click_default_group import DefaultGroup
 
 from zoom_cli import auth
-from zoom_cli.api import meetings, oauth, recordings, users
+from zoom_cli.api import meetings, oauth, recordings, user_oauth, users
 from zoom_cli.api.client import ApiClient, ZoomApiError
 from zoom_cli.commands import (
     _edit,
@@ -300,24 +300,114 @@ def _now():
 def status():
     """``status`` deliberately does NOT use ``@_translate_keyring_errors``.
 
-    ``has_s2s_credentials`` swallows backend-missing errors itself and
-    reports "not configured", which is the right UX for a probe-style
+    ``has_*_credentials`` swallow backend-missing errors themselves and
+    report "not configured", which is the right UX for a probe-style
     command — you don't want a 'check status' to crash the script. Users
     debugging a missing backend should run ``zoom auth s2s test`` (which
     surfaces the backend error).
+
+    Reports both auth surfaces — S2S (account-wide) and User OAuth
+    (per-developer, closes #12).
     """
     if auth.has_s2s_credentials():
         click.echo("Server-to-Server OAuth: configured")
     else:
         click.echo("Server-to-Server OAuth: not configured")
-        click.echo("Run `zoom auth s2s set` to configure.")
+        click.echo("  Run `zoom auth s2s set` to configure.")
+
+    if auth.has_user_oauth_credentials():
+        click.echo("User OAuth (PKCE): configured")
+    else:
+        click.echo("User OAuth (PKCE): not configured")
+        click.echo("  Run `zoom auth login --client-id <id>` to configure.")
 
 
-@auth_cmd.command(help="Clear all stored API authentication credentials.")
+@auth_cmd.command(help="Clear ALL stored API authentication credentials (S2S + user OAuth).")
 @_translate_keyring_errors
 def logout():
     auth.clear_s2s_credentials()
+    auth.clear_user_oauth_credentials()
     click.echo("Cleared Server-to-Server OAuth credentials.")
+    click.echo("Cleared User OAuth credentials.")
+
+
+@auth_cmd.command(
+    "login",
+    help=(
+        "Authenticate as a Zoom user via OAuth 2.0 + PKCE (3-legged flow). "
+        "Opens the browser; captures the redirect on a loopback port; "
+        "exchanges the auth code for a refresh_token (stored in OS keyring)."
+    ),
+)
+@click.option(
+    "--client-id",
+    required=True,
+    envvar="ZOOM_USER_CLIENT_ID",
+    help="OAuth Client ID for a user-managed (not S2S) app. Picks up ZOOM_USER_CLIENT_ID env var.",
+)
+@click.option(
+    "--port",
+    type=click.IntRange(0, 65535),
+    default=0,
+    show_default=True,
+    help="Loopback port for the OAuth redirect. 0 = pick an ephemeral port.",
+)
+@click.option(
+    "--timeout",
+    type=click.IntRange(10, 1800),
+    default=300,
+    show_default=True,
+    help="Seconds to wait for the browser callback.",
+)
+@click.option(
+    "--no-browser",
+    is_flag=True,
+    default=False,
+    help="Don't try to open a browser; just print the auth URL for manual paste.",
+)
+@_translate_keyring_errors
+def auth_login(client_id, port, timeout, no_browser):
+    """Closes #12. Refresh token persists across CLI invocations; access
+    token (1-hour lifetime) lives only in memory and is re-minted via
+    refresh as needed."""
+
+    def _no_browser(_url):
+        # webbrowser.open returns bool; mimic that.
+        return False
+
+    browser = _no_browser if no_browser else None
+
+    def _print_url(url):
+        click.echo(f"Open this URL in a browser to authorize:\n  {url}")
+
+    try:
+        tokens = user_oauth.run_pkce_flow(
+            client_id,
+            port=port,
+            browser=browser,
+            timeout=float(timeout),
+            on_url=_print_url,
+        )
+    except user_oauth.ZoomUserAuthError as exc:
+        click.echo(f"OAuth failed: {exc}", err=True)
+        raise click.exceptions.Exit(code=1) from exc
+    except TimeoutError as exc:
+        click.echo(f"Timed out waiting for browser callback: {exc}", err=True)
+        raise click.exceptions.Exit(code=1) from exc
+    except httpx.HTTPError as exc:
+        click.echo(f"Could not reach Zoom OAuth endpoint: {exc}", err=True)
+        raise click.exceptions.Exit(code=1) from exc
+
+    auth.save_user_oauth_credentials(
+        auth.UserOAuthCredentials(
+            refresh_token=tokens.refresh_token,
+            client_id=client_id,
+        )
+    )
+    minutes = max(int((tokens.expires_at - _now()).total_seconds() // 60), 0)
+    click.echo(f"Logged in. Refresh token saved to keyring; access token expires in {minutes}m.")
+    if tokens.scopes:
+        click.echo(f"Scopes: {' '.join(tokens.scopes)}")
 
 
 # ---- Zoom Users REST API -------------------------------------------------

--- a/zoom_cli/api/user_oauth.py
+++ b/zoom_cli/api/user_oauth.py
@@ -1,0 +1,369 @@
+"""User OAuth 2.0 flow with PKCE for Zoom (closes #12).
+
+Reference: https://developers.zoom.us/docs/integrations/oauth/
+
+For developers without S2S marketplace credentials, the user-OAuth flow
+authenticates as the developer's own Zoom user instead of an account.
+The flow:
+
+1. Generate a PKCE ``code_verifier`` (random URL-safe string) and the
+   matching ``code_challenge`` = ``base64url(sha256(verifier))``.
+2. Start a loopback HTTP server on ``127.0.0.1:<ephemeral-port>``.
+3. Build the authorize URL pointing back at that loopback as
+   ``redirect_uri``; open it in the user's default browser.
+4. The user authorizes in-browser; Zoom redirects to the loopback with
+   ``?code=<auth-code>&state=<our-state>``.
+5. The loopback handler captures the code; the CLI exchanges it for an
+   access + refresh token pair at ``POST https://zoom.us/oauth/token``.
+6. ``refresh_token`` is persisted in the OS keyring; ``access_token``
+   stays in memory (1-hour lifetime).
+
+Module surface:
+
+  build_authorize_url(client_id, redirect_uri, code_challenge, state)
+      Pure. Useful for tests + for printing the URL when ``webbrowser``
+      can't open one (headless environments).
+
+  exchange_code_for_tokens(client_id, redirect_uri, code, code_verifier,
+                           *, http=None)
+      The token exchange. HTTP — mock with ``httpx.MockTransport``.
+
+  refresh_user_tokens(refresh_token, client_id, *, http=None)
+      Use the refresh_token to get a new access_token (and possibly a
+      rotated refresh_token).
+
+  run_pkce_flow(client_id, *, port=0, browser=None, timeout=300, http=None)
+      End-to-end flow. The integration is hard to unit-test (real socket
+      + real browser callback); test the components above instead.
+
+The Zoom user-OAuth ``access_token`` is short-lived (1 hour) like the
+S2S token. Refresh tokens are also short-lived (~14 days) and are
+**rotated** on each refresh, so the new ``refresh_token`` from a
+refresh response must be persisted back to the keyring immediately.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+
+#: Zoom's user-OAuth authorize endpoint. Different from the API base
+#: (api.zoom.us) and from the S2S token endpoint URL — those are pinned
+#: separately so a future endpoint move doesn't silently break.
+AUTHORIZE_URL = "https://zoom.us/oauth/authorize"
+
+#: Same token endpoint as S2S; the ``grant_type`` distinguishes the two.
+TOKEN_URL = "https://zoom.us/oauth/token"  # noqa: S105 - public endpoint URL
+
+#: Default timeout for the token exchange / refresh round-trips.
+DEFAULT_TIMEOUT_SECONDS = 15.0
+
+#: Minimum allowed length for the PKCE code_verifier per RFC 7636 (43 chars
+#: of [A-Z / a-z / 0-9 / "-" / "." / "_" / "~"]).
+_PKCE_VERIFIER_MIN_LEN = 43
+
+
+@dataclass(frozen=True)
+class UserOAuthTokens:
+    """Tokens returned by the OAuth token endpoint.
+
+    ``access_token`` is short-lived (1 hour). ``refresh_token`` is
+    longer-lived (~14 days) and **rotated** on every refresh — callers
+    must persist the new value, not the old.
+    """
+
+    access_token: str
+    refresh_token: str
+    expires_at: datetime
+    scopes: tuple[str, ...]
+
+
+class ZoomUserAuthError(RuntimeError):
+    """A non-2xx from the user-OAuth token endpoint, or a flow-level
+    error (CSRF state mismatch, browser timeout, etc.)."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        error_code: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.error_code = error_code
+
+
+# ---- PKCE primitives (pure) --------------------------------------------
+
+
+def _pkce_pair() -> tuple[str, str]:
+    """Generate a (code_verifier, code_challenge) pair per RFC 7636.
+
+    Verifier is 64 chars from ``secrets.token_urlsafe`` (URL-safe base64
+    of 48 random bytes, ~64 chars after padding strip — within the
+    43..128 RFC range). Challenge is ``base64url(sha256(verifier))``
+    with the trailing ``=`` stripped.
+    """
+    verifier = secrets.token_urlsafe(48)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+def _random_state() -> str:
+    """Random opaque string used as OAuth ``state`` (CSRF token)."""
+    return secrets.token_urlsafe(24)
+
+
+def build_authorize_url(
+    client_id: str,
+    redirect_uri: str,
+    code_challenge: str,
+    state: str,
+) -> str:
+    """Build the Zoom authorize URL for a PKCE flow.
+
+    Pure — no I/O. Useful for tests and for headless environments where
+    the operator pastes the URL into a browser by hand.
+    """
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+    }
+    return f"{AUTHORIZE_URL}?{urlencode(params)}"
+
+
+# ---- token exchange (HTTP) ---------------------------------------------
+
+
+def _parse_token_response(response: httpx.Response) -> UserOAuthTokens:
+    """Translate a 2xx token-endpoint response into :class:`UserOAuthTokens`.
+
+    Raises :class:`ZoomUserAuthError` on non-2xx OR a 2xx that doesn't
+    have a usable ``access_token``. Mirrors the pattern in
+    :mod:`zoom_cli.api.oauth` (#42 hardening).
+    """
+    if response.status_code >= 400:
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = {}
+        raise ZoomUserAuthError(
+            payload.get("reason") or payload.get("error_description") or response.text,
+            status_code=response.status_code,
+            error_code=payload.get("error"),
+        )
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise ZoomUserAuthError(
+            "Token endpoint returned 2xx with non-JSON body "
+            f"(content-type={response.headers.get('content-type', 'unknown')})",
+            status_code=response.status_code,
+        ) from exc
+
+    access = payload.get("access_token")
+    refresh = payload.get("refresh_token")
+    if not access or not refresh:
+        raise ZoomUserAuthError(
+            "Token endpoint returned 2xx but access_token/refresh_token missing",
+            status_code=response.status_code,
+        )
+
+    expires_in = int(payload.get("expires_in", 3600))
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+    scopes_str = payload.get("scope", "")
+    scopes = tuple(scopes_str.split()) if scopes_str else ()
+
+    return UserOAuthTokens(
+        access_token=access,
+        refresh_token=refresh,
+        expires_at=expires_at,
+        scopes=scopes,
+    )
+
+
+def exchange_code_for_tokens(
+    *,
+    client_id: str,
+    redirect_uri: str,
+    code: str,
+    code_verifier: str,
+    http: httpx.Client | None = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> UserOAuthTokens:
+    """Trade an authorization code for a token pair.
+
+    Raises:
+        ZoomUserAuthError: Zoom rejected the exchange (bad code, wrong
+            verifier, expired code, etc.) or returned a malformed body.
+        httpx.HTTPError: never reached the endpoint (DNS / TCP / TLS /
+            timeout). CLI translates this into a friendly message.
+    """
+    owns = http is None
+    if http is None:
+        http = httpx.Client(timeout=timeout)
+    try:
+        response = http.post(
+            TOKEN_URL,
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "client_id": client_id,
+                "code_verifier": code_verifier,
+            },
+        )
+    finally:
+        if owns:
+            http.close()
+    return _parse_token_response(response)
+
+
+def refresh_user_tokens(
+    *,
+    refresh_token: str,
+    client_id: str,
+    http: httpx.Client | None = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> UserOAuthTokens:
+    """Use a refresh_token to mint a fresh access_token (and a rotated
+    refresh_token — always persist the new one)."""
+    owns = http is None
+    if http is None:
+        http = httpx.Client(timeout=timeout)
+    try:
+        response = http.post(
+            TOKEN_URL,
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": client_id,
+            },
+        )
+    finally:
+        if owns:
+            http.close()
+    return _parse_token_response(response)
+
+
+# ---- end-to-end flow ----------------------------------------------------
+
+
+def run_pkce_flow(
+    client_id: str,
+    *,
+    port: int = 0,
+    browser: Any = None,
+    timeout: float = 300.0,
+    http: httpx.Client | None = None,
+    on_url: Any = None,
+) -> UserOAuthTokens:
+    """End-to-end PKCE flow.
+
+    Args:
+        client_id: Zoom OAuth Client ID for a user-managed app.
+        port: Loopback port to bind. ``0`` (default) picks an ephemeral
+            port — recommended for prod; specific port useful for tests.
+        browser: Optional callable taking the auth URL. Defaults to
+            :func:`webbrowser.open`. Pass a no-op for headless flows.
+        timeout: Seconds to wait for the browser callback before giving
+            up. Default 5 minutes.
+        http: Optional preconfigured ``httpx.Client`` for the token
+            exchange — useful for tests.
+        on_url: Optional callable invoked with the auth URL just before
+            the browser launches; lets the CLI print the URL so the
+            user can paste it manually if the browser doesn't open.
+
+    Returns:
+        :class:`UserOAuthTokens` on success.
+
+    Raises:
+        ZoomUserAuthError: state mismatch (CSRF), Zoom returned an
+            ``error`` query param on the callback, or the token
+            exchange failed.
+        TimeoutError: the user didn't authorize within ``timeout``.
+    """
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+    from urllib.parse import parse_qs, urlsplit
+
+    verifier, challenge = _pkce_pair()
+    state = _random_state()
+
+    captured: dict[str, str] = {}
+
+    class _CallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            query = parse_qs(urlsplit(self.path).query)
+            captured["code"] = query.get("code", [""])[0]
+            captured["state"] = query.get("state", [""])[0]
+            captured["error"] = query.get("error", [""])[0]
+            captured["error_description"] = query.get("error_description", [""])[0]
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.end_headers()
+            body = (
+                b"<html><body><h2>Authorization received.</h2>"
+                b"<p>You can close this tab and return to the terminal.</p>"
+                b"</body></html>"
+            )
+            self.wfile.write(body)
+
+        def log_message(self, fmt, *args):
+            # Silence the default stderr-spam on every request.
+            pass
+
+    # Bind first so we know the port (caller may have asked for ``0``).
+    server = HTTPServer(("127.0.0.1", port), _CallbackHandler)
+    server.socket.settimeout(timeout)
+    bound_port = server.server_port
+    redirect_uri = f"http://127.0.0.1:{bound_port}/callback"
+    auth_url = build_authorize_url(client_id, redirect_uri, challenge, state)
+
+    if on_url is not None:
+        on_url(auth_url)
+
+    if browser is None:
+        import webbrowser
+
+        browser = webbrowser.open
+    browser(auth_url)
+
+    server.timeout = timeout
+    try:
+        server.handle_request()
+    except (TimeoutError, OSError) as exc:
+        raise TimeoutError(f"OAuth callback didn't arrive within {timeout:.0f}s") from exc
+    finally:
+        server.server_close()
+
+    if captured.get("error"):
+        raise ZoomUserAuthError(
+            captured.get("error_description") or captured["error"],
+            error_code=captured["error"],
+        )
+    if not captured.get("code"):
+        raise TimeoutError("OAuth callback didn't carry a code")
+    if captured.get("state") != state:
+        raise ZoomUserAuthError("OAuth state mismatch — possible CSRF attempt")
+
+    return exchange_code_for_tokens(
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        code=captured["code"],
+        code_verifier=verifier,
+        http=http,
+    )

--- a/zoom_cli/auth.py
+++ b/zoom_cli/auth.py
@@ -132,3 +132,95 @@ def has_s2s_credentials() -> bool:
         return load_s2s_credentials() is not None
     except (keyring.errors.NoKeyringError, keyring.errors.InitError):
         return False
+
+
+# ---- User OAuth (PKCE) credential storage (closes #12 storage layer) ----
+#
+# Distinct service name from S2S so a `zoom auth logout` can clear one
+# without touching the other. We persist:
+#   - refresh_token: long-lived (~14 days, rotated on each refresh)
+#   - client_id: needed to re-do the refresh; not secret on its own but
+#     still per-installation, so we store it alongside.
+# access_token is in-memory only — Zoom rotates it every hour and the
+# refresh path is cheap.
+
+#: Keyring service identifier for user-OAuth credentials.
+SERVICE_NAME_USER = "zoom-cli-user-auth"
+
+_USER_REFRESH_KEY = "user.refresh_token"
+_USER_CLIENT_ID_KEY = "user.client_id"
+
+_USER_ALL_KEYS = (_USER_REFRESH_KEY, _USER_CLIENT_ID_KEY)
+
+
+@dataclass(frozen=True)
+class UserOAuthCredentials:
+    """Persisted half of a user-OAuth session.
+
+    The access_token isn't in here — it's short-lived and lives in
+    memory only.
+    """
+
+    refresh_token: str
+    client_id: str
+
+
+def save_user_oauth_credentials(creds: UserOAuthCredentials) -> None:
+    """Persist user-OAuth refresh + client_id to the OS keyring.
+
+    Best-effort transactional, mirroring :func:`save_s2s_credentials`
+    (closes #35 pattern): snapshot existing values, write new ones,
+    restore the snapshot on any partial failure.
+    """
+    snapshot = {key: keyring.get_password(SERVICE_NAME_USER, key) for key in _USER_ALL_KEYS}
+    written: list[str] = []
+    try:
+        for key, value in (
+            (_USER_REFRESH_KEY, creds.refresh_token),
+            (_USER_CLIENT_ID_KEY, creds.client_id),
+        ):
+            keyring.set_password(SERVICE_NAME_USER, key, value)
+            written.append(key)
+    except Exception:
+        for key in written:
+            previous = snapshot[key]
+            with contextlib.suppress(Exception):
+                if previous is None:
+                    keyring.delete_password(SERVICE_NAME_USER, key)
+                else:
+                    keyring.set_password(SERVICE_NAME_USER, key, previous)
+        raise
+
+
+def load_user_oauth_credentials() -> UserOAuthCredentials | None:
+    """Return persisted user-OAuth credentials, or ``None`` if absent.
+
+    Same NoKeyringError-propagates semantics as :func:`load_s2s_credentials`
+    (closes #41): the CLI distinguishes "user has not run `zoom auth login`"
+    from "this machine has no keyring backend at all".
+    """
+    refresh = keyring.get_password(SERVICE_NAME_USER, _USER_REFRESH_KEY)
+    client_id = keyring.get_password(SERVICE_NAME_USER, _USER_CLIENT_ID_KEY)
+    if not (refresh and client_id):
+        return None
+    return UserOAuthCredentials(refresh_token=refresh, client_id=client_id)
+
+
+def clear_user_oauth_credentials() -> None:
+    """Remove all user-OAuth keyring entries. Safe to call when none exist."""
+    for key in _USER_ALL_KEYS:
+        with contextlib.suppress(keyring.errors.PasswordDeleteError):
+            keyring.delete_password(SERVICE_NAME_USER, key)
+
+
+def has_user_oauth_credentials() -> bool:
+    """Cheap "is a user-OAuth session configured?" check.
+
+    Same probe-style semantics as :func:`has_s2s_credentials` — swallows
+    backend-missing errors so ``zoom auth status`` doesn't crash on a
+    misconfigured machine.
+    """
+    try:
+        return load_user_oauth_credentials() is not None
+    except (keyring.errors.NoKeyringError, keyring.errors.InitError):
+        return False


### PR DESCRIPTION
## Summary

Closes #12. Adds a 3-legged OAuth flow with PKCE for developers without S2S marketplace credentials. Authenticates as the developer's own Zoom user instead of as an account.

| Surface | What it does |
|---|---|
| `zoom_cli/api/user_oauth.py` | PKCE primitives, authorize-URL builder, token exchange, refresh, end-to-end loopback flow |
| `zoom_cli.auth.UserOAuthCredentials` | Persistent half (refresh_token + client_id) under service `zoom-cli-user-auth` |
| `zoom auth login --client-id <id>` | The user-facing 3-legged flow |
| `zoom auth status` (extended) | Reports both surfaces |
| `zoom auth logout` (extended) | Clears both stores |

## What's new

### `zoom_cli/api/user_oauth.py`

```python
def _pkce_pair() -> tuple[str, str]            # RFC 7636 verifier + S256 challenge
def _random_state() -> str                       # CSRF token
def build_authorize_url(client_id, redirect_uri, code_challenge, state) -> str  # pure
def exchange_code_for_tokens(*, client_id, redirect_uri, code, code_verifier, http=None)
def refresh_user_tokens(*, refresh_token, client_id, http=None)
def run_pkce_flow(client_id, *, port=0, browser=None, timeout=300, http=None, on_url=None)
```

`run_pkce_flow` binds an HTTPServer on `127.0.0.1:<port>` (port `0` = ephemeral), opens the browser to the authorize URL, waits for the callback, validates the `state` parameter (CSRF), and exchanges the code. CSRF mismatch → `ZoomUserAuthError`. No callback in `timeout` seconds → `TimeoutError`.

Refresh tokens are **rotated** by Zoom on each refresh — the docstring + return type pin this so callers always persist the new value.

Same `#42` 2xx-non-JSON hardening as the S2S oauth module: HTML/empty/garbage 2xx bodies surface as `ZoomUserAuthError` with the response's content-type embedded.

### `zoom_cli.auth` extension

```python
SERVICE_NAME_USER = "zoom-cli-user-auth"   # distinct from "zoom-cli-auth" (S2S)

@dataclass(frozen=True)
class UserOAuthCredentials:
    refresh_token: str
    client_id: str

save_user_oauth_credentials(creds)        # transactional rollback (#35 pattern)
load_user_oauth_credentials() -> UserOAuthCredentials | None
                                          # propagates NoKeyringError (#41 pattern)
clear_user_oauth_credentials()
has_user_oauth_credentials() -> bool      # swallows NoKeyringError (probe-style)
```

`access_token` is **not** persisted — it's 1-hour and the refresh path is cheap.

### CLI

**`zoom auth login --client-id <id>`** — picks up `ZOOM_USER_CLIENT_ID` env var. Optional `--port 0..65535` (default `0` = ephemeral), `--timeout 10..1800` (default 300), `--no-browser` (skip the browser launch — useful for headless / SSH sessions where you'll paste the URL elsewhere).

Prints the auth URL **before** launching the browser so headless users can copy it. On success, persists the refresh token, prints the granted scopes + access-token TTL minutes, never echoes the secret.

Friendly error mapping:
- `ZoomUserAuthError` → exit 1, "OAuth failed: <reason>"
- `TimeoutError` → exit 1, "Timed out waiting for browser callback"
- `httpx.HTTPError` → exit 1, "Could not reach Zoom OAuth endpoint"

**`zoom auth status`** — now reports both surfaces with separate "configured / not configured" lines and per-surface "run X to configure" hints.

**`zoom auth logout`** — clears both stores (S2S + user OAuth) and reports both clears.

## Tests (+30 new)

| File | New | Covers |
|---|---|---|
| `tests/test_user_oauth.py` | +12 | PKCE pair charset/length/randomness, challenge derivation, state randomness; authorize URL has all required params + percent-encoded redirect; code exchange round-trip with form-encoded body; 4xx with Zoom error envelope; 2xx without access_token; 2xx HTML body; refresh round-trip with rotated refresh token; refresh 4xx; URL constants pinned |
| `tests/test_auth.py` | +9 | user-OAuth round-trip; load None when nothing saved; clear removes both keys + idempotent; partial state returns None; `has_*` swallows NoKeyring; `load_*` propagates; parametrized rollback on partial failure (calls 1, 2); `SERVICE_NAME_USER` pinned |
| `tests/test_cli.py` | +9 | login requires --client-id; login persists refresh + client_id; login never echoes secret; login error paths (ZoomUserAuthError, TimeoutError); status reports both surfaces; logout clears both. Existing `test_auth_status_when_configured` updated for the new two-line output |

All HTTP via `httpx.MockTransport`. The browser-callback dance in `run_pkce_flow` is **not** unit-tested end-to-end — instead the tests cover each component (PKCE generation, URL building, token exchange, refresh) plus the CLI command stubs `run_pkce_flow` to inject tokens directly.

## Verification

```
ruff check .          # All checks passed!
ruff format --check . # 29 files already formatted
mypy                  # Success: no issues found in 14 source files
pytest -q             # 384 passed (was 354; +30)
```

## Out of scope (deferred)

- **End-to-end `run_pkce_flow` integration test** (real socket + real browser callback). Components are tested individually; the integration is left to manual smoke.
- **`ApiClient` integration with user-OAuth tokens** — which token to use for which API call (S2S vs user). Tracked separately for a follow-up.
- **Auto-refresh of expiring access tokens** during long-running CLI sessions. The `refresh_user_tokens` helper is in place; wiring it into `ApiClient` is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)