### PR TITLE
feat(storage): close #24 (schema versioning) — meetings.json envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Meetings write surface (PR #52): closes #13 (write piece). New `zoom meetings create / update / delete / end` commands. `ApiClient` gains `post`/`patch`/`put`/`delete` convenience wrappers.
 > Users write surface (PR #53): closes #14 (write + settings-read piece). New `zoom users create / delete / settings get` commands.
 > Recordings surface (PR #54): closes #15. New `zoom recordings list / get / download / delete` commands; `zoom_cli/api/recordings.py`; `ApiClient.stream_download` for atomic streamed downloads.
-> User OAuth + PKCE (this branch): closes #12. New `zoom auth login` 3-legged OAuth flow with loopback callback; `zoom_cli/api/user_oauth.py`; refresh-token storage in keyring service `zoom-cli-user-auth`; extended `auth status` and `auth logout` to cover both surfaces.
+> User OAuth + PKCE (PR #55): closes #12. New `zoom auth login` 3-legged OAuth flow with loopback callback; `zoom_cli/api/user_oauth.py`; refresh-token storage in keyring service `zoom-cli-user-auth`; extended `auth status` and `auth logout` to cover both surfaces.
+> Schema versioning (this branch): closes #24 (final piece). `meetings.json` now wraps the meetings dict in a `{schema_version, meetings}` envelope; legacy v0 (pre-#24) files read transparently and migrate on first write.
+
+### Added (issue #24, schema versioning piece)
+- `zoom_cli/utils.py` — `SCHEMA_VERSION = 1` constant; new `UnknownSchemaVersionError` for files written by a newer CLI; new `_detect_envelope()` helper that handles both v0 (flat dict at root) and v1 (wrapped envelope).
+- `write_to_meeting_file` now emits `{schema_version: 1, meetings: {...}}`. Atomic-write semantics from PR #27 are unchanged.
+- `get_meeting_file_contents` transparently reads both formats — pure read does NOT migrate the file (no surprise modifications). The first `zoom save`/`edit`/`rm` after a CLI upgrade migrates v0 → v1 opportunistically.
+- A v1 file written by a future `schema_version > 1` CLI raises `UnknownSchemaVersionError` with a clear "Upgrade zoom-cli to read it" message — fail-loud rather than silently dropping fields the future version added.
+- A corrupt envelope (`meetings` not a dict) returns empty rather than crashing — fail-soft so the user can re-save.
+- `tests/conftest.py` `write_meetings` fixture now writes the v1 envelope to match what the CLI itself produces.
 
 ### Added (issue #12)
 - `zoom_cli/api/user_oauth.py` — PKCE primitives (`_pkce_pair`, `_random_state`), `build_authorize_url`, `exchange_code_for_tokens`, `refresh_user_tokens`, end-to-end `run_pkce_flow` with loopback HTTP server + browser launch + state-mismatch CSRF check + 5-minute timeout.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,7 +98,17 @@ def captured_launches(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
 
 
 def _write_meetings(save_file: Path, payload: dict) -> None:
-    save_file.write_text(json.dumps(payload, indent=2))
+    """Write the v1 envelope (closes #24 schema-versioning).
+
+    Most tests just want a flat ``{name: entry}`` payload; this wraps it
+    in the current schema envelope so the fixture matches what the CLI
+    itself writes. Tests that exercise legacy v0 (pre-#24) bypass this
+    fixture and write the raw flat dict directly.
+    """
+    from zoom_cli.utils import SCHEMA_VERSION
+
+    envelope = {"schema_version": SCHEMA_VERSION, "meetings": payload}
+    save_file.write_text(json.dumps(envelope, indent=2))
 
 
 @pytest.fixture

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,7 +59,7 @@ def test_save_url_via_flags(runner: CliRunner, tmp_zoom_cli_home: Path) -> None:
         ["save", "-n", "standup", "--url", "https://zoom.us/j/1"],
     )
     assert result.exit_code == 0, result.output
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == {"standup": {"url": "https://zoom.us/j/1"}}
 
 
@@ -72,7 +72,7 @@ def test_save_id_password_via_flags(runner: CliRunner, tmp_zoom_cli_home: Path) 
         ["save", "-n", "standup", "--id", "1234567890", "-p", "pw"],
     )
     assert result.exit_code == 0, result.output
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == {"standup": {"id": "1234567890"}}
     assert secrets.get_password("standup") == "pw"
 
@@ -85,7 +85,7 @@ def test_save_url_does_not_prompt_for_password_when_pwd_in_url(
         ["save", "-n", "standup", "--url", "https://zoom.us/j/1?pwd=abc"],
     )
     assert result.exit_code == 0, result.output
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == {"standup": {"url": "https://zoom.us/j/1?pwd=abc"}}
 
 
@@ -97,7 +97,7 @@ def test_rm_with_argument_no_prompt(
     write_meetings({"a": {"id": "1"}, "b": {"id": "2"}})
     result = runner.invoke(main, ["rm", "a"])
     assert result.exit_code == 0, result.output
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == {"b": {"id": "2"}}
 
 
@@ -109,7 +109,7 @@ def test_rm_dry_run_does_not_modify_file(
     assert result.exit_code == 0, result.output
     assert "[dry-run]" in result.output
     assert "a" in result.output
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == {"a": {"id": "1"}, "b": {"id": "2"}}
 
 
@@ -132,7 +132,7 @@ def test_rm_interactive_dry_run_does_not_confirm_or_delete(
     assert "alpha" in result.output
     assert "Remove meeting" not in result.output  # confirm prompt did NOT fire
 
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == {"alpha": {"id": "1"}, "beta": {"id": "2"}}
 
 
@@ -154,7 +154,7 @@ def test_rm_interactive_confirms_before_deleting(
     assert result.exit_code == 0, result.output
     assert "Aborted" in result.output
     # Meeting still present.
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert "a" in on_disk
 
 
@@ -467,7 +467,7 @@ def test_rm_interactive_with_yes_flag_skips_confirmation(
 
     result = runner.invoke(main, ["rm", "--yes"])
     assert result.exit_code == 0, result.output
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert "a" not in on_disk
 
 
@@ -543,7 +543,7 @@ def test_rm_ctrl_c_on_name_select_does_not_crash(
     result = runner.invoke(main, ["rm"])
     assert result.exit_code != 0
     # Existing meetings still present.
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert "a" in on_disk and "b" in on_disk
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -12,7 +12,7 @@ from zoom_cli import commands as commands_mod
 
 def test_save_url_persists_payload(tmp_zoom_cli_home: Path) -> None:
     commands_mod._save_url("standup", "https://zoom.us/j/1", "")
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == {"standup": {"url": "https://zoom.us/j/1"}}
 
 
@@ -22,7 +22,7 @@ def test_save_url_includes_password_when_provided(tmp_zoom_cli_home: Path) -> No
 
     commands_mod._save_url("standup", "https://zoom.us/j/1", "p@ss")
 
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == {"standup": {"url": "https://zoom.us/j/1"}}
     assert secrets.get_password("standup") == "p@ss"
 
@@ -32,21 +32,21 @@ def test_save_id_password_persists_payload(tmp_zoom_cli_home: Path) -> None:
 
     commands_mod._save_id_password("standup", "1234567890", "secret")
 
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == {"standup": {"id": "1234567890"}}
     assert secrets.get_password("standup") == "secret"
 
 
 def test_save_id_password_omits_password_when_empty(tmp_zoom_cli_home: Path) -> None:
     commands_mod._save_id_password("standup", "1234567890", "")
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == {"standup": {"id": "1234567890"}}
 
 
 def test_remove_deletes_entry(write_meetings, tmp_zoom_cli_home: Path) -> None:
     write_meetings({"a": {"id": "1"}, "b": {"id": "2"}})
     commands_mod._remove("a")
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == {"b": {"id": "2"}}
 
 
@@ -314,9 +314,9 @@ def test_save_url_keyring_failure_leaves_json_untouched(
     If the keyring write fails, the prior on-disk state is preserved."""
     from zoom_cli import secrets
 
-    # Seed: existing meeting with a known JSON contents.
+    # Seed: existing meeting with a known JSON contents (v1 envelope from #24).
     (tmp_zoom_cli_home / "meetings.json").write_text(
-        '{"standup": {"url": "https://old.example/j/1"}}'
+        '{"schema_version": 1, "meetings": {"standup": {"url": "https://old.example/j/1"}}}'
     )
 
     def boom(*_args, **_kwargs):
@@ -328,7 +328,7 @@ def test_save_url_keyring_failure_leaves_json_untouched(
         commands_mod._save_url("standup", "https://NEW.example/j/2", "newpw")
 
     # JSON must be unchanged — the rewrite never happened.
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == {"standup": {"url": "https://old.example/j/1"}}
 
 
@@ -470,7 +470,7 @@ def test_edit_overwrites_url_with_new_answer(
 
     commands_mod._edit("team", "", "", "")
 
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == {"team": {"url": "https://new.example/j/2"}}
 
 
@@ -490,7 +490,7 @@ def test_edit_with_password_flag_writes_to_keyring(
 
     commands_mod._edit("team", "", "", "new-pw")
 
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == {"team": {"url": "https://new.example/j/2"}}
     assert secrets.get_password("team") == "new-pw"
 
@@ -515,7 +515,7 @@ def test_edit_migrates_legacy_plaintext_password_into_keyring(
 
     commands_mod._edit("team", "", "", "")
 
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     # Legacy password field is gone from JSON — but the value is in the keyring.
     assert on_disk == {"team": {"url": "https://kept.example/j/1"}}
     assert secrets.get_password("team") == "legacy"
@@ -553,7 +553,7 @@ def test_edit_aborts_cleanly_on_ctrl_c(
         commands_mod._edit("team", "", "", "")
 
     # Original entry must be untouched.
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == {"team": {"url": "https://old.example/j/1"}}
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,7 +41,7 @@ def test_get_meeting_names_sorted(write_meetings) -> None:
 def test_write_to_meeting_file_round_trips(tmp_zoom_cli_home: Path) -> None:
     payload = {"team": {"id": "999", "password": "secret"}}
     utils_mod.write_to_meeting_file(payload)
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == payload
 
 
@@ -241,7 +241,7 @@ def test_write_to_meeting_file_actually_calls_os_replace(
     assert os.path.dirname(src) == os.path.dirname(dst)
     assert os.path.basename(src).startswith(".meetings.")
 
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == payload
 
     leftovers = [p for p in tmp_zoom_cli_home.iterdir() if p.name != "meetings.json"]
@@ -252,9 +252,12 @@ def test_write_to_meeting_file_cleans_up_when_replace_fails(
     tmp_zoom_cli_home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """If ``os.replace`` raises, the original file must remain intact and
-    the tempfile must be cleaned up."""
+    the tempfile must be cleaned up.
+
+    Pre-seeds with the v1 envelope (closes #24) so the post-failure read
+    matches the schema we write."""
     target = tmp_zoom_cli_home / "meetings.json"
-    target.write_text('{"original": {"id": "999"}}')
+    target.write_text('{"schema_version": 1, "meetings": {"original": {"id": "999"}}}')
 
     def boom(*_args, **_kwargs):
         raise OSError("simulated replace failure")
@@ -264,7 +267,7 @@ def test_write_to_meeting_file_cleans_up_when_replace_fails(
     with pytest.raises(OSError, match="simulated replace failure"):
         utils_mod.write_to_meeting_file({"new": {"id": "111"}})
 
-    on_disk = json.loads(target.read_text())
+    on_disk = json.loads(target.read_text())["meetings"]
     assert on_disk == {"original": {"id": "999"}}
 
     leftovers = [p for p in tmp_zoom_cli_home.iterdir() if p.name != "meetings.json"]
@@ -279,7 +282,7 @@ def test_write_to_meeting_file_cleans_up_when_fsync_fails(
     original meetings.json must remain intact. Covers the asymmetric path
     flagged in code review (codex + python-review on PR #27)."""
     target = tmp_zoom_cli_home / "meetings.json"
-    target.write_text('{"original": {"id": "999"}}')
+    target.write_text('{"schema_version": 1, "meetings": {"original": {"id": "999"}}}')
 
     real_fsync = utils_mod.os.fsync
 
@@ -297,7 +300,7 @@ def test_write_to_meeting_file_cleans_up_when_fsync_fails(
     # Restore for any subsequent fixtures
     monkeypatch.setattr(utils_mod.os, "fsync", real_fsync)
 
-    on_disk = json.loads(target.read_text())
+    on_disk = json.loads(target.read_text())["meetings"]
     assert on_disk == {"original": {"id": "999"}}
 
     leftovers = [p for p in tmp_zoom_cli_home.iterdir() if p.name != "meetings.json"]
@@ -310,7 +313,7 @@ def test_write_to_meeting_file_round_trips_unicode(tmp_zoom_cli_home: Path) -> N
     back, so the round-trip is lossless."""
     payload = {"meeting-with-emoji-🚀": {"password": "p@ss-Ω"}}
     utils_mod.write_to_meeting_file(payload)
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == payload
 
 
@@ -472,7 +475,7 @@ def test_ensure_storage_tightens_existing_permissive_dir(
 def test_meeting_file_transaction_persists_changes(tmp_zoom_cli_home: Path) -> None:
     with utils_mod.meeting_file_transaction() as contents:
         contents["new"] = {"id": "1"}
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert on_disk == {"new": {"id": "1"}}
 
 
@@ -502,6 +505,102 @@ def test_meeting_file_transaction_lock_serializes_concurrent_writes(
     t1.join()
     t2.join()
 
-    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    on_disk = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())["meetings"]
     assert "alpha" in on_disk
     assert "beta" in on_disk
+
+
+# ---- #24 schema versioning ----------------------------------------------
+
+
+def test_schema_version_constant_is_pinned() -> None:
+    """A bump should be a deliberate, reviewed change."""
+    assert utils_mod.SCHEMA_VERSION == 1
+
+
+def test_write_emits_v1_envelope(tmp_zoom_cli_home: Path) -> None:
+    utils_mod.write_to_meeting_file({"team": {"id": "1"}})
+    raw = json.loads((tmp_zoom_cli_home / "meetings.json").read_text())
+    assert raw == {"schema_version": 1, "meetings": {"team": {"id": "1"}}}
+
+
+def test_read_legacy_v0_returns_flat_meetings(tmp_zoom_cli_home: Path) -> None:
+    """A pre-#24 file (no schema_version, flat name→entry at root) must
+    still be readable for back-compat with existing installs."""
+    legacy = '{"team": {"id": "1"}, "standup": {"url": "https://zoom.us/j/2"}}'
+    (tmp_zoom_cli_home / "meetings.json").write_text(legacy)
+
+    result = utils_mod.get_meeting_file_contents()
+
+    assert result == {"team": {"id": "1"}, "standup": {"url": "https://zoom.us/j/2"}}
+
+
+def test_read_legacy_v0_does_not_rewrite_file(tmp_zoom_cli_home: Path) -> None:
+    """A pure read should NOT migrate the file format on disk — that
+    would surprise users who are just inspecting state."""
+    target = tmp_zoom_cli_home / "meetings.json"
+    legacy = '{"team": {"id": "1"}}'
+    target.write_text(legacy)
+
+    utils_mod.get_meeting_file_contents()
+
+    assert target.read_text() == legacy
+
+
+def test_first_write_after_v0_migrates_to_v1(tmp_zoom_cli_home: Path) -> None:
+    """The migration is opportunistic: only the first write after upgrade
+    converts the file to v1."""
+    target = tmp_zoom_cli_home / "meetings.json"
+    target.write_text('{"team": {"id": "1"}}')
+
+    # Read returns the legacy contents; emit them back via write to migrate.
+    contents = utils_mod.get_meeting_file_contents()
+    utils_mod.write_to_meeting_file(contents)
+
+    raw = json.loads(target.read_text())
+    assert raw == {"schema_version": 1, "meetings": {"team": {"id": "1"}}}
+
+
+def test_read_future_version_raises(tmp_zoom_cli_home: Path) -> None:
+    """A v9999 file (written by some future CLI) must surface a clear
+    error, not silently lose data by assuming an empty meetings dict."""
+    future = '{"schema_version": 9999, "meetings": {"team": {"id": "1"}, "future_field": "data"}}'
+    (tmp_zoom_cli_home / "meetings.json").write_text(future)
+
+    with pytest.raises(utils_mod.UnknownSchemaVersionError) as excinfo:
+        utils_mod.get_meeting_file_contents()
+    assert excinfo.value.found_version == 9999
+    # Message tells the user how to recover.
+    assert "Upgrade zoom-cli" in str(excinfo.value)
+
+
+def test_read_corrupt_envelope_returns_empty(tmp_zoom_cli_home: Path) -> None:
+    """A v1-envelope-shaped file with non-dict 'meetings' is corrupt;
+    return empty rather than crash. Explicit policy: don't try to
+    repair, just fail-soft so the user can re-save."""
+    (tmp_zoom_cli_home / "meetings.json").write_text(
+        '{"schema_version": 1, "meetings": "not a dict"}'
+    )
+
+    assert utils_mod.get_meeting_file_contents() == {}
+
+
+def test_read_empty_file_returns_empty(tmp_zoom_cli_home: Path) -> None:
+    """Empty {} file (the initial state from _ensure_storage)."""
+    (tmp_zoom_cli_home / "meetings.json").write_text("{}")
+    assert utils_mod.get_meeting_file_contents() == {}
+
+
+def test_meeting_file_transaction_migrates_v0_to_v1(tmp_zoom_cli_home: Path) -> None:
+    """Using the public transaction API on a legacy file produces a v1
+    file — the same opportunistic migration path users hit on first
+    save/edit/rm after upgrade."""
+    target = tmp_zoom_cli_home / "meetings.json"
+    target.write_text('{"old": {"id": "1"}}')
+
+    with utils_mod.meeting_file_transaction() as contents:
+        contents["new"] = {"id": "2"}
+
+    raw = json.loads(target.read_text())
+    assert raw["schema_version"] == 1
+    assert raw["meetings"] == {"old": {"id": "1"}, "new": {"id": "2"}}

--- a/zoom_cli/utils.py
+++ b/zoom_cli/utils.py
@@ -154,12 +154,76 @@ def dict_to_json_string(data) -> str:
     return json.dumps(data, default=dumper, indent=2)
 
 
+#: Current meetings.json schema version. v0 (legacy, pre-#24) was a flat
+#: ``{name: entry}`` dict at the file root. v1 wraps that under a
+#: ``meetings`` key inside an envelope ``{schema_version, meetings}`` so
+#: future versions can add metadata (counters, defaults, format hints)
+#: without colliding with meeting names. Closes #24 schema-versioning.
+SCHEMA_VERSION = 1
+
+
+class UnknownSchemaVersionError(RuntimeError):
+    """The meetings file has a schema_version this CLI doesn't understand.
+
+    Means the file was written by a *newer* CLI than the one currently
+    running. We refuse rather than silently downgrade so we don't strip
+    fields the newer version added.
+    """
+
+    def __init__(self, found_version: int) -> None:
+        super().__init__(
+            f"meetings.json schema_version={found_version} is newer than this "
+            f"CLI supports (max {SCHEMA_VERSION}). Upgrade zoom-cli to read it."
+        )
+        self.found_version = found_version
+
+
+def _detect_envelope(raw: dict) -> tuple[int, dict]:
+    """Return ``(schema_version, meetings_dict)`` from a raw parsed JSON dict.
+
+    Migration policy:
+      - Missing ``schema_version`` → legacy v0 (flat name→entry at root).
+      - ``schema_version == 1`` → read ``meetings`` sub-dict.
+      - ``schema_version > SCHEMA_VERSION`` → :class:`UnknownSchemaVersionError`.
+
+    The migration is *read-only*: we don't write the v1 envelope back
+    until the next mutation. That means a CLI upgrade alone doesn't
+    rewrite the file (no surprise modifications); only the first
+    ``zoom save``/``edit``/``rm`` after upgrade does.
+    """
+    if not raw:
+        # Empty file or {} — treat as v0 with no meetings.
+        return 0, {}
+    if "schema_version" not in raw:
+        # Legacy v0 — the whole dict IS the meetings.
+        return 0, raw
+    version = raw.get("schema_version")
+    if not isinstance(version, int) or version > SCHEMA_VERSION:
+        raise UnknownSchemaVersionError(version if isinstance(version, int) else 0)
+    meetings = raw.get("meetings", {})
+    if not isinstance(meetings, dict):
+        # Corrupt envelope — better to start clean than silently lose data
+        # by assuming an empty meetings dict. Treat as empty.
+        return version, {}
+    return version, meetings
+
+
 def get_meeting_file_contents() -> dict:
+    """Return the flat ``{name: entry}`` dict of saved meetings.
+
+    Transparently handles both schema versions: v0 (pre-#24, flat at
+    root) and v1 (wrapped envelope). The on-disk format isn't changed
+    by this read — see :func:`_detect_envelope` for the policy.
+    """
     try:
         with open(SAVE_FILE_PATH) as file:
-            return json.loads(file.read())
+            raw = json.loads(file.read())
     except (OSError, json.JSONDecodeError):
         return {}
+    if not isinstance(raw, dict):
+        return {}
+    _, meetings = _detect_envelope(raw)
+    return meetings
 
 
 def get_meeting_names() -> list[str]:
@@ -168,6 +232,12 @@ def get_meeting_names() -> list[str]:
 
 def write_to_meeting_file(contents: dict) -> None:
     """Write the meetings JSON atomically and durably.
+
+    Wraps ``contents`` (a flat ``{name: entry}`` dict) in the v1 envelope
+    ``{schema_version, meetings}`` (closes #24 schema-versioning). The
+    first write after a v0→v1 upgrade migrates the file format; readers
+    on older CLI versions will see the new envelope and break (expected
+    — schema versions are explicit upgrade points).
 
     Strategy:
     1. Serialize the new content to a sibling tempfile (created via
@@ -187,7 +257,8 @@ def write_to_meeting_file(contents: dict) -> None:
     cannot corrupt it.
     """
     _ensure_storage()
-    payload = dict_to_json_string(contents)
+    envelope = {"schema_version": SCHEMA_VERSION, "meetings": contents}
+    payload = dict_to_json_string(envelope)
     dir_name = os.path.dirname(SAVE_FILE_PATH) or "."
     fd, tmp_path = tempfile.mkstemp(prefix=".meetings.", suffix=".tmp", dir=dir_name)
     try:


### PR DESCRIPTION
## Summary

Closes the final piece of #24. Atomic writes + \`--dry-run\` / \`--yes\` shipped in PR #27 long ago; this PR adds the schema-versioning envelope that's been the remaining open work.

| | Old (v0) | New (v1) |
|---|---|---|
| File format | \`{name: entry}\` flat | \`{schema_version: 1, meetings: {name: entry}}\` |
| Why | implicit, fragile | explicit version → can extend with counters/defaults/format-hints later without colliding with meeting names |

## What's new

### \`zoom_cli/utils.py\`

\`\`\`python
SCHEMA_VERSION = 1                    # pinned by a test

class UnknownSchemaVersionError(RuntimeError):
    \"\"\"Raised when a *newer* CLI wrote the file. Refusal is loud rather
    than silently downgrading (would strip fields).\"\"\"

def _detect_envelope(raw) -> (int, dict):
    # missing schema_version → v0 (legacy flat root)
    # schema_version == 1    → return raw["meetings"]
    # schema_version > 1     → raise UnknownSchemaVersionError
    # corrupt (meetings not a dict) → empty (fail-soft)
\`\`\`

\`get_meeting_file_contents()\` transparently reads both v0 and v1 — and a pure read does **not** migrate the file. Migration happens opportunistically on the first \`zoom save\` / \`edit\` / \`rm\` after upgrade.

### Tests

- **+9 new** in \`tests/test_utils.py\` covering: constant pinned, write emits envelope, v0 round-trip, v0 read leaves file untouched, opportunistic migration on next write, future-version raises with actionable message, corrupt envelope returns empty (fail-soft), empty file, transaction-API migration.
- **~17 existing tests updated**: tests that read \`meetings.json\` directly now peek into \`[\"meetings\"]\`; tests that pre-seed raw JSON now seed the v1 envelope shape.
- **\`tests/conftest.py\`** \`write_meetings\` fixture now writes the v1 envelope (matches what the CLI produces).

## Migration story

| Scenario | Behaviour |
|---|---|
| Fresh install | Always writes v1. |
| Existing v0 file, run \`zoom ls\` | Reads transparently as v0. **No file modification.** |
| Existing v0 file, run \`zoom save NAME ...\` | Reads transparently as v0; writes back as v1. **One-time silent migration.** |
| File written by future CLI (schema_version > 1) | \`UnknownSchemaVersionError: schema_version=N is newer than this CLI supports (max 1). Upgrade zoom-cli to read it.\` |
| Corrupt v1 file (\`meetings\` not a dict) | Returns empty meetings dict; subsequent save rebuilds. |

## Verification

\`\`\`
ruff check .          # All checks passed!
ruff format --check . # 29 files already formatted
mypy                  # Success: no issues found in 14 source files
pytest -q             # 393 passed (was 384; +9 new + ~17 updated)
\`\`\`

Closes #24 (final piece — atomic writes + --dry-run already shipped in PR #27)

🤖 Generated with [Claude Code](https://claude.com/claude-code)