### PR TITLE
feat(webhooks): close #17 — local HMAC-verified Zoom webhook receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Schema versioning (PR #56): closes #24 (final piece). `meetings.json` now wraps the meetings dict in a `{schema_version, meetings}` envelope; legacy v0 (pre-#24) files read transparently and migrate on first write.
 > Per-tier rate limiting (PR #57): closes #49 (follow-up to #16's partial close). `zoom_cli/api/rate_limit.py` with token-bucket + daily counter + endpoint→tier classification; opt-in via `ApiClient(creds, rate_limiter=RateLimiter())`.
 > Documentation rewrite (PR #58): closes #23. README rewritten around the two-mode reality (local launcher + REST API), full CLI reference, configuration table, security overview; new `examples/` directory with three runnable scripts.
-> Codegen tooling (this branch): closes #22. New `scripts/codegen.py` wraps `datamodel-code-generator` for Pydantic v2 model generation from Zoom's OpenAPI spec. Optional `[codegen]` extra; output gitignored by default.
+> Codegen tooling (PR #59): closes #22. New `scripts/codegen.py` wraps `datamodel-code-generator` for Pydantic v2 model generation from Zoom's OpenAPI spec. Optional `[codegen]` extra; output gitignored by default.
+> Webhook receiver (this branch): closes #17. New `zoom webhook serve` command + `zoom_cli/api/webhook.py` with constant-time HMAC verification and the endpoint.url_validation handshake.
+
+### Added (issue #17)
+- `zoom_cli/api/webhook.py` — pure crypto helpers: `compute_signature(secret_token, timestamp, body)` returns Zoom's `v0=<64-hex>` format; `verify_signature(...)` does constant-time `hmac.compare_digest`; `compute_url_validation_response(secret_token, plain_token)` builds the handshake response. `_make_handler(secret_token, *, sink)` builds a `BaseHTTPRequestHandler` subclass that recognises `endpoint.url_validation` (unsigned by Zoom — special handshake), verifies signed events, rejects tampering with 401 + stderr line, and dumps verified events to the `sink` callable.
+- `zoom webhook serve --secret-token TOKEN [--bind 127.0.0.1] [--port 8000]` CLI command. Picks up `ZOOM_WEBHOOK_SECRET` env var. Default `--bind 127.0.0.1` (loopback only) — use `ngrok http 8000` or similar to expose during development.
+- README "Webhooks" section in the CLI reference.
+
+### Out of scope (deferred)
+- Persistent storage / replay of received events. Stdout is the sink; pipe through `jq`/`tee`/etc. for ad-hoc storage.
+- Timestamp-skew rejection (replay protection beyond signature). The `MAX_TIMESTAMP_SKEW_SECONDS = 300` constant is pinned for a follow-up that wires it into the verification path.
+- TLS termination — use `ngrok` or another reverse proxy for HTTPS.
 
 ### Added (issue #22)
 - `scripts/codegen.py` — reproducible wrapper around `datamodel-code-generator` with the project's preferred flag set pinned in code (Pydantic v2, double quotes, standard collections, py3.10+ syntax, enum-as-literal). Supports `--dry-run` for safe inspection, errors with an actionable message if `datamodel-codegen` isn't installed, propagates non-zero exit codes.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,16 @@ zoom recordings download <meeting-id> [--out-dir DIR] [--file-type MP4 ...]
 zoom recordings delete <meeting-id> [--file-id ID] [--action trash|delete] [--yes] [--dry-run]
 ```
 
+### Webhooks
+
+```
+zoom webhook serve --secret-token TOKEN [--bind 127.0.0.1] [--port 8000]
+                                              # HMAC-verified receiver
+                                              # picks up ZOOM_WEBHOOK_SECRET env var
+```
+
+Streams verified events to stdout as one-line JSON; rejected deliveries get a 401 + a stderr line. Use with `ngrok http 8000` (or similar) to expose to the public internet during development; the receiver itself binds to loopback by default.
+
 ## Codegen (optional, dev tool)
 
 For developers who want statically-typed Pydantic v2 models instead of `dict[str, Any]`, [`scripts/codegen.py`](scripts/codegen.py) wraps `datamodel-code-generator` against Zoom's published OpenAPI spec.

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,234 @@
+"""Tests for zoom_cli.api.webhook — HMAC-verified webhook receiver."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import socket
+from http.client import HTTPConnection
+from threading import Thread
+
+import pytest
+from zoom_cli.api import webhook
+
+# ---- crypto primitives (pure) ------------------------------------------
+
+
+def test_compute_signature_format() -> None:
+    """Signature is ``v0=<64-char-hex>`` per Zoom's published format."""
+    sig = webhook.compute_signature("secret", "1660157595650", b'{"foo":"bar"}')
+    assert sig.startswith("v0=")
+    digest = sig[len("v0=") :]
+    assert len(digest) == 64
+    assert all(c in "0123456789abcdef" for c in digest)
+
+
+def test_compute_signature_matches_zoom_documented_formula() -> None:
+    """Pin the exact HMAC algorithm against an independent computation."""
+    secret = "topsecret"
+    timestamp = "1660157595650"
+    body = b'{"event":"meeting.started","payload":{}}'
+
+    expected_msg = b"v0:" + timestamp.encode("ascii") + b":" + body
+    expected_digest = hmac.new(secret.encode("utf-8"), expected_msg, hashlib.sha256).hexdigest()
+    expected = f"v0={expected_digest}"
+
+    assert webhook.compute_signature(secret, timestamp, body) == expected
+
+
+def test_compute_signature_accepts_str_or_bytes_body() -> None:
+    sig_bytes = webhook.compute_signature("s", "t", b'{"x":1}')
+    sig_str = webhook.compute_signature("s", "t", '{"x":1}')
+    assert sig_bytes == sig_str
+
+
+def test_compute_signature_changes_with_any_input() -> None:
+    """Tampering with any of {secret, timestamp, body} flips the signature."""
+    base = webhook.compute_signature("s1", "t1", b"body")
+    assert webhook.compute_signature("s2", "t1", b"body") != base
+    assert webhook.compute_signature("s1", "t2", b"body") != base
+    assert webhook.compute_signature("s1", "t1", b"different") != base
+
+
+def test_verify_signature_accepts_valid() -> None:
+    sig = webhook.compute_signature("secret", "1234", b"hello")
+    assert webhook.verify_signature("secret", "1234", b"hello", sig) is True
+
+
+def test_verify_signature_rejects_tampering() -> None:
+    sig = webhook.compute_signature("secret", "1234", b"hello")
+    assert webhook.verify_signature("secret", "1234", b"different", sig) is False
+    assert webhook.verify_signature("secret", "9999", b"hello", sig) is False
+    assert webhook.verify_signature("wrong", "1234", b"hello", sig) is False
+
+
+def test_verify_signature_rejects_truncated_signature() -> None:
+    sig = webhook.compute_signature("s", "t", b"body")
+    assert webhook.verify_signature("s", "t", b"body", sig[:-1]) is False
+
+
+def test_compute_url_validation_response_format() -> None:
+    """The handshake response is ``{plainToken, encryptedToken: hex(hmac)}``."""
+    resp = webhook.compute_url_validation_response("secret", "abc-plain-token")
+
+    assert resp["plainToken"] == "abc-plain-token"
+    expected = hmac.new(b"secret", b"abc-plain-token", hashlib.sha256).hexdigest()
+    assert resp["encryptedToken"] == expected
+
+
+def test_url_validation_response_does_not_include_signature_prefix() -> None:
+    """Unlike X-Zm-Signature, the handshake response is bare hex (no v0=)."""
+    resp = webhook.compute_url_validation_response("s", "p")
+    assert not resp["encryptedToken"].startswith("v0=")
+
+
+# ---- module constants pinned ------------------------------------------
+
+
+def test_signature_version_prefix_pinned() -> None:
+    assert webhook.SIGNATURE_VERSION_PREFIX == "v0="
+
+
+def test_max_timestamp_skew_pinned() -> None:
+    """5 minutes matches Zoom's documented tolerance."""
+    assert webhook.MAX_TIMESTAMP_SKEW_SECONDS == 300
+
+
+# ---- HTTP handler (integration with a real loopback server) ------------
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    try:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+    finally:
+        s.close()
+
+
+@pytest.fixture
+def webhook_server():
+    """Spin up a real ``HTTPServer`` on an ephemeral loopback port and
+    yield (port, captured_events) for the test. Server thread is shut
+    down on teardown."""
+    from http.server import HTTPServer
+
+    captured: list[dict] = []
+    secret = "test-secret"
+    handler_cls = webhook._make_handler(secret, sink=captured.append)
+
+    port = _free_port()
+    server = HTTPServer(("127.0.0.1", port), handler_cls)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield secret, port, captured
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _post(port: int, body: bytes, headers: dict[str, str] | None = None):
+    conn = HTTPConnection("127.0.0.1", port)
+    conn.request(
+        "POST",
+        "/",
+        body=body,
+        headers={"Content-Type": "application/json", **(headers or {})},
+    )
+    response = conn.getresponse()
+    payload = response.read()
+    conn.close()
+    return response.status, payload
+
+
+def test_handler_responds_to_url_validation_handshake(webhook_server) -> None:
+    """First handshake is unsigned; we recognise it by event name."""
+    secret, port, captured = webhook_server
+    body = json.dumps(
+        {"event": "endpoint.url_validation", "payload": {"plainToken": "abc"}}
+    ).encode()
+
+    status, response = _post(port, body)
+
+    assert status == 200
+    parsed = json.loads(response)
+    assert parsed["plainToken"] == "abc"
+    expected = hmac.new(secret.encode(), b"abc", hashlib.sha256).hexdigest()
+    assert parsed["encryptedToken"] == expected
+    # url_validation is NOT a real event — sink should not be invoked.
+    assert captured == []
+
+
+def test_handler_accepts_valid_signed_event(webhook_server) -> None:
+    secret, port, captured = webhook_server
+    body = json.dumps({"event": "meeting.started", "payload": {"foo": "bar"}}).encode()
+    timestamp = "1660157595650"
+    sig = webhook.compute_signature(secret, timestamp, body)
+
+    status, _ = _post(
+        port,
+        body,
+        headers={"X-Zm-Request-Timestamp": timestamp, "X-Zm-Signature": sig},
+    )
+
+    assert status == 200
+    assert len(captured) == 1
+    assert captured[0]["event"] == "meeting.started"
+
+
+def test_handler_rejects_invalid_signature(webhook_server) -> None:
+    _secret, port, captured = webhook_server
+    body = b'{"event":"meeting.started","payload":{}}'
+    status, response = _post(
+        port,
+        body,
+        headers={
+            "X-Zm-Request-Timestamp": "1234",
+            "X-Zm-Signature": "v0=" + "0" * 64,  # wrong hex
+        },
+    )
+
+    assert status == 401
+    assert b"invalid signature" in response
+    assert captured == []  # sink never invoked on rejected events
+
+
+def test_handler_rejects_missing_signature_headers(webhook_server) -> None:
+    _secret, port, captured = webhook_server
+    status, response = _post(port, b'{"event":"meeting.started","payload":{}}')
+
+    assert status == 401
+    assert b"missing signature headers" in response
+    assert captured == []
+
+
+def test_handler_rejects_invalid_json_body(webhook_server) -> None:
+    _secret, port, captured = webhook_server
+    status, response = _post(port, b"not json at all")
+
+    assert status == 400
+    assert b"invalid JSON body" in response
+    assert captured == []
+
+
+def test_handler_rejects_tampered_body_after_signature(webhook_server) -> None:
+    """Sign one body, send a different one — must be rejected. Pins the
+    integrity guarantee against a man-in-the-middle who changes the body
+    in flight."""
+    secret, port, captured = webhook_server
+    original = b'{"event":"meeting.started","payload":{"foo":"bar"}}'
+    timestamp = "1234"
+    sig = webhook.compute_signature(secret, timestamp, original)
+
+    # Send a different body with the original signature.
+    tampered = b'{"event":"meeting.started","payload":{"foo":"EVIL"}}'
+    status, _ = _post(
+        port,
+        tampered,
+        headers={"X-Zm-Request-Timestamp": timestamp, "X-Zm-Signature": sig},
+    )
+
+    assert status == 401
+    assert captured == []

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -8,7 +8,7 @@ import questionary
 from click_default_group import DefaultGroup
 
 from zoom_cli import auth
-from zoom_cli.api import meetings, oauth, recordings, user_oauth, users
+from zoom_cli.api import meetings, oauth, recordings, user_oauth, users, webhook
 from zoom_cli.api.client import ApiClient, ZoomApiError
 from zoom_cli.commands import (
     _edit,
@@ -1235,6 +1235,54 @@ def recordings_delete(meeting_id, file_id, action, yes, dry_run):
         _exit_on_api_error(exc)
     verb = "Deleted" if action == "delete" else "Trashed"
     click.echo(f"{verb} {target}.")
+
+
+# ---- Zoom Webhooks ------------------------------------------------------
+
+
+@main.group(
+    "webhook",
+    help="Local HMAC-verified Zoom webhook receiver (closes #17).",
+)
+def webhook_cmd():
+    """Group for ``zoom webhook ...``."""
+
+
+@webhook_cmd.command(
+    "serve",
+    help=(
+        "Run a local HTTP server that receives + verifies Zoom webhooks. "
+        "Use with ngrok or similar to expose to the internet during dev."
+    ),
+)
+@click.option(
+    "--secret-token",
+    envvar="ZOOM_WEBHOOK_SECRET",
+    required=True,
+    help=(
+        "The webhook secret token from the Zoom Marketplace app's "
+        "Feature -> Event Subscriptions tab. Picks up "
+        "ZOOM_WEBHOOK_SECRET env var."
+    ),
+)
+@click.option(
+    "--bind",
+    default="127.0.0.1",
+    show_default=True,
+    help="Address to bind. Default 127.0.0.1 (loopback only).",
+)
+@click.option(
+    "--port",
+    type=click.IntRange(1, 65535),
+    default=8000,
+    show_default=True,
+    help="Port to listen on.",
+)
+def webhook_serve(secret_token, bind, port):
+    """Streams verified events to stdout as one-line JSON; rejected
+    deliveries get a 401 + a stderr line. Ctrl-C exits cleanly. Closes
+    #17."""
+    webhook.run_webhook_server(secret_token, bind=bind, port=port)
 
 
 if __name__ == "__main__":

--- a/zoom_cli/api/webhook.py
+++ b/zoom_cli/api/webhook.py
@@ -1,0 +1,196 @@
+"""Local HMAC-verified webhook receiver for Zoom (closes #17).
+
+Reference: https://developers.zoom.us/docs/api/webhooks/
+
+How Zoom signs webhook deliveries (since 2023):
+
+  X-Zm-Request-Timestamp: 1660157595650
+  X-Zm-Signature: v0=<hex(hmac-sha256(SECRET_TOKEN, "v0:" + ts + ":" + body))>
+
+The signature scheme is "v0:" — currently the only supported version.
+Receivers must verify in constant time (``hmac.compare_digest``).
+
+Endpoint validation: when you set up a new webhook in the Zoom Marketplace,
+Zoom sends one POST with body
+``{"event": "endpoint.url_validation", "payload": {"plainToken": "..."}}``
+and expects ``{"plainToken": "...", "encryptedToken": "..."}`` back, where
+``encryptedToken = hex(hmac-sha256(SECRET_TOKEN, plainToken))``. The CLI
+``zoom webhook serve`` handles that handshake automatically.
+
+This module is split:
+
+  - **Crypto helpers** (pure, side-effect-free) — easily unit-tested:
+      compute_signature(secret_token, timestamp, body) -> str
+      verify_signature(secret_token, timestamp, body, signature) -> bool
+      compute_url_validation_response(secret_token, plain_token) -> dict
+
+  - **HTTP handler** (BaseHTTPRequestHandler subclass) — the receiver
+    loop. Spawned by ``zoom webhook serve``.
+
+The ``run_webhook_server`` entrypoint binds, prints the listen address,
+and serves until interrupted (Ctrl-C). Each verified event is dumped to
+stdout as JSON (one event per line for easy ``jq`` piping); failed
+verifications get a 401 + a stderr line.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+#: Maximum age (seconds) for the X-Zm-Request-Timestamp before we reject
+#: the request as a possible replay. 5 minutes matches Zoom's documented
+#: tolerance and is short enough to limit the window of a stolen body.
+MAX_TIMESTAMP_SKEW_SECONDS = 300
+
+#: Currently the only signature scheme Zoom emits. Pinned so a future
+#: scheme upgrade is a deliberate, reviewed change.
+SIGNATURE_VERSION_PREFIX = "v0="
+
+
+def compute_signature(secret_token: str, timestamp: str, body: bytes | str) -> str:
+    """Return the ``X-Zm-Signature`` value for the given request.
+
+    The body is mixed into the HMAC as bytes — never as the parsed
+    JSON. Whitespace, key order, and trailing newlines all matter to
+    the signature.
+    """
+    body_bytes = body.encode("utf-8") if isinstance(body, str) else body
+    msg = b"v0:" + timestamp.encode("ascii") + b":" + body_bytes
+    digest = hmac.new(secret_token.encode("utf-8"), msg, hashlib.sha256).hexdigest()
+    return f"{SIGNATURE_VERSION_PREFIX}{digest}"
+
+
+def verify_signature(
+    secret_token: str,
+    timestamp: str,
+    body: bytes | str,
+    signature: str,
+) -> bool:
+    """Constant-time HMAC verification of an incoming Zoom webhook.
+
+    Returns ``True`` only if the signature matches exactly. Any tampering
+    of the body, timestamp, or signature flips the result. Uses
+    ``hmac.compare_digest`` to avoid timing leaks.
+    """
+    expected = compute_signature(secret_token, timestamp, body)
+    return hmac.compare_digest(expected, signature)
+
+
+def compute_url_validation_response(secret_token: str, plain_token: str) -> dict[str, str]:
+    """Build the response body for Zoom's endpoint.url_validation handshake.
+
+    Zoom sends ``{"plainToken": "..."}`` and expects back
+    ``{"plainToken": "<echo>", "encryptedToken": "<hex(hmac)>"}``.
+    """
+    digest = hmac.new(
+        secret_token.encode("utf-8"),
+        plain_token.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return {"plainToken": plain_token, "encryptedToken": digest}
+
+
+def _make_handler(secret_token: str, *, sink=None):
+    """Build a :class:`BaseHTTPRequestHandler` subclass closed over
+    ``secret_token``. ``sink`` is a callable taking the parsed event dict
+    (default: dump as one-line JSON to stdout); useful for tests.
+    """
+    if sink is None:
+
+        def sink(event: dict[str, Any]) -> None:
+            sys.stdout.write(json.dumps(event) + "\n")
+            sys.stdout.flush()
+
+    class WebhookHandler(BaseHTTPRequestHandler):
+        # POST is the only verb Zoom uses.
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", "0") or "0")
+            body = self.rfile.read(length) if length else b""
+            timestamp = self.headers.get("X-Zm-Request-Timestamp", "")
+            signature = self.headers.get("X-Zm-Signature", "")
+
+            # Endpoint URL validation: Zoom doesn't sign this handshake;
+            # we recognise it by event name and respond synchronously.
+            try:
+                payload = json.loads(body.decode("utf-8")) if body else {}
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                self._respond(400, b'{"error":"invalid JSON body"}')
+                return
+
+            if payload.get("event") == "endpoint.url_validation":
+                plain = payload.get("payload", {}).get("plainToken", "")
+                response = compute_url_validation_response(secret_token, plain)
+                self._respond(
+                    200,
+                    json.dumps(response).encode("utf-8"),
+                    content_type="application/json",
+                )
+                return
+
+            # Real event — must be signed.
+            if not signature or not timestamp:
+                self._respond(401, b'{"error":"missing signature headers"}')
+                sys.stderr.write("webhook: rejected — missing signature headers\n")
+                return
+
+            if not verify_signature(secret_token, timestamp, body, signature):
+                self._respond(401, b'{"error":"invalid signature"}')
+                sys.stderr.write("webhook: rejected — invalid signature\n")
+                return
+
+            # Verified — surface the event.
+            sink(payload)
+            self._respond(200, b'{"status":"ok"}')
+
+        def _respond(
+            self,
+            status: int,
+            body: bytes,
+            *,
+            content_type: str = "application/json",
+        ) -> None:
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, fmt, *args):
+            # Silence the default request log; structured output goes to
+            # stdout via ``sink``.
+            pass
+
+    return WebhookHandler
+
+
+def run_webhook_server(
+    secret_token: str,
+    *,
+    bind: str = "127.0.0.1",
+    port: int = 8000,
+    sink=None,
+    server_class=HTTPServer,
+) -> None:
+    """Bind and serve forever. Ctrl-C exits cleanly.
+
+    ``server_class`` is injected for tests (e.g. a one-shot server). Tests
+    typically poke the handler directly via :func:`_make_handler` instead.
+    """
+    handler_cls = _make_handler(secret_token, sink=sink)
+    server = server_class((bind, port), handler_cls)
+    bound_host, bound_port = server.server_address[:2]
+    sys.stderr.write(f"Listening for Zoom webhooks on http://{bound_host}:{bound_port}/\n")
+    sys.stderr.write("Configure your Zoom app's Event Subscription URL to point here.\n")
+    sys.stderr.write("Press Ctrl-C to stop.\n")
+    sys.stderr.flush()
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        sys.stderr.write("\nStopping.\n")
+    finally:
+        server.server_close()


### PR DESCRIPTION
## Summary

Closes #17. Adds a local webhook receiver for Zoom event subscriptions, with constant-time HMAC verification and the \`endpoint.url_validation\` handshake.

## What's new

### \`zoom_cli/api/webhook.py\` (new)

Pure crypto helpers — easily unit-tested:

\`\`\`python
compute_signature(secret_token, timestamp, body) -> "v0=<64-hex>"
verify_signature(secret_token, timestamp, body, sig) -> bool   # constant-time
compute_url_validation_response(secret_token, plain_token) -> dict
\`\`\`

HTTP handler built by \`_make_handler(secret_token, *, sink)\`. Three cases:

1. body is \`endpoint.url_validation\` → respond with hex(hmac(secret, plain_token)). Zoom doesn't sign the handshake; recognised by event name.
2. signed event with valid signature → invoke \`sink(payload)\`, return 200.
3. anything else → 401 with reason + stderr line.

Server entrypoint: \`run_webhook_server(secret_token, *, bind, port, sink, server_class)\`.

### CLI

\`\`\`bash
zoom webhook serve --secret-token TOKEN [--bind 127.0.0.1] [--port 8000]
\`\`\`

Picks up \`ZOOM_WEBHOOK_SECRET\` env var. Default bind is loopback; use \`ngrok http 8000\` (or similar) to expose during development.

Verified events stream to stdout as one-line JSON (jq-friendly):

\`\`\`
$ zoom webhook serve --secret-token "$ZOOM_WEBHOOK_SECRET" 2>/dev/null | jq .
{"event":"meeting.started","payload":{...}}
{"event":"meeting.ended","payload":{...}}
...
\`\`\`

## Tests (+17 new)

| Group | Count | Covers |
|---|---|---|
| Crypto (pure) | 8 | signature format \`v0=<64-hex>\`; exact HMAC matches Zoom's documented formula vs independent computation; str/bytes body equivalence; tampering flips sig (3 inputs); verify accepts valid + rejects 4 tampering kinds + 1 truncation; url_validation response format + no \`v0=\` prefix |
| Constants pinned | 2 | \`SIGNATURE_VERSION_PREFIX\`, \`MAX_TIMESTAMP_SKEW_SECONDS\` |
| HTTP integration | 7 | spin up a real \`HTTPServer\` in a daemon thread on an ephemeral loopback port, send via \`http.client.HTTPConnection\`, verify status + sink + body. Covers: handshake, valid signed event, invalid signature, missing headers, invalid JSON body, tampered-body-with-original-signature |

## Verification

\`\`\`
ruff check .          # All checks passed!
ruff format --check . # 36 files already formatted
mypy                  # Success: no issues found in 16 source files
pytest -q             # 453 passed (was 436; +17)
\`\`\`

## Out of scope (deferred)

- **Persistent storage / replay** of received events. Stdout is the sink; pipe through \`jq\`/\`tee\` for ad-hoc storage.
- **Timestamp-skew rejection** (replay protection beyond signature integrity). \`MAX_TIMESTAMP_SKEW_SECONDS = 300\` is pinned for a follow-up that wires it into the verification path.
- **TLS termination** — use \`ngrok\` or another reverse proxy for HTTPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)