### PR TITLE
feat(api): close #49 — per-tier token-bucket rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Users write surface (PR #53): closes #14 (write + settings-read piece). New `zoom users create / delete / settings get` commands.
 > Recordings surface (PR #54): closes #15. New `zoom recordings list / get / download / delete` commands; `zoom_cli/api/recordings.py`; `ApiClient.stream_download` for atomic streamed downloads.
 > User OAuth + PKCE (PR #55): closes #12. New `zoom auth login` 3-legged OAuth flow with loopback callback; `zoom_cli/api/user_oauth.py`; refresh-token storage in keyring service `zoom-cli-user-auth`; extended `auth status` and `auth logout` to cover both surfaces.
-> Schema versioning (this branch): closes #24 (final piece). `meetings.json` now wraps the meetings dict in a `{schema_version, meetings}` envelope; legacy v0 (pre-#24) files read transparently and migrate on first write.
+> Schema versioning (PR #56): closes #24 (final piece). `meetings.json` now wraps the meetings dict in a `{schema_version, meetings}` envelope; legacy v0 (pre-#24) files read transparently and migrate on first write.
+> Per-tier rate limiting (this branch): closes #49 (follow-up to #16's partial close). `zoom_cli/api/rate_limit.py` with token-bucket + daily counter + endpoint→tier classification; opt-in via `ApiClient(creds, rate_limiter=RateLimiter())`.
+
+### Added (issue #49)
+- `zoom_cli/api/rate_limit.py` — `Tier` enum (LIGHT/MEDIUM/HEAVY/RESOURCE_INTENSIVE) and `TIER_LIMITS` table pinned by tests against Zoom's published caps (80/60/40/20 per-second; HEAVY + RESOURCE_INTENSIVE additionally cap at 60,000/day). `TokenBucket` and `DailyCounter` primitives take injectable `clock` / `sleep` / `day_clock` for deterministic tests. `RateLimiter` composes the per-tier buckets and daily counters; `acquire(method, path)` blocks (or raises `DailyCapExhaustedError`) and returns the classified tier.
+- `tier_for(method, path)` — pinned regex table maps the endpoints currently in use; unmapped paths fall back to `Tier.MEDIUM`. Strips a leading `/v1`/`/v2`/etc. version prefix so callers can pass either relative or full paths.
+- `ApiClient` gains `rate_limiter: RateLimiter | None = None` constructor arg. Default `None` = no proactive limiting (existing behaviour unchanged; the 429/Retry-After backoff from #16 still catches reactive throttling). Pass an instance for batch / long-running automation:
+
+  ```python
+  from zoom_cli.api.rate_limit import RateLimiter
+  client = ApiClient(creds, rate_limiter=RateLimiter())
+  ```
 
 ### Added (issue #24, schema versioning piece)
 - `zoom_cli/utils.py` — `SCHEMA_VERSION = 1` constant; new `UnknownSchemaVersionError` for files written by a newer CLI; new `_detect_envelope()` helper that handles both v0 (flat dict at root) and v1 (wrapped envelope).

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -712,3 +712,40 @@ def test_stream_download_cleans_up_tempfile_on_partial(
     # And no .zoom-dl.* tempfile should be left in tmp_path.
     leftovers = list(tmp_path.glob(".zoom-dl.*"))
     assert leftovers == []
+
+
+# ---- #49: rate-limiter integration --------------------------------------
+
+
+def test_apiclient_default_has_no_rate_limiter() -> None:
+    """Default ApiClient is unlimited — same behaviour as before #49."""
+    c = ApiClient(_creds())
+    assert c._rate_limiter is None
+
+
+def test_apiclient_rate_limiter_acquires_before_send(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Closes #49 integration: the limiter is invoked with the request's
+    method + path on every send."""
+    from zoom_cli.api.rate_limit import RateLimiter, Tier
+
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token())
+
+    captured: list[tuple[str, str]] = []
+
+    class _SpyLimiter(RateLimiter):
+        def acquire(self, method: str, path: str) -> Tier:
+            captured.append((method, path))
+            return Tier.LIGHT
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"id": "u-me"})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    with ApiClient(_creds(), http_client=http, rate_limiter=_SpyLimiter()) as c:
+        c.get("/users/me")
+
+    # ApiClient passes the full path (including /v2) to the limiter;
+    # tier_for() strips the version prefix before matching.
+    assert captured == [("GET", "/v2/users/me")]

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,246 @@
+"""Tests for zoom_cli.api.rate_limit — per-tier token-bucket limiter."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from zoom_cli.api.rate_limit import (
+    TIER_LIMITS,
+    DailyCapExhaustedError,
+    DailyCounter,
+    RateLimiter,
+    Tier,
+    TokenBucket,
+    tier_for,
+)
+
+# ---- TokenBucket -------------------------------------------------------
+
+
+class _FakeClock:
+    """Manually-advanceable clock + sleep pair for deterministic tests."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def __call__(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+def test_token_bucket_allows_initial_burst_up_to_capacity() -> None:
+    """Bucket starts full; the first ``capacity`` acquires don't sleep."""
+    clock = _FakeClock()
+    bucket = TokenBucket(capacity=5, rate=5, clock=clock, sleep=clock.sleep)
+    for _ in range(5):
+        assert bucket.acquire() == 0.0
+    assert clock.sleeps == []
+
+
+def test_token_bucket_blocks_when_empty() -> None:
+    """The 6th request when capacity=5 must sleep (1/rate seconds)."""
+    clock = _FakeClock()
+    bucket = TokenBucket(capacity=5, rate=5, clock=clock, sleep=clock.sleep)
+    for _ in range(5):
+        bucket.acquire()
+    wait = bucket.acquire()
+    # Slept ~0.2s for one token at rate 5/s.
+    assert wait == pytest.approx(0.2)
+    assert clock.sleeps == [pytest.approx(0.2)]
+
+
+def test_token_bucket_refills_over_time() -> None:
+    clock = _FakeClock()
+    bucket = TokenBucket(capacity=5, rate=10, clock=clock, sleep=clock.sleep)
+    for _ in range(5):
+        bucket.acquire()
+    # Drain done; advance clock 1 second → 10 tokens generated, capped at 5.
+    clock.now += 1.0
+    for _ in range(5):
+        # All five within the new bucket should be free.
+        assert bucket.acquire() == 0.0
+    assert clock.sleeps == []
+
+
+def test_token_bucket_does_not_overfill_past_capacity() -> None:
+    """A long idle period doesn't accumulate more than ``capacity`` tokens."""
+    clock = _FakeClock()
+    bucket = TokenBucket(capacity=3, rate=10, clock=clock, sleep=clock.sleep)
+    # Drain.
+    for _ in range(3):
+        bucket.acquire()
+    # Idle for an hour — way more refill time than capacity holds.
+    clock.now += 3600.0
+    for _ in range(3):
+        assert bucket.acquire() == 0.0
+    # The 4th call must sleep (capped at 3).
+    wait = bucket.acquire()
+    assert wait > 0.0
+
+
+# ---- DailyCounter ------------------------------------------------------
+
+
+class _FakeDayClock:
+    def __init__(self, *, year: int = 2026, month: int = 4, day: int = 27) -> None:
+        self._dt = datetime(year, month, day, 12, 0, 0, tzinfo=timezone.utc)
+
+    def __call__(self) -> datetime:
+        return self._dt
+
+    def advance_to(self, *, year: int, month: int, day: int) -> None:
+        self._dt = datetime(year, month, day, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def test_daily_counter_allows_up_to_cap() -> None:
+    clock = _FakeDayClock()
+    c = DailyCounter(daily_cap=3, clock=clock)
+    for _ in range(3):
+        c.acquire(Tier.HEAVY)
+
+
+def test_daily_counter_raises_at_cap() -> None:
+    clock = _FakeDayClock()
+    c = DailyCounter(daily_cap=3, clock=clock)
+    for _ in range(3):
+        c.acquire(Tier.HEAVY)
+    with pytest.raises(DailyCapExhaustedError) as excinfo:
+        c.acquire(Tier.HEAVY)
+    assert excinfo.value.tier == Tier.HEAVY
+    assert excinfo.value.cap == 3
+    assert "UTC midnight" in str(excinfo.value)
+
+
+def test_daily_counter_resets_at_utc_midnight() -> None:
+    clock = _FakeDayClock(year=2026, month=4, day=27)
+    c = DailyCounter(daily_cap=2, clock=clock)
+    c.acquire(Tier.HEAVY)
+    c.acquire(Tier.HEAVY)
+    # Roll over to next UTC day.
+    clock.advance_to(year=2026, month=4, day=28)
+    # Cap resets — two more allowed.
+    c.acquire(Tier.HEAVY)
+    c.acquire(Tier.HEAVY)
+
+
+# ---- tier_for classification ------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method,path,expected",
+    [
+        # Light: single-resource reads.
+        ("GET", "/users/me", Tier.LIGHT),
+        ("GET", "/users/u-123", Tier.LIGHT),
+        ("GET", "/users/u-123/settings", Tier.LIGHT),
+        ("GET", "/meetings/12345", Tier.LIGHT),
+        ("GET", "/meetings/12345/recordings", Tier.LIGHT),
+        # Medium: listings + writes.
+        ("GET", "/users", Tier.MEDIUM),
+        ("GET", "/users/u-123/meetings", Tier.MEDIUM),
+        ("GET", "/users/u-123/recordings", Tier.MEDIUM),
+        ("PATCH", "/meetings/12345", Tier.MEDIUM),
+        ("DELETE", "/meetings/12345", Tier.MEDIUM),
+        ("DELETE", "/users/u-123", Tier.MEDIUM),
+        ("DELETE", "/meetings/12345/recordings", Tier.MEDIUM),
+        ("DELETE", "/meetings/12345/recordings/rec-abc", Tier.MEDIUM),
+        ("PUT", "/meetings/12345/status", Tier.MEDIUM),
+        # Heavy: creates.
+        ("POST", "/users", Tier.HEAVY),
+        ("POST", "/users/u-123/meetings", Tier.HEAVY),
+        # Unknown endpoint → MEDIUM default.
+        ("GET", "/some/unknown/path", Tier.MEDIUM),
+        ("POST", "/another/endpoint", Tier.MEDIUM),
+    ],
+)
+def test_tier_for_classifies_known_endpoints(method: str, path: str, expected: Tier) -> None:
+    assert tier_for(method, path) == expected
+
+
+def test_tier_for_strips_query_string() -> None:
+    assert tier_for("GET", "/users/me?page_size=10") == Tier.LIGHT
+
+
+def test_tier_for_strips_trailing_slash() -> None:
+    assert tier_for("GET", "/users/me/") == Tier.LIGHT
+
+
+def test_tier_for_is_method_sensitive() -> None:
+    """GET /users vs POST /users land on different tiers."""
+    assert tier_for("GET", "/users") == Tier.MEDIUM
+    assert tier_for("POST", "/users") == Tier.HEAVY
+
+
+# ---- RateLimiter integration ------------------------------------------
+
+
+def test_rate_limiter_acquire_returns_tier() -> None:
+    """``acquire`` returns the classified tier — useful for metrics/logging."""
+    clock = _FakeClock()
+    day_clock = _FakeDayClock()
+    rl = RateLimiter(clock=clock, sleep=clock.sleep, day_clock=day_clock)
+    assert rl.acquire("GET", "/users/me") == Tier.LIGHT
+    assert rl.acquire("POST", "/users/u-1/meetings") == Tier.HEAVY
+
+
+def test_rate_limiter_does_not_sleep_on_first_request() -> None:
+    clock = _FakeClock()
+    day_clock = _FakeDayClock()
+    rl = RateLimiter(clock=clock, sleep=clock.sleep, day_clock=day_clock)
+    rl.acquire("GET", "/users/me")
+    assert clock.sleeps == []
+
+
+def test_rate_limiter_blocks_after_per_sec_cap_exhausted() -> None:
+    """Exhaust the LIGHT bucket (80) then the next acquire sleeps."""
+    clock = _FakeClock()
+    day_clock = _FakeDayClock()
+    rl = RateLimiter(clock=clock, sleep=clock.sleep, day_clock=day_clock)
+    for _ in range(80):
+        rl.acquire("GET", "/users/me")
+    rl.acquire("GET", "/users/me")
+    assert len(clock.sleeps) == 1
+    assert clock.sleeps[0] > 0.0
+
+
+def test_rate_limiter_daily_cap_raises_on_heavy() -> None:
+    """HEAVY has daily=60_000. Stub the daily cap by reaching into the
+    counter directly; that's the cleanest deterministic test."""
+    clock = _FakeClock()
+    day_clock = _FakeDayClock()
+    rl = RateLimiter(clock=clock, sleep=clock.sleep, day_clock=day_clock)
+    # Pre-fill the heavy daily counter to one below the cap.
+    rl._daily[Tier.HEAVY]._count = TIER_LIMITS[Tier.HEAVY].daily - 1
+    rl.acquire("POST", "/users/u-1/meetings")  # last allowed
+    with pytest.raises(DailyCapExhaustedError):
+        rl.acquire("POST", "/users/u-1/meetings")
+
+
+def test_rate_limiter_light_has_no_daily_cap() -> None:
+    """LIGHT in TIER_LIMITS has daily=None — _daily must omit it."""
+    rl = RateLimiter()
+    assert Tier.LIGHT not in rl._daily
+    assert Tier.MEDIUM not in rl._daily
+    assert Tier.HEAVY in rl._daily
+    assert Tier.RESOURCE_INTENSIVE in rl._daily
+
+
+# ---- TIER_LIMITS pinned -----------------------------------------------
+
+
+def test_tier_limits_match_zoom_published_caps() -> None:
+    """Pinned by docs: a future bump should be a deliberate, reviewed change.
+    Reference: https://developers.zoom.us/docs/api/rate-limits/"""
+    assert TIER_LIMITS[Tier.LIGHT].per_sec == 80
+    assert TIER_LIMITS[Tier.LIGHT].daily is None
+    assert TIER_LIMITS[Tier.MEDIUM].per_sec == 60
+    assert TIER_LIMITS[Tier.MEDIUM].daily is None
+    assert TIER_LIMITS[Tier.HEAVY].per_sec == 40
+    assert TIER_LIMITS[Tier.HEAVY].daily == 60_000
+    assert TIER_LIMITS[Tier.RESOURCE_INTENSIVE].per_sec == 20
+    assert TIER_LIMITS[Tier.RESOURCE_INTENSIVE].daily == 60_000

--- a/zoom_cli/api/client.py
+++ b/zoom_cli/api/client.py
@@ -37,6 +37,7 @@ from typing import Any
 import httpx
 
 from zoom_cli.api import oauth
+from zoom_cli.api.rate_limit import RateLimiter
 from zoom_cli.auth import S2SCredentials
 
 #: Zoom REST API base URL. All paths are relative to this.
@@ -131,11 +132,24 @@ class ApiClient:
         *,
         http_client: httpx.Client | None = None,
         timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        rate_limiter: RateLimiter | None = None,
     ) -> None:
+        """Construct an ApiClient.
+
+        ``rate_limiter`` (closes #49): if set, ``acquire(method, url)`` is
+        called before every request to throttle against Zoom's per-tier
+        per-account limits. Default ``None`` = no proactive limiting; the
+        429/Retry-After backoff from #16 still catches reactive
+        throttling. Pass an instance for batch / long-running automation:
+
+            from zoom_cli.api.rate_limit import RateLimiter
+            client = ApiClient(creds, rate_limiter=RateLimiter())
+        """
         self._credentials = credentials
         self._owns_client = http_client is None
         self._http = http_client if http_client is not None else httpx.Client(timeout=timeout)
         self._cached_token: oauth.AccessToken | None = None
+        self._rate_limiter = rate_limiter
 
     # ---- context-manager hooks ---------------------------------------
 
@@ -180,6 +194,16 @@ class ApiClient:
         json: dict[str, Any] | None,
         force_refresh: bool = False,
     ) -> httpx.Response:
+        # Per-tier rate limiting (closes #49). Acquire BEFORE token
+        # fetch so a token refresh doesn't escape the limiter — Zoom's
+        # /oauth/token endpoint counts against the same per-account
+        # quotas. Path is parsed from the URL so endpoint classification
+        # works for both relative and absolute URLs.
+        if self._rate_limiter is not None:
+            from urllib.parse import urlsplit
+
+            path = urlsplit(url).path or url
+            self._rate_limiter.acquire(method, path)
         token = self._access_token(force_refresh=force_refresh)
         return self._http.request(
             method,

--- a/zoom_cli/api/rate_limit.py
+++ b/zoom_cli/api/rate_limit.py
@@ -1,0 +1,279 @@
+"""Per-tier token-bucket rate limiting for the Zoom REST API (closes #49).
+
+Zoom enforces per-account rate limits broken into four tiers (per
+https://developers.zoom.us/docs/api/rate-limits/):
+
+| Tier               | Per-second cap | Per-day cap |
+|--------------------|----------------|-------------|
+| Light              | 80             | —           |
+| Medium             | 60             | —           |
+| Heavy              | 40             | 60,000      |
+| Resource-intensive | 20             | 60,000      |
+
+This module provides:
+
+  - :class:`Tier` — enum of the four tiers.
+  - :data:`TIER_LIMITS` — pinned table mapping tier → (per_sec, daily).
+  - :data:`ENDPOINT_TIERS` — list of ``(method, regex, Tier)`` rules
+    matched in order; tests pin every endpoint the CLI currently uses.
+  - :func:`tier_for(method, path)` — classify a request.
+  - :class:`TokenBucket` — pure token-bucket primitive with injectable
+    clock + sleep so tests run deterministically.
+  - :class:`DailyCounter` — UTC-day window counter with injectable clock.
+    Raises :class:`DailyCapExhaustedError` when the cap is hit; we
+    deliberately don't sleep until midnight (could be many hours).
+  - :class:`RateLimiter` — composes per-tier buckets + daily counters.
+    Pass an instance to :class:`~zoom_cli.api.client.ApiClient` to
+    enable limiting; default is no limiting (the 429 retry from #16
+    catches most single-shot use).
+
+The 429/Retry-After backoff from #16 still runs *after* this limiter:
+the limiter prevents most violations proactively; the 429 retry catches
+anything the per-account state didn't predict (e.g., other clients on
+the same account also hammering Zoom).
+"""
+
+from __future__ import annotations
+
+import enum
+import re
+import time
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+
+
+class Tier(enum.Enum):
+    """Zoom's four rate-limit tiers, ordered roughly by burst budget."""
+
+    LIGHT = "light"
+    MEDIUM = "medium"
+    HEAVY = "heavy"
+    RESOURCE_INTENSIVE = "resource_intensive"
+
+
+@dataclass(frozen=True)
+class TierLimit:
+    """Per-tier caps. ``daily`` is ``None`` for tiers without a daily cap."""
+
+    per_sec: int
+    daily: int | None
+
+
+#: Pinned by a test — bumping these requires updating the docstring at the
+#: top of this file too.
+TIER_LIMITS: dict[Tier, TierLimit] = {
+    Tier.LIGHT: TierLimit(per_sec=80, daily=None),
+    Tier.MEDIUM: TierLimit(per_sec=60, daily=None),
+    Tier.HEAVY: TierLimit(per_sec=40, daily=60_000),
+    Tier.RESOURCE_INTENSIVE: TierLimit(per_sec=20, daily=60_000),
+}
+
+
+# ---- endpoint → tier classification --------------------------------------
+#
+# Order matters: most-specific patterns first. Each rule is
+# ``(method or "*", compiled regex, Tier)``. ``method == "*"`` matches
+# any method. The regex is anchored with ^ and $ implicitly via fullmatch.
+
+_TIER_RULES: list[tuple[str, re.Pattern[str], Tier]] = [
+    # /users/me — single-resource read, the cheapest call.
+    ("GET", re.compile(r"/users/me"), Tier.LIGHT),
+    # GET /users — listing
+    ("GET", re.compile(r"/users"), Tier.MEDIUM),
+    # GET /users/<id>/settings — single-user metadata
+    ("GET", re.compile(r"/users/[^/]+/settings"), Tier.LIGHT),
+    # GET /users/<id>/meetings — listing for a user
+    ("GET", re.compile(r"/users/[^/]+/meetings"), Tier.MEDIUM),
+    # GET /users/<id>/recordings — listing recordings
+    ("GET", re.compile(r"/users/[^/]+/recordings"), Tier.MEDIUM),
+    # GET /users/<id> — single user
+    ("GET", re.compile(r"/users/[^/]+"), Tier.LIGHT),
+    # POST /users — create user
+    ("POST", re.compile(r"/users"), Tier.HEAVY),
+    # DELETE /users/<id> — disassociate / delete
+    ("DELETE", re.compile(r"/users/[^/]+"), Tier.MEDIUM),
+    # POST /users/<id>/meetings — create meeting
+    ("POST", re.compile(r"/users/[^/]+/meetings"), Tier.HEAVY),
+    # GET /meetings/<id>/recordings — single meeting's recordings
+    ("GET", re.compile(r"/meetings/[^/]+/recordings"), Tier.LIGHT),
+    # DELETE /meetings/<id>/recordings or .../recordings/<rid>
+    ("DELETE", re.compile(r"/meetings/[^/]+/recordings(?:/[^/]+)?"), Tier.MEDIUM),
+    # PUT /meetings/<id>/status — end meeting
+    ("PUT", re.compile(r"/meetings/[^/]+/status"), Tier.MEDIUM),
+    # GET /meetings/<id>
+    ("GET", re.compile(r"/meetings/[^/]+"), Tier.LIGHT),
+    # PATCH /meetings/<id> — update
+    ("PATCH", re.compile(r"/meetings/[^/]+"), Tier.MEDIUM),
+    # DELETE /meetings/<id>
+    ("DELETE", re.compile(r"/meetings/[^/]+"), Tier.MEDIUM),
+]
+
+#: Default tier for unmapped endpoints. MEDIUM matches Zoom's most-common
+#: tier for read+listing endpoints, so it's the safe default.
+_DEFAULT_TIER = Tier.MEDIUM
+
+
+def tier_for(method: str, path: str) -> Tier:
+    """Classify a request into a :class:`Tier`.
+
+    ``path`` should be the URL path (no query string, no leading host).
+    A leading API-version prefix (``/v1``, ``/v2``, ...) is stripped
+    before matching, so callers can pass either the relative path
+    (``/users/me``) or the full path (``/v2/users/me``). Trailing
+    slashes are stripped. Unknown endpoints fall back to
+    :data:`_DEFAULT_TIER` (MEDIUM).
+    """
+    method_u = method.upper()
+    path_no_query = path.split("?", 1)[0]
+    # Strip a leading version prefix like /v1, /v2, /v33.
+    path_norm = re.sub(r"^/v\d+", "", path_no_query).rstrip("/") or "/"
+    for rule_method, regex, tier in _TIER_RULES:
+        if rule_method != "*" and rule_method != method_u:
+            continue
+        if regex.fullmatch(path_norm):
+            return tier
+    return _DEFAULT_TIER
+
+
+# ---- primitives ---------------------------------------------------------
+
+
+class DailyCapExhaustedError(RuntimeError):
+    """Daily cap for a tier is exhausted.
+
+    Sleeping until UTC midnight could be many hours; we surface this as
+    an exception so the caller can decide (defer the job, alert, etc.)
+    rather than silently blocking.
+    """
+
+    def __init__(self, tier: Tier, cap: int) -> None:
+        super().__init__(
+            f"Daily cap of {cap} requests for tier {tier.value} is exhausted; "
+            "retry after UTC midnight"
+        )
+        self.tier = tier
+        self.cap = cap
+
+
+class TokenBucket:
+    """Classic token-bucket primitive.
+
+    Constructor:
+      capacity:  max tokens the bucket holds
+      rate:      tokens added per second
+      clock:     callable returning monotonic seconds (default time.monotonic)
+      sleep:     callable taking seconds (default time.sleep)
+
+    ``acquire(n=1.0)`` returns the number of seconds slept (0.0 on a hit).
+    """
+
+    def __init__(
+        self,
+        capacity: float,
+        rate: float,
+        *,
+        clock=time.monotonic,
+        sleep=time.sleep,
+    ) -> None:
+        self.capacity = float(capacity)
+        self.rate = float(rate)
+        self._tokens = float(capacity)
+        self._last = clock()
+        self._clock = clock
+        self._sleep = sleep
+
+    def _refill(self) -> None:
+        now = self._clock()
+        delta = now - self._last
+        if delta > 0:
+            self._tokens = min(self.capacity, self._tokens + delta * self.rate)
+            self._last = now
+
+    def acquire(self, n: float = 1.0) -> float:
+        self._refill()
+        if self._tokens >= n:
+            self._tokens -= n
+            return 0.0
+        deficit = n - self._tokens
+        wait = deficit / self.rate
+        self._sleep(wait)
+        # Advance internal clock + drain the bucket; we consumed our share.
+        self._last = self._clock()
+        self._tokens = 0.0
+        return wait
+
+
+class DailyCounter:
+    """UTC-day window counter; raises when the cap is hit.
+
+    Constructor takes ``daily_cap`` and an optional ``clock`` returning a
+    timezone-aware ``datetime`` (default ``datetime.now(timezone.utc)``).
+    The window resets when the UTC date changes.
+    """
+
+    def __init__(
+        self,
+        daily_cap: int,
+        *,
+        clock=lambda: datetime.now(timezone.utc),
+    ) -> None:
+        self._cap = daily_cap
+        self._clock = clock
+        self._count = 0
+        self._day: date = clock().date()
+
+    def acquire(self, tier: Tier) -> None:
+        today = self._clock().date()
+        if today != self._day:
+            self._day = today
+            self._count = 0
+        if self._count >= self._cap:
+            raise DailyCapExhaustedError(tier, self._cap)
+        self._count += 1
+
+
+# ---- composed limiter --------------------------------------------------
+
+
+class RateLimiter:
+    """Composes a per-tier :class:`TokenBucket` + (where applicable) a
+    :class:`DailyCounter`.
+
+    Default per-tier capacities and refill rates come from
+    :data:`TIER_LIMITS`. Inject ``clock`` / ``sleep`` / ``day_clock`` to
+    drive deterministic tests.
+    """
+
+    def __init__(
+        self,
+        *,
+        clock=time.monotonic,
+        sleep=time.sleep,
+        day_clock=lambda: datetime.now(timezone.utc),
+    ) -> None:
+        self._buckets: dict[Tier, TokenBucket] = {}
+        self._daily: dict[Tier, DailyCounter] = {}
+        for tier, limit in TIER_LIMITS.items():
+            self._buckets[tier] = TokenBucket(
+                capacity=limit.per_sec,
+                rate=limit.per_sec,
+                clock=clock,
+                sleep=sleep,
+            )
+            if limit.daily is not None:
+                self._daily[tier] = DailyCounter(limit.daily, clock=day_clock)
+
+    def acquire(self, method: str, path: str) -> Tier:
+        """Block until a slot is available for ``(method, path)``.
+
+        Returns the tier the request was classified as (useful for
+        logging / metrics). Raises :class:`DailyCapExhaustedError` if
+        the tier's daily cap is hit.
+        """
+        tier = tier_for(method, path)
+        # Daily counter first — if exhausted, no point in waiting on the
+        # per-second bucket.
+        if tier in self._daily:
+            self._daily[tier].acquire(tier)
+        self._buckets[tier].acquire()
+        return tier


### PR DESCRIPTION
## Summary

Closes #49 (follow-up to #16's partial close). Adds proactive per-tier rate limiting on top of the reactive 429 backoff that landed in #16.

| Tier | Per-second cap | Per-day cap |
|---|---|---|
| Light | 80 | — |
| Medium | 60 | — |
| Heavy | 40 | 60,000 |
| Resource-intensive | 20 | 60,000 |

## What's new

### \`zoom_cli/api/rate_limit.py\`

\`\`\`python
class Tier(enum.Enum): LIGHT, MEDIUM, HEAVY, RESOURCE_INTENSIVE
TIER_LIMITS: dict[Tier, TierLimit]    # pinned against Zoom's published caps

class TokenBucket(capacity, rate, *, clock=..., sleep=...)
    acquire(n=1.0) -> float  # seconds slept

class DailyCounter(daily_cap, *, clock=...)
    acquire(tier) -> None  # raises DailyCapExhaustedError at the cap

class RateLimiter(*, clock=..., sleep=..., day_clock=...)
    acquire(method, path) -> Tier  # blocks; returns classified tier

def tier_for(method, path) -> Tier  # regex table; strips /vN; default MEDIUM
\`\`\`

Sleeping until UTC midnight (when a daily cap is hit) could be many hours, so \`DailyCapExhaustedError\` surfaces instead of blocking — caller decides whether to defer the job, alert, etc.

### \`ApiClient\` integration (opt-in)

\`\`\`python
from zoom_cli.api.rate_limit import RateLimiter
client = ApiClient(creds, rate_limiter=RateLimiter())
\`\`\`

Default \`None\` = no proactive limiting (existing behaviour unchanged; the 429/Retry-After backoff from #16 still catches reactive throttling). Pass an instance for batch / long-running automation.

When set, \`_send\` acquires the limiter **before** the token fetch — Zoom's \`/oauth/token\` endpoint counts against per-account quotas too, so a token refresh that races against the bucket would otherwise escape the limiter.

## Tests (+36 new)

| File | New | Covers |
|---|---|---|
| \`tests/test_rate_limit.py\` | +34 | TokenBucket: initial burst, blocks-when-empty, refills-over-time, no-overfill. DailyCounter: allows-up-to-cap, raises-at-cap with actionable message, resets-at-utc-midnight. \`tier_for\` parametrized over every endpoint the CLI uses (16 cases) + strips query string + strips trailing slash + method-sensitive. RateLimiter: acquire returns tier, no-sleep-on-first, blocks-after-per-sec-exhausted, daily-cap-raises-on-heavy, light-has-no-daily. TIER_LIMITS pinned against published caps |
| \`tests/test_api_client.py\` | +2 | Default has no rate_limiter; when set, \`acquire(method, path)\` is invoked on every send |

All clock + sleep injection is via \`_FakeClock\` / \`_FakeDayClock\` helpers — no real \`time.sleep\` calls in tests.

## Verification

\`\`\`
ruff check .          # All checks passed!
ruff format --check . # 31 files already formatted
mypy                  # Success: no issues found in 15 source files
pytest -q             # 429 passed (was 393; +36)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)