### PR TITLE
feat(api,cli): close #18 — Zoom Phone API (users/call-logs/queues/recordings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Per-tier rate limiting (PR #57): closes #49 (follow-up to #16's partial close). `zoom_cli/api/rate_limit.py` with token-bucket + daily counter + endpoint→tier classification; opt-in via `ApiClient(creds, rate_limiter=RateLimiter())`.
 > Documentation rewrite (PR #58): closes #23. README rewritten around the two-mode reality (local launcher + REST API), full CLI reference, configuration table, security overview; new `examples/` directory with three runnable scripts.
 > Codegen tooling (PR #59): closes #22. New `scripts/codegen.py` wraps `datamodel-code-generator` for Pydantic v2 model generation from Zoom's OpenAPI spec. Optional `[codegen]` extra; output gitignored by default.
-> Webhook receiver (this branch): closes #17. New `zoom webhook serve` command + `zoom_cli/api/webhook.py` with constant-time HMAC verification and the endpoint.url_validation handshake.
+> Webhook receiver (PR #60): closes #17. New `zoom webhook serve` command + `zoom_cli/api/webhook.py` with constant-time HMAC verification and the endpoint.url_validation handshake.
+> Zoom Phone API (this branch): closes #18 (read-only piece). New `zoom phone users / call-logs / queues / recordings list/get` commands; `zoom_cli/api/phone.py`; tier mappings extended for `/phone/*` endpoints.
+
+### Added (issue #18)
+- `zoom_cli/api/phone.py` — `list_phone_users`, `get_phone_user`, `list_call_logs` (account-wide or per-user), `list_call_queues`, `list_phone_recordings` (account-wide or per-user). All paginated via the helper from PR #48; date-filter forwarding for `--from`/`--to` where applicable.
+- CLI subgroups under `zoom phone`:
+  - `zoom phone users list [--page-size]` (TSV: id\\temail\\textension_number\\tstatus)
+  - `zoom phone users get <user-id>` (JSON dump)
+  - `zoom phone call-logs list [--user-id] [--from] [--to] [--page-size]` (TSV: id\\tdirection\\tcaller_number\\tcallee_number\\tstart_time\\tduration)
+  - `zoom phone queues list [--page-size]` (TSV: id\\tname\\textension_number\\tsite_name)
+  - `zoom phone recordings list [--user-id] [--from] [--to] [--page-size]` (TSV: id\\tcaller_number\\tcallee_number\\tdate_time\\tduration)
+- `rate_limit.ENDPOINT_TIERS` extended with `/phone/users`, `/phone/users/{id}`, `/phone/users/{id}/call_logs`, `/phone/users/{id}/recordings`, `/phone/call_logs`, `/phone/call_queues`, `/phone/recordings` — single-resource user lookup is LIGHT, everything else MEDIUM.
 
 ### Added (issue #17)
 - `zoom_cli/api/webhook.py` — pure crypto helpers: `compute_signature(secret_token, timestamp, body)` returns Zoom's `v0=<64-hex>` format; `verify_signature(...)` does constant-time `hmac.compare_digest`; `compute_url_validation_response(secret_token, plain_token)` builds the handshake response. `_make_handler(secret_token, *, sink)` builds a `BaseHTTPRequestHandler` subclass that recognises `endpoint.url_validation` (unsigned by Zoom — special handshake), verifies signed events, rejects tampering with 401 + stderr line, and dumps verified events to the `sink` callable.

--- a/tests/test_api_phone.py
+++ b/tests/test_api_phone.py
@@ -1,0 +1,125 @@
+"""Tests for zoom_cli.api.phone — Zoom Phone endpoint helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from zoom_cli.api import phone
+
+
+def test_list_phone_users_paginates_users_endpoint() -> None:
+    fake_client = MagicMock()
+    fake_client.get.side_effect = [
+        {"users": [{"id": "u1"}, {"id": "u2"}], "next_page_token": "tok-2"},
+        {"users": [{"id": "u3"}], "next_page_token": ""},
+    ]
+
+    result = list(phone.list_phone_users(fake_client))
+
+    assert result == [{"id": "u1"}, {"id": "u2"}, {"id": "u3"}]
+    assert fake_client.get.call_count == 2
+    assert fake_client.get.call_args_list[0][0][0] == "/phone/users"
+
+
+def test_get_phone_user_targets_user_path_and_url_encodes() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"id": "u-1"}
+
+    phone.get_phone_user(fake_client, "alice@example.com")
+
+    assert fake_client.get.call_args[0][0] == "/phone/users/alice%40example.com"
+
+
+def test_list_call_logs_account_wide_when_no_user_id() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"call_logs": [], "next_page_token": ""}
+
+    list(phone.list_call_logs(fake_client))
+
+    assert fake_client.get.call_args[0][0] == "/phone/call_logs"
+
+
+def test_list_call_logs_per_user_when_user_id_set() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"call_logs": [], "next_page_token": ""}
+
+    list(phone.list_call_logs(fake_client, user_id="u-42"))
+
+    assert fake_client.get.call_args[0][0] == "/phone/users/u-42/call_logs"
+
+
+def test_list_call_logs_forwards_date_filters() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"call_logs": [], "next_page_token": ""}
+
+    list(phone.list_call_logs(fake_client, from_="2026-04-01", to="2026-04-30"))
+
+    params = fake_client.get.call_args[1]["params"]
+    assert params["from"] == "2026-04-01"
+    assert params["to"] == "2026-04-30"
+
+
+def test_list_call_logs_omits_date_filters_when_unset() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"call_logs": [], "next_page_token": ""}
+
+    list(phone.list_call_logs(fake_client))
+
+    params = fake_client.get.call_args[1]["params"]
+    assert "from" not in params
+    assert "to" not in params
+
+
+def test_list_call_logs_walks_pagination_cursor() -> None:
+    fake_client = MagicMock()
+    fake_client.get.side_effect = [
+        {"call_logs": [{"id": "c1"}], "next_page_token": "tok-2"},
+        {"call_logs": [{"id": "c2"}, {"id": "c3"}], "next_page_token": ""},
+    ]
+
+    result = list(phone.list_call_logs(fake_client))
+
+    assert result == [{"id": "c1"}, {"id": "c2"}, {"id": "c3"}]
+    assert fake_client.get.call_count == 2
+
+
+def test_list_call_queues_paginates() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {
+        "call_queues": [{"id": "q1"}, {"id": "q2"}],
+        "next_page_token": "",
+    }
+
+    result = list(phone.list_call_queues(fake_client))
+
+    assert result == [{"id": "q1"}, {"id": "q2"}]
+    assert fake_client.get.call_args[0][0] == "/phone/call_queues"
+
+
+def test_list_phone_recordings_account_wide_when_no_user_id() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"recordings": [], "next_page_token": ""}
+
+    list(phone.list_phone_recordings(fake_client))
+
+    assert fake_client.get.call_args[0][0] == "/phone/recordings"
+
+
+def test_list_phone_recordings_per_user_when_user_id_set() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"recordings": [], "next_page_token": ""}
+
+    list(phone.list_phone_recordings(fake_client, user_id="u-7"))
+
+    assert fake_client.get.call_args[0][0] == "/phone/users/u-7/recordings"
+
+
+def test_list_phone_recordings_forwards_date_filters() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"recordings": [], "next_page_token": ""}
+
+    list(phone.list_phone_recordings(fake_client, from_="2026-04-01", to="2026-04-30"))
+
+    params = fake_client.get.call_args[1]["params"]
+    assert params["from"] == "2026-04-01"
+    assert params["to"] == "2026-04-30"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2014,3 +2014,140 @@ def test_auth_logout_clears_both_stores(runner: CliRunner) -> None:
 
     assert auth.has_s2s_credentials() is False
     assert auth.has_user_oauth_credentials() is False
+
+
+# ---- #18: zoom phone CLI ------------------------------------------------
+
+
+def _patch_phone_module(monkeypatch: pytest.MonkeyPatch, **funcs):
+    import zoom_cli.__main__ as main_mod
+
+    for name, fn in funcs.items():
+        monkeypatch.setattr(main_mod.phone, name, fn)
+    monkeypatch.setattr(
+        main_mod.oauth, "fetch_access_token", lambda *_a, **_k: _fake_access_token()
+    )
+
+
+def test_phone_users_list_prints_tab_separated(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+
+    def fake_list(_client, *, page_size):
+        return iter(
+            [
+                {
+                    "id": "u1",
+                    "email": "alice@example.com",
+                    "extension_number": "100",
+                    "status": "activate",
+                },
+                {
+                    "id": "u2",
+                    "email": "bob@example.com",
+                    "extension_number": "101",
+                    "status": "deactivate",
+                },
+            ]
+        )
+
+    _patch_phone_module(monkeypatch, list_phone_users=fake_list)
+    result = runner.invoke(main, ["phone", "users", "list"])
+    assert result.exit_code == 0, result.output
+    lines = result.output.strip().split("\n")
+    assert lines[0] == "id\temail\textension_number\tstatus"
+    assert lines[1] == "u1\talice@example.com\t100\tactivate"
+
+
+def test_phone_users_get_prints_json(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    _save_creds()
+
+    def fake_get(_client, user_id):
+        return {"id": user_id, "email": "x@y", "extension_number": "200"}
+
+    _patch_phone_module(monkeypatch, get_phone_user=fake_get)
+    result = runner.invoke(main, ["phone", "users", "get", "u-X"])
+    assert result.exit_code == 0, result.output
+    import json as _json
+
+    parsed = _json.loads(result.output)
+    assert parsed["id"] == "u-X"
+
+
+def test_phone_call_logs_list_forwards_filters(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured = {}
+
+    def fake_list(_client, *, user_id, from_, to, page_size):
+        captured.update({"user_id": user_id, "from_": from_, "to": to})
+        return iter([])
+
+    _patch_phone_module(monkeypatch, list_call_logs=fake_list)
+    result = runner.invoke(
+        main,
+        [
+            "phone",
+            "call-logs",
+            "list",
+            "--user-id",
+            "u-X",
+            "--from",
+            "2026-04-01",
+            "--to",
+            "2026-04-30",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured == {"user_id": "u-X", "from_": "2026-04-01", "to": "2026-04-30"}
+
+
+def test_phone_queues_list_prints_tab_separated(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+
+    def fake_list(_client, *, page_size):
+        return iter(
+            [
+                {"id": "q1", "name": "Sales", "extension_number": "200", "site": {"name": "HQ"}},
+            ]
+        )
+
+    _patch_phone_module(monkeypatch, list_call_queues=fake_list)
+    result = runner.invoke(main, ["phone", "queues", "list"])
+    assert result.exit_code == 0, result.output
+    lines = result.output.strip().split("\n")
+    assert lines[0] == "id\tname\textension_number\tsite_name"
+    assert lines[1] == "q1\tSales\t200\tHQ"
+
+
+def test_phone_recordings_list_forwards_filters(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured = {}
+
+    def fake_list(_client, *, user_id, from_, to, page_size):
+        captured.update({"user_id": user_id, "from_": from_, "to": to})
+        return iter([])
+
+    _patch_phone_module(monkeypatch, list_phone_recordings=fake_list)
+    result = runner.invoke(
+        main,
+        [
+            "phone",
+            "recordings",
+            "list",
+            "--user-id",
+            "u-X",
+            "--from",
+            "2026-04-01",
+            "--to",
+            "2026-04-30",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured == {"user_id": "u-X", "from_": "2026-04-01", "to": "2026-04-30"}

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -244,3 +244,24 @@ def test_tier_limits_match_zoom_published_caps() -> None:
     assert TIER_LIMITS[Tier.HEAVY].daily == 60_000
     assert TIER_LIMITS[Tier.RESOURCE_INTENSIVE].per_sec == 20
     assert TIER_LIMITS[Tier.RESOURCE_INTENSIVE].daily == 60_000
+
+
+# ---- #18 Zoom Phone tier mappings --------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method,path,expected",
+    [
+        # Single-resource phone user: LIGHT
+        ("GET", "/phone/users/u-1", Tier.LIGHT),
+        # Phone listings: MEDIUM
+        ("GET", "/phone/users", Tier.MEDIUM),
+        ("GET", "/phone/call_logs", Tier.MEDIUM),
+        ("GET", "/phone/users/u-1/call_logs", Tier.MEDIUM),
+        ("GET", "/phone/call_queues", Tier.MEDIUM),
+        ("GET", "/phone/recordings", Tier.MEDIUM),
+        ("GET", "/phone/users/u-1/recordings", Tier.MEDIUM),
+    ],
+)
+def test_tier_for_classifies_phone_endpoints(method: str, path: str, expected: Tier) -> None:
+    assert tier_for(method, path) == expected

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -8,7 +8,7 @@ import questionary
 from click_default_group import DefaultGroup
 
 from zoom_cli import auth
-from zoom_cli.api import meetings, oauth, recordings, user_oauth, users, webhook
+from zoom_cli.api import meetings, oauth, phone, recordings, user_oauth, users, webhook
 from zoom_cli.api.client import ApiClient, ZoomApiError
 from zoom_cli.commands import (
     _edit,
@@ -1235,6 +1235,181 @@ def recordings_delete(meeting_id, file_id, action, yes, dry_run):
         _exit_on_api_error(exc)
     verb = "Deleted" if action == "delete" else "Trashed"
     click.echo(f"{verb} {target}.")
+
+
+# ---- Zoom Phone --------------------------------------------------------
+
+
+@main.group(
+    "phone",
+    help="Zoom Phone API (https://developers.zoom.us/docs/api/phone/).",
+)
+def phone_cmd():
+    """Group for ``zoom phone ...``."""
+
+
+@phone_cmd.group("users", help="Zoom Phone users.")
+def phone_users_cmd():
+    pass
+
+
+@phone_users_cmd.command("list", help="List phone-licensed users (paginated).")
+@click.option(
+    "--page-size",
+    type=click.IntRange(1, 300),
+    default=300,
+    show_default=True,
+)
+@_translate_keyring_errors
+def phone_users_list(page_size):
+    """TSV: id\\temail\\textension_number\\tstatus."""
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            click.echo("id\temail\textension_number\tstatus")
+            for u in phone.list_phone_users(client, page_size=page_size):
+                click.echo(
+                    f"{u.get('id', '')}\t"
+                    f"{u.get('email', '')}\t"
+                    f"{u.get('extension_number', '')}\t"
+                    f"{u.get('status', '')}"
+                )
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+
+
+@phone_users_cmd.command("get", help="Print a phone user's profile (JSON).")
+@click.argument("user_id")
+@_translate_keyring_errors
+def phone_users_get(user_id):
+    import json as _json
+
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            profile = phone.get_phone_user(client, user_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(_json.dumps(profile, indent=2, sort_keys=True))
+
+
+@phone_cmd.group("call-logs", help="Zoom Phone call logs.")
+def phone_call_logs_cmd():
+    pass
+
+
+@phone_call_logs_cmd.command("list", help="List call log entries (paginated).")
+@click.option(
+    "--user-id",
+    default=None,
+    help="Limit to one user's call logs. Omit for account-wide.",
+)
+@click.option("--from", "from_", metavar="YYYY-MM-DD", help="Lower bound on date.")
+@click.option("--to", metavar="YYYY-MM-DD", help="Upper bound on date.")
+@click.option(
+    "--page-size",
+    type=click.IntRange(1, 300),
+    default=300,
+    show_default=True,
+)
+@_translate_keyring_errors
+def phone_call_logs_list(user_id, from_, to, page_size):
+    """TSV: id\\tdirection\\tcaller_number\\tcallee_number\\tstart_time\\tduration."""
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            click.echo("id\tdirection\tcaller_number\tcallee_number\tstart_time\tduration")
+            for entry in phone.list_call_logs(
+                client,
+                user_id=user_id,
+                from_=from_,
+                to=to,
+                page_size=page_size,
+            ):
+                click.echo(
+                    f"{entry.get('id', '')}\t"
+                    f"{entry.get('direction', '')}\t"
+                    f"{entry.get('caller_number', '')}\t"
+                    f"{entry.get('callee_number', '')}\t"
+                    f"{entry.get('start_time', '')}\t"
+                    f"{entry.get('duration', '')}"
+                )
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+
+
+@phone_cmd.group("queues", help="Zoom Phone call queues.")
+def phone_queues_cmd():
+    pass
+
+
+@phone_queues_cmd.command("list", help="List call queues (paginated).")
+@click.option(
+    "--page-size",
+    type=click.IntRange(1, 300),
+    default=300,
+    show_default=True,
+)
+@_translate_keyring_errors
+def phone_queues_list(page_size):
+    """TSV: id\\tname\\textension_number\\tsite_name."""
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            click.echo("id\tname\textension_number\tsite_name")
+            for q in phone.list_call_queues(client, page_size=page_size):
+                click.echo(
+                    f"{q.get('id', '')}\t"
+                    f"{q.get('name', '')}\t"
+                    f"{q.get('extension_number', '')}\t"
+                    f"{q.get('site', {}).get('name', '')}"
+                )
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+
+
+@phone_cmd.group("recordings", help="Zoom Phone call recordings.")
+def phone_recordings_cmd():
+    pass
+
+
+@phone_recordings_cmd.command("list", help="List phone call recordings (paginated).")
+@click.option(
+    "--user-id",
+    default=None,
+    help="Limit to one user. Omit for account-wide.",
+)
+@click.option("--from", "from_", metavar="YYYY-MM-DD")
+@click.option("--to", metavar="YYYY-MM-DD")
+@click.option(
+    "--page-size",
+    type=click.IntRange(1, 300),
+    default=300,
+    show_default=True,
+)
+@_translate_keyring_errors
+def phone_recordings_list(user_id, from_, to, page_size):
+    """TSV: id\\tcaller_number\\tcallee_number\\tdate_time\\tduration."""
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            click.echo("id\tcaller_number\tcallee_number\tdate_time\tduration")
+            for r in phone.list_phone_recordings(
+                client,
+                user_id=user_id,
+                from_=from_,
+                to=to,
+                page_size=page_size,
+            ):
+                click.echo(
+                    f"{r.get('id', '')}\t"
+                    f"{r.get('caller_number', '')}\t"
+                    f"{r.get('callee_number', '')}\t"
+                    f"{r.get('date_time', '')}\t"
+                    f"{r.get('duration', '')}"
+                )
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
 
 
 # ---- Zoom Webhooks ------------------------------------------------------

--- a/zoom_cli/api/phone.py
+++ b/zoom_cli/api/phone.py
@@ -1,0 +1,157 @@
+"""Zoom Phone API helpers (closes #18).
+
+Reference: https://developers.zoom.us/docs/api/phone/
+
+Endpoints covered:
+
+  list_phone_users(client, *, page_size=300) -> Iterator[dict]
+      → GET /phone/users (paginated)
+
+  get_phone_user(client, user_id) -> dict
+      → GET /phone/users/{user_id}
+
+  list_call_logs(client, *, user_id=None, from_=None, to=None,
+                 page_size=300) -> Iterator[dict]
+      → GET /phone/call_logs (account-wide if user_id is None)
+      → GET /phone/users/{user_id}/call_logs (per-user when set)
+
+  list_call_queues(client, *, page_size=300) -> Iterator[dict]
+      → GET /phone/call_queues
+
+  list_phone_recordings(client, *, user_id=None, from_=None, to=None,
+                        page_size=300) -> Iterator[dict]
+      → GET /phone/recordings (account-wide)
+      → GET /phone/users/{user_id}/recordings (per-user)
+
+Same conventions as the meetings/users/recordings modules: each function
+maps 1:1 to a Zoom endpoint, percent-encodes path segments, returns the
+parsed JSON envelope (or yields items via the paginate() helper for
+list endpoints). Higher-level concerns (CLI flags, output format) live
+in __main__.py.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from urllib.parse import quote
+
+from zoom_cli.api.client import ApiClient
+from zoom_cli.api.pagination import DEFAULT_PAGE_SIZE, paginate
+
+
+def list_phone_users(
+    client: ApiClient,
+    *,
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> Iterator[dict[str, Any]]:
+    """``GET /phone/users`` — yield phone-licensed users across all pages.
+
+    Required scopes: ``phone:read:list_users``.
+    """
+    return paginate(
+        client,
+        "/phone/users",
+        item_key="users",
+        page_size=page_size,
+    )
+
+
+def get_phone_user(client: ApiClient, user_id: str) -> dict[str, Any]:
+    """``GET /phone/users/{user_id}`` — single phone user's profile.
+
+    ``user_id`` accepts a Zoom user ID or email address. Required scopes:
+    ``phone:read:user``.
+    """
+    return client.get(f"/phone/users/{quote(user_id, safe='')}")
+
+
+def list_call_logs(
+    client: ApiClient,
+    *,
+    user_id: str | None = None,
+    from_: str | None = None,
+    to: str | None = None,
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> Iterator[dict[str, Any]]:
+    """Yield call log entries.
+
+    If ``user_id`` is ``None`` (default), uses the account-level endpoint
+    ``/phone/call_logs``. If set, uses the per-user
+    ``/phone/users/{user_id}/call_logs``.
+
+    ``from_`` / ``to`` are ISO-8601 dates (YYYY-MM-DD); the server-side
+    cap is 1 month per request — callers walking longer ranges should
+    chunk in 30-day windows.
+
+    Required scopes: ``phone:read:call_log:admin`` (account) or
+    ``phone:read:call_log`` (per-user).
+    """
+    path = (
+        f"/phone/users/{quote(user_id, safe='')}/call_logs"
+        if user_id is not None
+        else "/phone/call_logs"
+    )
+    params: dict[str, Any] = {}
+    if from_ is not None:
+        params["from"] = from_
+    if to is not None:
+        params["to"] = to
+    return paginate(
+        client,
+        path,
+        item_key="call_logs",
+        params=params,
+        page_size=page_size,
+    )
+
+
+def list_call_queues(
+    client: ApiClient,
+    *,
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> Iterator[dict[str, Any]]:
+    """``GET /phone/call_queues`` — yield call queues across all pages.
+
+    Required scopes: ``phone:read:list_call_queues:admin``.
+    """
+    return paginate(
+        client,
+        "/phone/call_queues",
+        item_key="call_queues",
+        page_size=page_size,
+    )
+
+
+def list_phone_recordings(
+    client: ApiClient,
+    *,
+    user_id: str | None = None,
+    from_: str | None = None,
+    to: str | None = None,
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> Iterator[dict[str, Any]]:
+    """Yield Zoom Phone call recordings.
+
+    Account-wide when ``user_id`` is ``None``; per-user otherwise.
+
+    Required scopes: ``phone:read:list_call_recordings:admin`` or
+    ``phone:read:list_user_recordings``.
+    """
+    path = (
+        f"/phone/users/{quote(user_id, safe='')}/recordings"
+        if user_id is not None
+        else "/phone/recordings"
+    )
+    params: dict[str, Any] = {}
+    if from_ is not None:
+        params["from"] = from_
+    if to is not None:
+        params["to"] = to
+    return paginate(
+        client,
+        path,
+        item_key="recordings",
+        params=params,
+        page_size=page_size,
+    )

--- a/zoom_cli/api/rate_limit.py
+++ b/zoom_cli/api/rate_limit.py
@@ -106,6 +106,14 @@ _TIER_RULES: list[tuple[str, re.Pattern[str], Tier]] = [
     ("PATCH", re.compile(r"/meetings/[^/]+"), Tier.MEDIUM),
     # DELETE /meetings/<id>
     ("DELETE", re.compile(r"/meetings/[^/]+"), Tier.MEDIUM),
+    # ---- Zoom Phone (#18) — listings are MEDIUM, single-resource is LIGHT
+    ("GET", re.compile(r"/phone/users/[^/]+/call_logs"), Tier.MEDIUM),
+    ("GET", re.compile(r"/phone/users/[^/]+/recordings"), Tier.MEDIUM),
+    ("GET", re.compile(r"/phone/users/[^/]+"), Tier.LIGHT),
+    ("GET", re.compile(r"/phone/users"), Tier.MEDIUM),
+    ("GET", re.compile(r"/phone/call_logs"), Tier.MEDIUM),
+    ("GET", re.compile(r"/phone/call_queues"), Tier.MEDIUM),
+    ("GET", re.compile(r"/phone/recordings"), Tier.MEDIUM),
 ]
 
 #: Default tier for unmapped endpoints. MEDIUM matches Zoom's most-common


### PR DESCRIPTION
## Summary

Closes #18 (read-only piece). Read-only Zoom Phone surface following the same module shape as PR #51's meetings + PR #54's recordings.

| Command | Endpoint |
|---|---|
| \`zoom phone users list\` | paginated \`GET /phone/users\` |
| \`zoom phone users get <id>\` | \`GET /phone/users/<id>\` |
| \`zoom phone call-logs list\` | \`GET /phone/call_logs\` (or per-user variant if \`--user-id\`) |
| \`zoom phone queues list\` | paginated \`GET /phone/call_queues\` |
| \`zoom phone recordings list\` | \`GET /phone/recordings\` (or per-user variant) |

## What's new

### \`zoom_cli/api/phone.py\` (new)

Five helpers, each maps to one Zoom endpoint. URL-encodes \`user_id\` (defense-in-depth from #36); paginated via the \`paginate()\` helper from PR #48; date filters (\`from_\`/\`to\`) only attached when set.

### CLI

All listings emit pipe-friendly TSV with header rows so they slot into the existing \`cut\`/\`awk\`/\`column\` patterns shown in \`examples/list-active-users.sh\`.

### Rate-limit tier mappings

\`rate_limit.ENDPOINT_TIERS\` extended for the new \`/phone/*\` paths:

| Path | Tier |
|---|---|
| \`GET /phone/users/<id>\` | LIGHT (single resource) |
| \`GET /phone/users\`, \`/phone/call_logs\`, \`/phone/call_queues\`, \`/phone/recordings\`, plus per-user variants | MEDIUM |

Tests pin every classification.

## Tests (+23 new)

| File | New | Covers |
|---|---|---|
| \`tests/test_api_phone.py\` | +11 | each helper's path; account-vs-per-user routing for call_logs and recordings; date-filter forwarding; pagination cursor walk; URL-encoding |
| \`tests/test_rate_limit.py\` | +1 parametrized × 7 cases | tier classification for all phone endpoints |
| \`tests/test_cli.py\` | +5 | users list TSV, users get JSON, call-logs flag forwarding, queues list TSV, recordings flag forwarding |

All HTTP via \`MagicMock\` (API helpers) or fully-stubbed flow (CLI). No socket I/O, no live Zoom calls.

## Verification

\`\`\`
ruff check .          # All checks passed!
ruff format --check . # 38 files already formatted
mypy                  # Success: no issues found in 17 source files
pytest -q             # 476 passed (was 453; +23)
\`\`\`

## Out of scope (deferred to issue #18 follow-up)

- **Phone call recording downloads** — downloads use the \`recording.download_url\` field; same pattern as \`zoom recordings download\` from PR #54 but for Phone-side recordings. Mechanically the same; can land as a separate PR.
- **Queue membership management** (POST/PATCH/DELETE on queue members). Read-only listing only in this PR.
- **Account-wide / call-handling configuration**. Read-only ergonomics first; write ergonomics need their own confirmation-flow design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)