### PR TITLE
feat(api,cli): close #20 — Zoom Reports (daily/meetings/participants/operationlogs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Codegen tooling (PR #59): closes #22. New `scripts/codegen.py` wraps `datamodel-code-generator` for Pydantic v2 model generation from Zoom's OpenAPI spec. Optional `[codegen]` extra; output gitignored by default.
 > Webhook receiver (PR #60): closes #17. New `zoom webhook serve` command + `zoom_cli/api/webhook.py` with constant-time HMAC verification and the endpoint.url_validation handshake.
 > Zoom Phone API (PR #61): closes #18 (read-only piece). New `zoom phone users / call-logs / queues / recordings list/get` commands; `zoom_cli/api/phone.py`; tier mappings extended for `/phone/*` endpoints.
-> Zoom Team Chat API (this branch): closes #19. New `zoom chat channels list` and `zoom chat messages send` commands; `zoom_cli/api/chat.py`.
+> Zoom Team Chat API (PR #62): closes #19. New `zoom chat channels list` and `zoom chat messages send` commands; `zoom_cli/api/chat.py`.
+> Zoom Reports API (this branch): closes #20. New `zoom reports daily / meetings list / meetings participants / operationlogs list` commands; `zoom_cli/api/reports.py`; tier mappings extended for `/report/*` (HEAVY tier).
+
+### Added (issue #20)
+- `zoom_cli/api/reports.py` — `get_daily(client, *, year, month)`, `list_meetings_report(client, *, user_id, from_, to, meeting_type, page_size)`, `list_meeting_participants(client, meeting_id, *, page_size)`, `list_operation_logs(client, *, from_, to, category_type, page_size)`. All paginated except `get_daily` (Zoom returns the whole month). URL-encodes `meeting_id` (Zoom UUIDs sometimes contain `/` so this is needed for correctness, not just defense).
+- CLI:
+  - `zoom reports daily [--year] [--month]` — JSON dump.
+  - `zoom reports meetings list --from --to [--user-id] [--type past|pastOne|pastJoined] [--page-size]` — TSV per meeting.
+  - `zoom reports meetings participants <meeting-id> [--page-size]` — TSV per participant.
+  - `zoom reports operationlogs list --from --to [--category-type] [--page-size]` — TSV per log entry.
+- `rate_limit.ENDPOINT_TIERS` now classifies all `/report/*` paths as `Tier.HEAVY` (40/s + 60,000/day cap). Tests pin every endpoint plus a wildcard fallback so an unmapped reports path still ends up HEAVY rather than the MEDIUM default.
+
+### Note
+Reports are heavyweight — pass `RateLimiter()` to `ApiClient` for batch use to stay under the 60k/day cap; the `DailyCapExhaustedError` from PR #57 surfaces when you'd otherwise be silently blocked.
 
 ### Added (issue #19)
 - `zoom_cli/api/chat.py` — `list_channels(client, *, user_id="me", page_size=50)` paginates `GET /chat/users/<id>/channels` (Zoom caps this at 50 not 300); `send_message(client, *, message, to_channel | to_contact, user_id, reply_main_message_id)` posts to `/chat/users/<id>/messages` and validates that exactly one of `to_channel` / `to_contact` is set.

--- a/tests/test_api_reports.py
+++ b/tests/test_api_reports.py
@@ -1,0 +1,144 @@
+"""Tests for zoom_cli.api.reports — Reports endpoint helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from zoom_cli.api import reports
+
+
+def test_get_daily_default_no_params() -> None:
+    """No year/month → empty params (Zoom returns the current month)."""
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"dates": []}
+
+    reports.get_daily(fake_client)
+
+    fake_client.get.assert_called_once_with("/report/daily", params=None)
+
+
+def test_get_daily_forwards_year_month() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {}
+
+    reports.get_daily(fake_client, year=2026, month=4)
+
+    fake_client.get.assert_called_once_with("/report/daily", params={"year": 2026, "month": 4})
+
+
+def test_list_meetings_report_account_wide_when_no_user_id() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"meetings": [], "next_page_token": ""}
+
+    list(reports.list_meetings_report(fake_client, from_="2026-04-01", to="2026-04-30"))
+
+    call = fake_client.get.call_args
+    assert call[0][0] == "/report/meetings"
+    assert call[1]["params"]["from"] == "2026-04-01"
+    assert call[1]["params"]["to"] == "2026-04-30"
+
+
+def test_list_meetings_report_per_user_path() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"meetings": [], "next_page_token": ""}
+
+    list(
+        reports.list_meetings_report(
+            fake_client, user_id="alice@example.com", from_="2026-04-01", to="2026-04-30"
+        )
+    )
+
+    assert fake_client.get.call_args[0][0] == "/report/users/alice%40example.com/meetings"
+
+
+def test_list_meetings_report_forwards_meeting_type() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"meetings": [], "next_page_token": ""}
+
+    list(
+        reports.list_meetings_report(
+            fake_client,
+            from_="2026-04-01",
+            to="2026-04-30",
+            meeting_type="past",
+        )
+    )
+
+    assert fake_client.get.call_args[1]["params"]["type"] == "past"
+
+
+def test_list_meetings_report_omits_type_when_none() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"meetings": [], "next_page_token": ""}
+
+    list(reports.list_meetings_report(fake_client, from_="2026-04-01", to="2026-04-30"))
+
+    assert "type" not in fake_client.get.call_args[1]["params"]
+
+
+def test_list_meetings_report_walks_pagination_cursor() -> None:
+    fake_client = MagicMock()
+    fake_client.get.side_effect = [
+        {"meetings": [{"id": 1}, {"id": 2}], "next_page_token": "tok-2"},
+        {"meetings": [{"id": 3}], "next_page_token": ""},
+    ]
+
+    result = list(reports.list_meetings_report(fake_client, from_="2026-04-01", to="2026-04-30"))
+
+    assert result == [{"id": 1}, {"id": 2}, {"id": 3}]
+
+
+def test_list_meeting_participants_targets_correct_path() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"participants": [], "next_page_token": ""}
+
+    list(reports.list_meeting_participants(fake_client, "12345"))
+
+    assert fake_client.get.call_args[0][0] == "/report/meetings/12345/participants"
+
+
+def test_list_meeting_participants_url_encodes_meeting_id() -> None:
+    """Zoom UUIDs sometimes contain `/` which would break the path; verify
+    they're percent-encoded."""
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"participants": [], "next_page_token": ""}
+
+    list(reports.list_meeting_participants(fake_client, "uuid/with/slashes=="))
+
+    arg = fake_client.get.call_args[0][0]
+    assert "uuid/with/slashes==" not in arg
+    assert "%2F" in arg
+
+
+def test_list_operation_logs_required_dates_forwarded() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"operation_logs": [], "next_page_token": ""}
+
+    list(reports.list_operation_logs(fake_client, from_="2026-04-01", to="2026-04-30"))
+
+    call = fake_client.get.call_args
+    assert call[0][0] == "/report/operationlogs"
+    assert call[1]["params"]["from"] == "2026-04-01"
+    assert call[1]["params"]["to"] == "2026-04-30"
+
+
+def test_list_operation_logs_forwards_category_type() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"operation_logs": [], "next_page_token": ""}
+
+    list(
+        reports.list_operation_logs(
+            fake_client, from_="2026-04-01", to="2026-04-30", category_type="user"
+        )
+    )
+
+    assert fake_client.get.call_args[1]["params"]["category_type"] == "user"
+
+
+def test_list_operation_logs_omits_category_when_none() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"operation_logs": [], "next_page_token": ""}
+
+    list(reports.list_operation_logs(fake_client, from_="2026-04-01", to="2026-04-30"))
+
+    assert "category_type" not in fake_client.get.call_args[1]["params"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2305,3 +2305,215 @@ def test_chat_messages_send_forwards_reply_id(
     )
     assert result.exit_code == 0, result.output
     assert captured["reply_main_message_id"] == "PARENT-MSG-ID"
+
+
+# ---- #20: zoom reports CLI ---------------------------------------------
+
+
+def _patch_reports_module(monkeypatch: pytest.MonkeyPatch, **funcs):
+    import zoom_cli.__main__ as main_mod
+
+    for name, fn in funcs.items():
+        monkeypatch.setattr(main_mod.reports, name, fn)
+    monkeypatch.setattr(
+        main_mod.oauth, "fetch_access_token", lambda *_a, **_k: _fake_access_token()
+    )
+
+
+def test_reports_daily_prints_json(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    _save_creds()
+    captured = {}
+
+    def fake_get(_client, *, year, month):
+        captured.update({"year": year, "month": month})
+        return {"year": "2026", "month": "04", "dates": []}
+
+    _patch_reports_module(monkeypatch, get_daily=fake_get)
+    result = runner.invoke(main, ["reports", "daily", "--year", "2026", "--month", "4"])
+    assert result.exit_code == 0, result.output
+    assert captured == {"year": 2026, "month": 4}
+    import json as _json
+
+    parsed = _json.loads(result.output)
+    assert parsed["year"] == "2026"
+
+
+def test_reports_daily_default_omits_year_month(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured = {}
+
+    def fake_get(_client, *, year, month):
+        captured.update({"year": year, "month": month})
+        return {}
+
+    _patch_reports_module(monkeypatch, get_daily=fake_get)
+    result = runner.invoke(main, ["reports", "daily"])
+    assert result.exit_code == 0, result.output
+    assert captured == {"year": None, "month": None}
+
+
+def test_reports_meetings_list_requires_dates(runner: CliRunner) -> None:
+    _save_creds()
+    result = runner.invoke(main, ["reports", "meetings", "list"])
+    assert result.exit_code != 0
+    assert "from" in result.output.lower() or "missing" in result.output.lower()
+
+
+def test_reports_meetings_list_prints_tab_separated(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+
+    def fake_list(_client, *, user_id, from_, to, meeting_type, page_size):
+        return iter(
+            [
+                {
+                    "uuid": "u-1",
+                    "id": 11,
+                    "topic": "Standup",
+                    "user_email": "alice@example.com",
+                    "start_time": "2026-04-28T10:00:00Z",
+                    "duration": 30,
+                    "participants_count": 5,
+                },
+            ]
+        )
+
+    _patch_reports_module(monkeypatch, list_meetings_report=fake_list)
+    result = runner.invoke(
+        main,
+        [
+            "reports",
+            "meetings",
+            "list",
+            "--from",
+            "2026-04-01",
+            "--to",
+            "2026-04-30",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    lines = result.output.strip().split("\n")
+    assert lines[0] == "uuid\tid\ttopic\tuser_email\tstart_time\tduration\tparticipants_count"
+    assert lines[1] == "u-1\t11\tStandup\talice@example.com\t2026-04-28T10:00:00Z\t30\t5"
+
+
+def test_reports_meetings_list_forwards_filters(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured = {}
+
+    def fake_list(_client, *, user_id, from_, to, meeting_type, page_size):
+        captured.update(
+            {"user_id": user_id, "from_": from_, "to": to, "meeting_type": meeting_type}
+        )
+        return iter([])
+
+    _patch_reports_module(monkeypatch, list_meetings_report=fake_list)
+    result = runner.invoke(
+        main,
+        [
+            "reports",
+            "meetings",
+            "list",
+            "--user-id",
+            "u-X",
+            "--from",
+            "2026-04-01",
+            "--to",
+            "2026-04-30",
+            "--type",
+            "past",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "user_id": "u-X",
+        "from_": "2026-04-01",
+        "to": "2026-04-30",
+        "meeting_type": "past",
+    }
+
+
+def test_reports_meetings_list_rejects_invalid_type(runner: CliRunner) -> None:
+    _save_creds()
+    result = runner.invoke(
+        main,
+        [
+            "reports",
+            "meetings",
+            "list",
+            "--from",
+            "2026-04-01",
+            "--to",
+            "2026-04-30",
+            "--type",
+            "garbage",
+        ],
+    )
+    assert result.exit_code != 0
+
+
+def test_reports_meetings_participants_prints_tab_separated(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+
+    def fake_list(_client, meeting_id, *, page_size):
+        return iter(
+            [
+                {
+                    "id": "p-1",
+                    "name": "Alice",
+                    "user_email": "alice@example.com",
+                    "join_time": "2026-04-28T10:00:00Z",
+                    "leave_time": "2026-04-28T10:30:00Z",
+                    "duration": 1800,
+                },
+            ]
+        )
+
+    _patch_reports_module(monkeypatch, list_meeting_participants=fake_list)
+    result = runner.invoke(main, ["reports", "meetings", "participants", "12345"])
+    assert result.exit_code == 0, result.output
+    lines = result.output.strip().split("\n")
+    assert lines[0] == "id\tname\tuser_email\tjoin_time\tleave_time\tduration"
+    assert lines[1] == (
+        "p-1\tAlice\talice@example.com\t2026-04-28T10:00:00Z\t2026-04-28T10:30:00Z\t1800"
+    )
+
+
+def test_reports_operationlogs_list_forwards_filters(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured = {}
+
+    def fake_list(_client, *, from_, to, category_type, page_size):
+        captured.update({"from_": from_, "to": to, "category_type": category_type})
+        return iter([])
+
+    _patch_reports_module(monkeypatch, list_operation_logs=fake_list)
+    result = runner.invoke(
+        main,
+        [
+            "reports",
+            "operationlogs",
+            "list",
+            "--from",
+            "2026-04-01",
+            "--to",
+            "2026-04-30",
+            "--category-type",
+            "user",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "from_": "2026-04-01",
+        "to": "2026-04-30",
+        "category_type": "user",
+    }

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -281,3 +281,22 @@ def test_tier_for_classifies_phone_endpoints(method: str, path: str, expected: T
 )
 def test_tier_for_classifies_chat_endpoints(method: str, path: str, expected: Tier) -> None:
     assert tier_for(method, path) == expected
+
+
+# ---- #20 Zoom Reports tier mappings ------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method,path",
+    [
+        ("GET", "/report/daily"),
+        ("GET", "/report/meetings"),
+        ("GET", "/report/users/u-1/meetings"),
+        ("GET", "/report/meetings/12345/participants"),
+        ("GET", "/report/operationlogs"),
+        ("GET", "/report/something/else/we-haven-t-mapped"),
+    ],
+)
+def test_tier_for_classifies_reports_endpoints_as_heavy(method: str, path: str) -> None:
+    """All /report/* endpoints sit on Zoom's HEAVY tier (40/s + 60k/day)."""
+    assert tier_for(method, path) == Tier.HEAVY

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -8,7 +8,17 @@ import questionary
 from click_default_group import DefaultGroup
 
 from zoom_cli import auth
-from zoom_cli.api import chat, meetings, oauth, phone, recordings, user_oauth, users, webhook
+from zoom_cli.api import (
+    chat,
+    meetings,
+    oauth,
+    phone,
+    recordings,
+    reports,
+    user_oauth,
+    users,
+    webhook,
+)
 from zoom_cli.api.client import ApiClient, ZoomApiError
 from zoom_cli.commands import (
     _edit,
@@ -1235,6 +1245,169 @@ def recordings_delete(meeting_id, file_id, action, yes, dry_run):
         _exit_on_api_error(exc)
     verb = "Deleted" if action == "delete" else "Trashed"
     click.echo(f"{verb} {target}.")
+
+
+# ---- Zoom Reports ------------------------------------------------------
+
+
+@main.group(
+    "reports",
+    help="Zoom Reports API (https://developers.zoom.us/docs/api/reports/).",
+)
+def reports_cmd():
+    """Group for ``zoom reports ...``. All Reports endpoints sit on the
+    HEAVY rate-limit tier (40/s + 60k/day) — pass ``RateLimiter()`` to
+    ``ApiClient`` for batch use to stay under the daily cap."""
+
+
+@reports_cmd.command("daily", help="Daily account usage report (JSON dump).")
+@click.option("--year", type=click.IntRange(2010, 2100), help="Year (default: current).")
+@click.option(
+    "--month",
+    type=click.IntRange(1, 12),
+    help="Month (default: current). Both --year and --month omitted = current month.",
+)
+@_translate_keyring_errors
+def reports_daily(year, month):
+    import json as _json
+
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            envelope = reports.get_daily(client, year=year, month=month)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(_json.dumps(envelope, indent=2, sort_keys=True))
+
+
+@reports_cmd.group("meetings", help="Meeting-level reports.")
+def reports_meetings_cmd():
+    pass
+
+
+@reports_meetings_cmd.command(
+    "list",
+    help="List meeting report entries (paginated).",
+)
+@click.option(
+    "--user-id",
+    default=None,
+    help="Limit to one user. Omit for account-wide.",
+)
+@click.option("--from", "from_", required=True, metavar="YYYY-MM-DD")
+@click.option("--to", required=True, metavar="YYYY-MM-DD")
+@click.option(
+    "--type",
+    "meeting_type",
+    type=click.Choice(["past", "pastOne", "pastJoined"]),
+    help="Filter by meeting type.",
+)
+@click.option(
+    "--page-size",
+    type=click.IntRange(1, 300),
+    default=300,
+    show_default=True,
+)
+@_translate_keyring_errors
+def reports_meetings_list(user_id, from_, to, meeting_type, page_size):
+    """TSV: uuid\\tid\\ttopic\\tuser_email\\tstart_time\\tduration\\tparticipants_count."""
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            click.echo("uuid\tid\ttopic\tuser_email\tstart_time\tduration\tparticipants_count")
+            for m in reports.list_meetings_report(
+                client,
+                user_id=user_id,
+                from_=from_,
+                to=to,
+                meeting_type=meeting_type,
+                page_size=page_size,
+            ):
+                click.echo(
+                    f"{m.get('uuid', '')}\t"
+                    f"{m.get('id', '')}\t"
+                    f"{m.get('topic', '')}\t"
+                    f"{m.get('user_email', '')}\t"
+                    f"{m.get('start_time', '')}\t"
+                    f"{m.get('duration', '')}\t"
+                    f"{m.get('participants_count', '')}"
+                )
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+
+
+@reports_meetings_cmd.command(
+    "participants",
+    help="List participants for one meeting (paginated).",
+)
+@click.argument("meeting_id")
+@click.option(
+    "--page-size",
+    type=click.IntRange(1, 300),
+    default=300,
+    show_default=True,
+)
+@_translate_keyring_errors
+def reports_meetings_participants(meeting_id, page_size):
+    """TSV: id\\tname\\tuser_email\\tjoin_time\\tleave_time\\tduration."""
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            click.echo("id\tname\tuser_email\tjoin_time\tleave_time\tduration")
+            for p in reports.list_meeting_participants(client, meeting_id, page_size=page_size):
+                click.echo(
+                    f"{p.get('id', '')}\t"
+                    f"{p.get('name', '')}\t"
+                    f"{p.get('user_email', '')}\t"
+                    f"{p.get('join_time', '')}\t"
+                    f"{p.get('leave_time', '')}\t"
+                    f"{p.get('duration', '')}"
+                )
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+
+
+@reports_cmd.group("operationlogs", help="Admin operation logs.")
+def reports_operationlogs_cmd():
+    pass
+
+
+@reports_operationlogs_cmd.command("list", help="List admin operation logs (paginated).")
+@click.option("--from", "from_", required=True, metavar="YYYY-MM-DD")
+@click.option("--to", required=True, metavar="YYYY-MM-DD")
+@click.option(
+    "--category-type",
+    help="Filter by category (user, account, billing, zoom_rooms, ...).",
+)
+@click.option(
+    "--page-size",
+    type=click.IntRange(1, 300),
+    default=300,
+    show_default=True,
+)
+@_translate_keyring_errors
+def reports_operationlogs_list(from_, to, category_type, page_size):
+    """TSV: time\\toperator\\tcategory_type\\taction\\toperation_detail."""
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            click.echo("time\toperator\tcategory_type\taction\toperation_detail")
+            for entry in reports.list_operation_logs(
+                client,
+                from_=from_,
+                to=to,
+                category_type=category_type,
+                page_size=page_size,
+            ):
+                click.echo(
+                    f"{entry.get('time', '')}\t"
+                    f"{entry.get('operator', '')}\t"
+                    f"{entry.get('category_type', '')}\t"
+                    f"{entry.get('action', '')}\t"
+                    f"{entry.get('operation_detail', '')}"
+                )
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
 
 
 # ---- Zoom Team Chat ----------------------------------------------------

--- a/zoom_cli/api/rate_limit.py
+++ b/zoom_cli/api/rate_limit.py
@@ -117,6 +117,8 @@ _TIER_RULES: list[tuple[str, re.Pattern[str], Tier]] = [
     # ---- Zoom Team Chat (#19)
     ("GET", re.compile(r"/chat/users/[^/]+/channels"), Tier.MEDIUM),
     ("POST", re.compile(r"/chat/users/[^/]+/messages"), Tier.MEDIUM),
+    # ---- Zoom Reports (#20) — all HEAVY per Zoom docs (40/s + 60k/day)
+    ("GET", re.compile(r"/report/.*"), Tier.HEAVY),
 ]
 
 #: Default tier for unmapped endpoints. MEDIUM matches Zoom's most-common

--- a/zoom_cli/api/reports.py
+++ b/zoom_cli/api/reports.py
@@ -1,0 +1,145 @@
+"""Zoom Reports API helpers (closes #20).
+
+Reference: https://developers.zoom.us/docs/api/reports/
+
+Endpoints covered:
+
+  get_daily(client, *, year=None, month=None) -> dict
+      → GET /report/daily (single page; returns the whole month)
+
+  list_meetings_report(client, *, user_id=None, from_, to,
+                       meeting_type=None, page_size=300) -> Iterator[dict]
+      → GET /report/users/{user_id}/meetings (paginated; per-user)
+      OR GET /report/meetings (paginated; account-wide when user_id is None)
+
+  list_meeting_participants(client, meeting_id, *, page_size=300) -> Iterator[dict]
+      → GET /report/meetings/{meeting_id}/participants (paginated)
+
+  list_operation_logs(client, *, from_, to, category_type=None,
+                      page_size=300) -> Iterator[dict]
+      → GET /report/operationlogs (paginated)
+
+All Reports endpoints sit on Zoom's HEAVY rate-limit tier (40/s,
+60,000/day) — see :mod:`zoom_cli.api.rate_limit` for the classification.
+``from_``/``to`` are ISO-8601 dates (Zoom's parameter name is just
+``from`` but Python reserves it).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from urllib.parse import quote
+
+from zoom_cli.api.client import ApiClient
+from zoom_cli.api.pagination import DEFAULT_PAGE_SIZE, paginate
+
+
+def get_daily(
+    client: ApiClient,
+    *,
+    year: int | None = None,
+    month: int | None = None,
+) -> dict[str, Any]:
+    """``GET /report/daily`` — daily account usage for one month.
+
+    Default (no year/month) returns the current month per Zoom's API
+    default. Pass ``year``/``month`` for a specific historical month.
+    Not paginated — Zoom returns the whole month in one envelope.
+
+    Required scopes: ``report:read:admin``.
+    """
+    params: dict[str, Any] = {}
+    if year is not None:
+        params["year"] = year
+    if month is not None:
+        params["month"] = month
+    return client.get("/report/daily", params=params or None)
+
+
+def list_meetings_report(
+    client: ApiClient,
+    *,
+    user_id: str | None = None,
+    from_: str,
+    to: str,
+    meeting_type: str | None = None,
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> Iterator[dict[str, Any]]:
+    """Yield meeting report entries.
+
+    If ``user_id`` is set, hits the per-user endpoint
+    ``/report/users/{user_id}/meetings``; otherwise the account-wide
+    ``/report/meetings``.
+
+    ``from_`` and ``to`` are ISO-8601 dates and **required** by Zoom.
+    ``meeting_type`` filters server-side (e.g. ``past``, ``pastOne``,
+    ``pastJoined``); omit to include all.
+
+    Required scopes: ``report:read:admin``.
+    """
+    path = (
+        f"/report/users/{quote(user_id, safe='')}/meetings"
+        if user_id is not None
+        else "/report/meetings"
+    )
+    params: dict[str, Any] = {"from": from_, "to": to}
+    if meeting_type is not None:
+        params["type"] = meeting_type
+    return paginate(
+        client,
+        path,
+        item_key="meetings",
+        params=params,
+        page_size=page_size,
+    )
+
+
+def list_meeting_participants(
+    client: ApiClient,
+    meeting_id: str | int,
+    *,
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> Iterator[dict[str, Any]]:
+    """``GET /report/meetings/{meeting_id}/participants`` — paginated.
+
+    The ``meeting_id`` is the meeting's UUID **or** numeric ID. Zoom
+    treats both interchangeably here. URL-encoded so a UUID containing
+    ``/`` (Zoom UUIDs sometimes do) doesn't break the path.
+
+    Required scopes: ``report:read:admin``.
+    """
+    return paginate(
+        client,
+        f"/report/meetings/{quote(str(meeting_id), safe='')}/participants",
+        item_key="participants",
+        page_size=page_size,
+    )
+
+
+def list_operation_logs(
+    client: ApiClient,
+    *,
+    from_: str,
+    to: str,
+    category_type: str | None = None,
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> Iterator[dict[str, Any]]:
+    """``GET /report/operationlogs`` — paginated admin operation log.
+
+    ``from_`` / ``to`` are ISO-8601 dates and required.
+    ``category_type`` filters by Zoom's category enum (``user``,
+    ``account``, ``billing``, ``zoom_rooms``, etc.); omit for all.
+
+    Required scopes: ``report:read:admin``.
+    """
+    params: dict[str, Any] = {"from": from_, "to": to}
+    if category_type is not None:
+        params["category_type"] = category_type
+    return paginate(
+        client,
+        "/report/operationlogs",
+        item_key="operation_logs",
+        params=params,
+        page_size=page_size,
+    )


### PR DESCRIPTION
## Summary

Closes #20. Read-only Zoom Reports surface — daily account usage, meeting + participant reports, and the admin operation log.

| Command | Endpoint | Tier |
|---|---|---|
| \`zoom reports daily\` | \`GET /report/daily\` | HEAVY |
| \`zoom reports meetings list\` | \`/report/meetings\` or \`/report/users/<id>/meetings\` (paginated) | HEAVY |
| \`zoom reports meetings participants <id>\` | \`/report/meetings/<id>/participants\` (paginated) | HEAVY |
| \`zoom reports operationlogs list\` | \`/report/operationlogs\` (paginated) | HEAVY |

## What's new

### \`zoom_cli/api/reports.py\` (new)

\`\`\`python
get_daily(client, *, year=None, month=None) -> dict
list_meetings_report(client, *, user_id=None, from_, to, meeting_type=None, page_size=300) -> Iterator
list_meeting_participants(client, meeting_id, *, page_size=300) -> Iterator
list_operation_logs(client, *, from_, to, category_type=None, page_size=300) -> Iterator
\`\`\`

\`from_\`/\`to\` are required by Zoom on the listing endpoints. \`meeting_id\` is URL-encoded — Zoom UUIDs sometimes contain \`/\`, so this is needed for correctness, not just defense-in-depth.

### CLI

\`zoom reports meetings list --type\` is validated against Zoom's enum (\`past\`, \`pastOne\`, \`pastJoined\`). All listings emit pipe-friendly TSV with header rows.

### Rate-limit tier mappings

\`\`\`
/report/.* (wildcard) → Tier.HEAVY (40/s + 60,000/day)
\`\`\`

Reports are heavyweight enough that batch use should pass \`RateLimiter()\` to \`ApiClient\` so the daily cap surfaces as \`DailyCapExhaustedError\` (from PR #57) rather than silently blocking mid-walk.

## Tests (+26 new)

| File | New | Covers |
|---|---|---|
| \`tests/test_api_reports.py\` | +12 | daily default-no-params + with year/month; meetings_report account-wide vs per-user paths; URL-encoded user_id; meeting_type forwarded vs omitted; pagination walk; participants path + URL-encoded UUID with slashes; operation_logs required dates + category_type forwarded vs omitted |
| \`tests/test_rate_limit.py\` | +1 parametrized × 6 cases | every reports endpoint + an unmapped \`/report/something\` path → HEAVY |
| \`tests/test_cli.py\` | +8 | daily JSON + year/month forwarding + None defaults; meetings list requires --from/--to; meetings list TSV + filter forwarding + invalid --type rejection; meetings participants TSV; operationlogs filter forwarding |

## Verification

\`\`\`
ruff check .          # All checks passed!
ruff format --check . # 42 files already formatted
mypy                  # Success: no issues found in 19 source files
pytest -q             # 523 passed (was 497; +26)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)