### PR TITLE
docs: close #23 — rewrite README around local + API modes; add examples/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Recordings surface (PR #54): closes #15. New `zoom recordings list / get / download / delete` commands; `zoom_cli/api/recordings.py`; `ApiClient.stream_download` for atomic streamed downloads.
 > User OAuth + PKCE (PR #55): closes #12. New `zoom auth login` 3-legged OAuth flow with loopback callback; `zoom_cli/api/user_oauth.py`; refresh-token storage in keyring service `zoom-cli-user-auth`; extended `auth status` and `auth logout` to cover both surfaces.
 > Schema versioning (PR #56): closes #24 (final piece). `meetings.json` now wraps the meetings dict in a `{schema_version, meetings}` envelope; legacy v0 (pre-#24) files read transparently and migrate on first write.
-> Per-tier rate limiting (this branch): closes #49 (follow-up to #16's partial close). `zoom_cli/api/rate_limit.py` with token-bucket + daily counter + endpoint→tier classification; opt-in via `ApiClient(creds, rate_limiter=RateLimiter())`.
+> Per-tier rate limiting (PR #57): closes #49 (follow-up to #16's partial close). `zoom_cli/api/rate_limit.py` with token-bucket + daily counter + endpoint→tier classification; opt-in via `ApiClient(creds, rate_limiter=RateLimiter())`.
+> Documentation rewrite (this branch): closes #23. README rewritten around the two-mode reality (local launcher + REST API), full CLI reference, configuration table, security overview; new `examples/` directory with three runnable scripts.
+
+### Documentation (issue #23)
+- **README rewrite** — restructured around the two operational modes (local launcher + Zoom REST API), each with its own quick-start. New "CLI reference" section enumerates every command. New "Configuration" table maps each storage location (`~/.zoom-cli/`, four keyring services, in-memory) to what it holds. Security section links to `SECURITY.md` / `LOCAL-SECURITY.md` and summarises the highlights. Project-layout block updated for the new `api/` modules.
+- **`examples/`** (new) — three runnable scripts:
+  - `list-active-users.sh` — TSV pipeline: `zoom users list` → `cut`/`sort -u`.
+  - `download-recent-recordings.sh` — list-then-download for the last 7 days; uses `awk` to filter the TSV, calls `zoom recordings download` per meeting.
+  - `batch-meetings-with-rate-limit.py` — programmatic Python use of `ApiClient` with the per-tier `RateLimiter` for batch automation.
 
 ### Added (issue #49)
 - `zoom_cli/api/rate_limit.py` — `Tier` enum (LIGHT/MEDIUM/HEAVY/RESOURCE_INTENSIVE) and `TIER_LIMITS` table pinned by tests against Zoom's published caps (80/60/40/20 per-second; HEAVY + RESOURCE_INTENSIVE additionally cap at 60,000/day). `TokenBucket` and `DailyCounter` primitives take injectable `clock` / `sleep` / `day_clock` for deterministic tests. `RateLimiter` composes the per-tier buckets and daily counters; `acquire(method, path)` blocks (or raises `DailyCapExhaustedError`) and returns the classified tier.

--- a/README.md
+++ b/README.md
@@ -4,91 +4,251 @@
 [![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-`zoom` is a command line tool that lets you store, access, and launch Zoom meetings on the fly. Written in Python, available via Homebrew.
+`zoom` is a command-line tool for Zoom — two modes in one binary:
 
-> **Heads up — fork in flight.** This fork (`jordan8037310/zoom-cli`) is being modernized and expanded toward Zoom REST API integration. See [`docs/comparative-analysis.md`](docs/comparative-analysis.md) for the maturity assessment and roadmap, and [`CHANGELOG.md`](CHANGELOG.md) for changes. Upstream is [`tmonfre/zoom-cli`](https://github.com/tmonfre/zoom-cli).
+| Mode | What it does | Auth |
+|---|---|---|
+| **Local launcher** (offline) | Save meetings as named bookmarks; launch the Zoom desktop client via `zoommtg://` | None |
+| **Zoom REST API** | List/get/create/update/delete users, meetings, recordings; download recordings | Server-to-Server OAuth or User OAuth (PKCE) |
 
-## Installation Instructions
+Both modes ship in the same `zoom` binary and share the same configuration directory (`~/.zoom-cli/`). You can use one or both.
 
-### Mac/Linux Users
+> **Fork in flight.** `jordan8037310/zoom-cli` is being modernized and expanded toward Zoom REST API integration. See [`CHANGELOG.md`](CHANGELOG.md) for the running notes and [`docs/comparative-analysis.md`](docs/comparative-analysis.md) for the maturity / roadmap. Upstream is [`tmonfre/zoom-cli`](https://github.com/tmonfre/zoom-cli).
 
-1. Download and install Homebrew: [https://brew.sh](https://brew.sh).
-2. `brew tap tmonfre/homebrew-tmonfre`
-3. `brew install zoom`
-4. (Only if zoom cask is also installed) `brew link zoom`
+## Quick start
 
-### PC Users
+### Local launcher mode
 
-This package is currently not yet available on Scoop. Please follow the [developer instructions](#developer-instructions) below in the meantime.
+```bash
+# Save a meeting
+zoom save -n standup --url 'https://zoom.us/j/123456789?pwd=secret'
 
-## Usage
+# Launch it later
+zoom standup
 
-Below are the available commands. If an option/flag listed below is omitted, you will be prompted to enter its value.
+# Or launch any URL on the fly
+zoom 'https://zoom.us/j/123456789?pwd=secret'
 
-### Launch Meetings
+# List saved meetings (passwords masked)
+zoom ls
 
-- `zoom [url]` to launch any meeting on the fly.
-- `zoom [name]` to launch a saved meeting by name.
+# Delete a saved meeting
+zoom rm standup
+```
 
-### Save Meetings
+Saved meetings live in `~/.zoom-cli/meetings.json` (just metadata). Passwords go into the OS keyring (Keychain on macOS, libsecret on Linux, Credential Manager on Windows) — never plaintext on disk for new entries.
 
-- `zoom save` to save a new meeting
-  - `-n, --name` meeting name
-  - `--id` meeting ID
-  - `--password` meeting password (optional)
-  - `--url` meeting URL (optional, must provide this or `--id`)
+### Zoom REST API mode
 
-- `zoom edit` to edit a stored meeting
-  - `-n, --name` meeting name (optional)
-  - `--id` meeting ID (optional)
-  - `--password` meeting password (optional)
-  - `--url` meeting URL (optional)
+```bash
+# Configure Server-to-Server OAuth credentials (creates a Zoom marketplace app first)
+zoom auth s2s set --account-id AAA --client-id BBB
+# Client secret is read from ZOOM_CLIENT_SECRET env var or prompted (never accepted as a flag)
 
-- `zoom rm [name]` to delete a stored meeting
+# Verify
+zoom auth s2s test
 
-- `zoom ls` to see all stored meetings
+# Read your own profile
+zoom users me
 
-## Developer Instructions
+# List users (paginated, TSV output)
+zoom users list
 
-Interested in contributing? Follow the steps below to install the project locally. Open a pull request and reference the related issue (`Closes #N`).
+# List your scheduled meetings
+zoom meetings list
 
-1. Ensure you have **Python 3.10+** installed.
-2. Clone this repository.
-3. Create a virtual environment and install in editable mode with dev extras:
+# Download a meeting's recordings
+zoom recordings download 12345 --out-dir ./recordings
+```
 
-    ```shell
-    python3 -m venv .venv
-    source .venv/bin/activate
-    pip install -e '.[dev]'
-    ```
+For users without admin marketplace access, `zoom auth login --client-id <id>` runs a 3-legged OAuth flow with PKCE instead.
 
-4. Run the test suite, lint, and type-check:
+## Installation
 
-    ```shell
-    pytest                # tests + coverage
-    ruff check .          # lint
-    ruff format --check . # formatting
-    mypy                  # type check
-    ```
+### macOS / Linux (via PyPI)
 
-5. Run the CLI directly: `python -m zoom_cli` or `./cli.py`.
-6. Build a distributable binary with PyInstaller (optional, for releases):
+```bash
+pip install zoom-cli           # (planned — not yet on PyPI)
+# Or directly from GitHub:
+pip install git+https://github.com/jordan8037310/zoom-cli.git
+```
 
-    ```shell
-    pip install -e '.[build]'
-    ./build.sh
-    ```
+### macOS / Linux (legacy Homebrew, upstream)
 
-    A binary named `zoom` will be generated in `dist/`. The script also generates `dist/zoom.tar.gz` and prints its SHA-256 hash for the Homebrew formula.
+The upstream `tmonfre/zoom-cli` Homebrew tap installs the local-launcher portion only:
+
+```bash
+brew tap tmonfre/homebrew-tmonfre
+brew install zoom
+```
+
+This fork's REST API surface is **not** available through that tap yet. Use `pip install` until a fresh formula publishes.
+
+### Windows
+
+Currently no installer; use the [developer instructions](#developer-instructions) below.
+
+## CLI reference
+
+Every command supports `--help`. Full surface as of latest:
+
+### Local launcher
+
+```
+zoom <name>                          # launch saved meeting
+zoom <url>                           # launch URL (only Zoom domains accepted)
+zoom save -n NAME [--url URL | --id ID] [-p PASSWORD]
+zoom edit  [-n NAME] [--url URL] [--id ID] [-p PASSWORD]
+zoom rm    [NAME] [--yes] [--dry-run]
+zoom ls                              # list saved (passwords masked)
+```
+
+URL safety: `zoom <url>` only accepts hosts on the Zoom allowlist (`zoom.us`, `*.zoom.us`, `zoomgov.com`, `*.zoomgov.com`). Look-alike hosts like `my-zoom.us-domain.com` are refused at the launcher.
+
+### Authentication
+
+```
+zoom auth s2s set [--account-id ID] [--client-id ID]
+                                # client secret: ZOOM_CLIENT_SECRET env var or masked prompt
+zoom auth s2s test              # exchange creds for an access token
+zoom auth login --client-id ID [--port N] [--timeout S] [--no-browser]
+                                # 3-legged user OAuth + PKCE (#12)
+zoom auth status                # show which surfaces are configured
+zoom auth logout                # clear all stored credentials
+```
+
+### Users API
+
+```
+zoom users me                                  # current user profile
+zoom users get <user-id-or-email>              # any user's profile
+zoom users list [--status active|inactive|pending] [--page-size N]
+zoom users create --email E --type {1,2,3} [--first-name] [--last-name] [...] [--action ...]
+zoom users delete <user-id> [--action disassociate|delete] [--transfer-email ...] [--yes] [--dry-run]
+zoom users settings get [user-id]              # JSON dump
+```
+
+### Meetings API
+
+```
+zoom meetings list [--user-id me] [--type scheduled|live|upcoming|...] [--page-size N]
+zoom meetings get <meeting-id>
+zoom meetings create --topic T [--type N] [--start-time ISO] [--duration MIN] [--password P] [...]
+zoom meetings update <meeting-id> [--topic] [--start-time] [--duration] [...]
+zoom meetings delete <meeting-id> [--yes] [--dry-run] [--notify-host] [--notify-registrants]
+zoom meetings end    <meeting-id> [--yes]      # kicks all participants
+```
+
+### Recordings API
+
+```
+zoom recordings list [--user-id me] [--from YYYY-MM-DD] [--to YYYY-MM-DD] [--page-size N]
+zoom recordings get <meeting-id>               # JSON dump for jq pipelines
+zoom recordings download <meeting-id> [--out-dir DIR] [--file-type MP4 ...]
+                                              # streamed atomic write per file
+zoom recordings delete <meeting-id> [--file-id ID] [--action trash|delete] [--yes] [--dry-run]
+```
+
+## Examples
+
+See [`examples/`](examples/) for runnable scripts:
+
+- [`examples/list-active-users.sh`](examples/list-active-users.sh) — TSV pipeline for `zoom users list` (cut/awk/sort).
+- [`examples/download-recent-recordings.sh`](examples/download-recent-recordings.sh) — list-then-download for the last week.
+- [`examples/batch-meetings-with-rate-limit.py`](examples/batch-meetings-with-rate-limit.py) — programmatic Python use of `ApiClient` with the per-tier rate limiter.
+
+## Configuration
+
+| Path | What it stores |
+|---|---|
+| `~/.zoom-cli/meetings.json` | Local launcher bookmarks (URL or meeting ID + name; passwords masked into the keyring on save). Atomic writes; schema-versioned. |
+| OS keyring service `zoom-cli` | Per-meeting passwords (one entry per saved meeting). |
+| OS keyring service `zoom-cli-auth` | Server-to-Server OAuth credentials (account_id, client_id, client_secret). |
+| OS keyring service `zoom-cli-user-auth` | User OAuth refresh token + client_id (PKCE flow). |
+| In-memory only | API access tokens (1-hour bearer; re-minted on demand). |
+
+Environment variables (all optional):
+
+- `ZOOM_ACCOUNT_ID`, `ZOOM_CLIENT_ID`, `ZOOM_CLIENT_SECRET` — alternative inputs for `zoom auth s2s set` (the secret is **never** accepted as a CLI flag).
+- `ZOOM_USER_CLIENT_ID` — alternative input for `zoom auth login`.
+
+## Security
+
+For the full threat model, see [`SECURITY.md`](SECURITY.md). Highlights:
+
+- All secrets live in the OS keyring; nothing sensitive on disk.
+- URLs go through a domain allowlist before launch — deceptive look-alikes refused.
+- All `meetings.json` writes are atomic (tempfile + fsync + `os.replace` + parent-dir fsync) and use a POSIX `fcntl.flock` to serialize concurrent CLI invocations.
+- File mode `0o600` for `meetings.json`, `0o700` for `~/.zoom-cli/`. Existing permissive perms are tightened on touch.
+- API client retries 401 once with a force-refresh and 429 up to three times with `Retry-After` + jitter. Optional opt-in per-tier token-bucket limiter for batch jobs.
+- AI assistants working on this project are denied (via `.claude/settings.json`) every endpoint command, keyring access against the `zoom-cli*` services, and direct `curl` against `api.zoom.us`. See [`LOCAL-SECURITY.md`](LOCAL-SECURITY.md).
+
+## Developer instructions
+
+Interested in contributing? See [`CLAUDE.md`](CLAUDE.md) for the project conventions and [`TASKS.md`](TASKS.md) for the open backlog.
+
+```bash
+# 1. Python 3.10+
+python3 -m venv .venv
+source .venv/bin/activate
+
+# 2. Editable install with dev extras
+pip install -e '.[dev]'
+
+# 3. Quality gate
+ruff check .          # lint
+ruff format --check . # formatting
+mypy                  # type check
+pytest                # 429+ tests across the matrix
+
+# 4. Run the CLI directly
+python -m zoom_cli --help
+
+# 5. (Optional) build a PyInstaller binary for releases
+pip install -e '.[build]'
+./build.sh             # produces dist/zoom + dist/zoom.tar.gz
+```
+
+CI runs the same gate on Python 3.10–3.13 × Ubuntu + macOS for every PR.
+
+### Branch + PR conventions
+
+- Branches: `feat/<topic>`, `fix/<topic>`, `chore/<topic>`, `docs/<topic>`, `refactor/<topic>`.
+- Commits: conventional-style (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`).
+- One issue → one PR. Reference the issue in the PR body (`Closes #N`).
+- Update [`CHANGELOG.md`](CHANGELOG.md) under `[Unreleased]` for any user-visible change.
 
 ## Project layout
 
 ```
-zoom_cli/        # package — CLI entrypoint, commands, storage helpers
-tests/           # pytest suite (utils, commands, CLI surface)
-docs/            # design notes & comparative analysis
-.github/         # CI workflow
-cli.py           # PyInstaller entrypoint shim
+zoom_cli/
+  __main__.py          # Click CLI entrypoint
+  commands.py          # Local-launcher commands
+  utils.py             # Storage, ANSI helpers, launch helpers, schema versioning
+  auth.py              # OS keyring storage for S2S + user OAuth credentials
+  secrets.py           # Per-meeting password storage (keyring)
+  api/
+    client.py          # ApiClient (bearer auth, 401/429 retry, optional rate limiter)
+    oauth.py           # S2S token exchange
+    user_oauth.py      # 3-legged PKCE flow
+    pagination.py      # paginate() generator helper
+    rate_limit.py      # per-tier token bucket + daily counter
+    users.py           # /users helpers
+    meetings.py        # /meetings helpers
+    recordings.py      # /meetings/<id>/recordings helpers
+tests/                 # pytest suite (429+ tests across the API + CLI surface)
+examples/              # runnable example scripts
+docs/                  # design notes & comparative analysis
+.github/workflows/     # CI
+.claude/               # FACET CC settings (AI-assistant guardrails)
 ```
 
-See [`CLAUDE.md`](CLAUDE.md) for AI-assistant project conventions and [`CHANGELOG.md`](CHANGELOG.md) for the running release notes.
+## Links
+
+- [`CHANGELOG.md`](CHANGELOG.md) — release notes
+- [`SECURITY.md`](SECURITY.md) — threat model
+- [`LOCAL-SECURITY.md`](LOCAL-SECURITY.md) — AI/MCP/skill risk register
+- [`CLAUDE.md`](CLAUDE.md) — AI-assistant project conventions
+- [`TASKS.md`](TASKS.md) — open backlog
+- [Zoom REST API docs](https://developers.zoom.us/docs/api/)
+- [Zoom rate limits](https://developers.zoom.us/docs/api/rate-limits/)

--- a/examples/batch-meetings-with-rate-limit.py
+++ b/examples/batch-meetings-with-rate-limit.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Programmatic batch use of the Zoom API client with proactive rate limiting.
+
+Use case: a long-running script that touches many users / meetings and
+wants to stay well under Zoom's per-account per-tier limits without
+relying solely on reactive 429 backoff.
+
+The CLI itself doesn't enable the rate limiter by default (it's
+opt-in via the constructor) — this script shows how to wire it up.
+
+Requires: `zoom auth s2s set` to have run first (or for the script to
+be invoked with ZOOM_ACCOUNT_ID / ZOOM_CLIENT_ID / ZOOM_CLIENT_SECRET
+in the environment if zoom-cli is configured to read them).
+"""
+
+from __future__ import annotations
+
+import sys
+
+from zoom_cli import auth
+from zoom_cli.api.client import ApiClient
+from zoom_cli.api.rate_limit import RateLimiter
+from zoom_cli.api.users import list_users
+
+
+def main() -> int:
+    creds = auth.load_s2s_credentials()
+    if creds is None:
+        print(
+            "No Server-to-Server OAuth credentials saved. Run `zoom auth s2s set` first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # The limiter throttles to Zoom's published per-tier caps (80/60/40/20
+    # per second; HEAVY + RESOURCE_INTENSIVE additionally cap at 60k/day).
+    # `ApiClient` will block (or raise DailyCapExhaustedError) before
+    # sending if a bucket is empty.
+    rate_limiter = RateLimiter()
+
+    with ApiClient(creds, rate_limiter=rate_limiter) as client:
+        # `list_users` paginates transparently; each page request goes
+        # through the limiter. For a large account this safely walks
+        # thousands of users at the MEDIUM tier (60/s).
+        for user in list_users(client, status="active"):
+            # Replace this with the real per-user work — list their
+            # meetings, fetch settings, etc. Each subsequent call
+            # also goes through the limiter automatically.
+            print(f"{user.get('id', '')}\t{user.get('email', '')}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/download-recent-recordings.sh
+++ b/examples/download-recent-recordings.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Download every recording from the last 7 days into ./recordings/.
+#
+# Walks `zoom recordings list` (paginated) for the date range, then
+# invokes `zoom recordings download` per meeting. Each download is
+# atomic (sibling tempfile + os.replace) so a network drop never
+# leaves a half-written file at the destination.
+#
+# Requires: `zoom auth s2s set` to have run first.
+
+set -euo pipefail
+
+OUT_DIR="${1:-./recordings}"
+mkdir -p "$OUT_DIR"
+
+# 7 days ago in YYYY-MM-DD format. macOS `date` and GNU `date` differ;
+# Python is more portable for date math.
+SINCE="$(python3 -c 'from datetime import date, timedelta; print(date.today() - timedelta(days=7))')"
+
+echo "Downloading recordings since $SINCE into $OUT_DIR ..."
+
+# `zoom recordings list` outputs TSV: uuid, meeting_id, topic, start_time, file_count
+# Skip the header, skip rows with file_count = 0.
+zoom recordings list --from "$SINCE" \
+    | tail -n +2 \
+    | awk -F$'\t' '$5 != "0" {print $2}' \
+    | while read -r meeting_id; do
+        echo "→ meeting $meeting_id"
+        zoom recordings download "$meeting_id" --out-dir "$OUT_DIR"
+    done
+
+echo "Done."

--- a/examples/list-active-users.sh
+++ b/examples/list-active-users.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# List all active Zoom users in the account, sorted by email.
+#
+# `zoom users list` emits TSV with a header row, designed to pipe through
+# the standard text tools (cut/awk/sort/column/etc.).
+#
+# Requires: `zoom auth s2s set` to have run first (or set ZOOM_ACCOUNT_ID +
+# ZOOM_CLIENT_ID + ZOOM_CLIENT_SECRET environment variables).
+
+set -euo pipefail
+
+# Skip the header row, then grab the email column (field 2) and sort.
+zoom users list --status active \
+    | tail -n +2 \
+    | cut -f2 \
+    | sort -u


### PR DESCRIPTION
## Summary

Closes #23. Old README was the upstream `tmonfre/zoom-cli` text — focused entirely on the local launcher. This rewrite restructures around the two operational modes that now coexist (local launcher + Zoom REST API), and adds an \`examples/\` directory with three runnable scripts.

## What changed

### README

- **Two-mode summary table** at the top (which mode, what it does, what auth it needs).
- **Quick-start blocks** for each mode — copy/paste-ready.
- **Installation**: pip (planned PyPI + git+GitHub now), legacy Homebrew note for the launcher-only upstream.
- **CLI reference** — every command with its flag surface, split per subcommand group: launcher, auth, users, meetings, recordings.
- **Configuration table** mapping each storage location to what it holds:
  - \`~/.zoom-cli/meetings.json\` — local bookmarks (passwords masked into keyring)
  - keyring \`zoom-cli\` — per-meeting passwords
  - keyring \`zoom-cli-auth\` — S2S credentials
  - keyring \`zoom-cli-user-auth\` — user OAuth refresh + client_id
  - in-memory only — API access tokens
- **Environment variables**: \`ZOOM_ACCOUNT_ID\` / \`CLIENT_ID\` / \`CLIENT_SECRET\` / \`USER_CLIENT_ID\`.
- **Security** section linking to \`SECURITY.md\` + \`LOCAL-SECURITY.md\`; summarises the guarantees (URL allowlist, atomic writes, keyring-only secrets, 401/429 retry, opt-in per-tier rate limiter).
- **Developer instructions** updated to reflect the 429+ test suite + matrix.
- **Project-layout block** updated for the new \`api/\` modules.

### examples/ (new)

| File | What it shows |
|---|---|
| [\`list-active-users.sh\`](examples/list-active-users.sh) | TSV pipeline: \`zoom users list\` → \`tail\` → \`cut\` → \`sort -u\` |
| [\`download-recent-recordings.sh\`](examples/download-recent-recordings.sh) | list-then-download for the last 7 days; awk filters; \`zoom recordings download\` per meeting |
| [\`batch-meetings-with-rate-limit.py\`](examples/batch-meetings-with-rate-limit.py) | Programmatic Python — opt-in \`RateLimiter()\` through \`ApiClient\` + \`list_users\` pagination |

All three are executable (\`chmod +x\`) and self-contained.

## Verification

\`\`\`
ruff check .          # All checks passed!
ruff format --check . # 32 files already formatted
mypy                  # Success: no issues found in 15 source files
pytest -q             # 429 passed (no source changes — pure docs)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)