### PR TITLE
feat(api,cli): close #21 — Zoom Dashboard / Metrics (meetings + zoomrooms)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Webhook receiver (PR #60): closes #17. New `zoom webhook serve` command + `zoom_cli/api/webhook.py` with constant-time HMAC verification and the endpoint.url_validation handshake.
 > Zoom Phone API (PR #61): closes #18 (read-only piece). New `zoom phone users / call-logs / queues / recordings list/get` commands; `zoom_cli/api/phone.py`; tier mappings extended for `/phone/*` endpoints.
 > Zoom Team Chat API (PR #62): closes #19. New `zoom chat channels list` and `zoom chat messages send` commands; `zoom_cli/api/chat.py`.
-> Zoom Reports API (this branch): closes #20. New `zoom reports daily / meetings list / meetings participants / operationlogs list` commands; `zoom_cli/api/reports.py`; tier mappings extended for `/report/*` (HEAVY tier).
+> Zoom Reports API (PR #63): closes #20. New `zoom reports daily / meetings list / meetings participants / operationlogs list` commands; `zoom_cli/api/reports.py`; tier mappings extended for `/report/*` (HEAVY tier).
+> Zoom Dashboard API (this branch): closes #21. New `zoom dashboard meetings list / get / participants` and `zoom dashboard zoomrooms list / get` commands; `zoom_cli/api/dashboard.py`; tier mappings extended for `/metrics/*` (HEAVY tier). Requires Business+ Zoom plan.
+
+### Added (issue #21)
+- `zoom_cli/api/dashboard.py` — `list_meetings(client, *, type, from_, to)`, `get_meeting(client, meeting_id)`, `list_meeting_participants(client, meeting_id, *, type)`, `list_zoomrooms(client)`, `get_zoomroom(client, room_id)`. `type` validated against `ALLOWED_MEETING_METRIC_TYPES = ("past", "live", "pastOne")`. URL-encodes meeting_id and room_id.
+- CLI:
+  - `zoom dashboard meetings list --from --to [--type past|live|pastOne] [--page-size]` — TSV per meeting.
+  - `zoom dashboard meetings get <meeting-id>` — JSON dump.
+  - `zoom dashboard meetings participants <meeting-id> [--type] [--page-size]` — TSV per participant.
+  - `zoom dashboard zoomrooms list [--page-size]` — TSV per room.
+  - `zoom dashboard zoomrooms get <room-id>` — JSON dump.
+- `rate_limit.ENDPOINT_TIERS` extended with `/metrics/.*` → `Tier.HEAVY` (matches Zoom's published table). Tests cover every endpoint plus an unmapped wildcard.
 
 ### Added (issue #20)
 - `zoom_cli/api/reports.py` — `get_daily(client, *, year, month)`, `list_meetings_report(client, *, user_id, from_, to, meeting_type, page_size)`, `list_meeting_participants(client, meeting_id, *, page_size)`, `list_operation_logs(client, *, from_, to, category_type, page_size)`. All paginated except `get_daily` (Zoom returns the whole month). URL-encodes `meeting_id` (Zoom UUIDs sometimes contain `/` so this is needed for correctness, not just defense).

--- a/tests/test_api_dashboard.py
+++ b/tests/test_api_dashboard.py
@@ -1,0 +1,142 @@
+"""Tests for zoom_cli.api.dashboard — Dashboard / Metrics endpoint helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from zoom_cli.api import dashboard
+
+
+def test_list_meetings_default_type_past() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"meetings": [], "next_page_token": ""}
+
+    list(dashboard.list_meetings(fake_client, from_="2026-04-01", to="2026-04-30"))
+
+    call = fake_client.get.call_args
+    assert call[0][0] == "/metrics/meetings"
+    assert call[1]["params"]["type"] == "past"
+    assert call[1]["params"]["from"] == "2026-04-01"
+    assert call[1]["params"]["to"] == "2026-04-30"
+
+
+def test_list_meetings_forwards_type() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"meetings": [], "next_page_token": ""}
+
+    list(dashboard.list_meetings(fake_client, type="live", from_="2026-04-01", to="2026-04-30"))
+
+    assert fake_client.get.call_args[1]["params"]["type"] == "live"
+
+
+def test_list_meetings_rejects_unknown_type() -> None:
+    fake_client = MagicMock()
+    with pytest.raises(ValueError, match="type"):
+        list(
+            dashboard.list_meetings(fake_client, type="bogus", from_="2026-04-01", to="2026-04-30")
+        )
+
+
+def test_list_meetings_walks_pagination_cursor() -> None:
+    fake_client = MagicMock()
+    fake_client.get.side_effect = [
+        {"meetings": [{"id": 1}], "next_page_token": "tok-2"},
+        {"meetings": [{"id": 2}, {"id": 3}], "next_page_token": ""},
+    ]
+
+    result = list(dashboard.list_meetings(fake_client, from_="2026-04-01", to="2026-04-30"))
+
+    assert result == [{"id": 1}, {"id": 2}, {"id": 3}]
+
+
+def test_get_meeting_targets_correct_path() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"id": 12345}
+
+    dashboard.get_meeting(fake_client, 12345)
+
+    fake_client.get.assert_called_once_with("/metrics/meetings/12345")
+
+
+def test_get_meeting_url_encodes_uuid_with_slashes() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {}
+
+    dashboard.get_meeting(fake_client, "uuid/with/slashes==")
+
+    arg = fake_client.get.call_args[0][0]
+    assert "uuid/with/slashes==" not in arg
+    assert "%2F" in arg
+
+
+def test_list_meeting_participants_targets_correct_path() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"participants": [], "next_page_token": ""}
+
+    list(dashboard.list_meeting_participants(fake_client, "12345"))
+
+    call = fake_client.get.call_args
+    assert call[0][0] == "/metrics/meetings/12345/participants"
+    assert call[1]["params"]["type"] == "past"
+
+
+def test_list_meeting_participants_forwards_type() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"participants": [], "next_page_token": ""}
+
+    list(dashboard.list_meeting_participants(fake_client, "12345", type="live"))
+
+    assert fake_client.get.call_args[1]["params"]["type"] == "live"
+
+
+def test_list_meeting_participants_rejects_unknown_type() -> None:
+    fake_client = MagicMock()
+    with pytest.raises(ValueError, match="type"):
+        list(dashboard.list_meeting_participants(fake_client, "12345", type="bogus"))
+
+
+def test_list_meeting_participants_url_encodes_meeting_id() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"participants": [], "next_page_token": ""}
+
+    list(dashboard.list_meeting_participants(fake_client, "uuid/with/slashes=="))
+
+    arg = fake_client.get.call_args[0][0]
+    assert "uuid/with/slashes==" not in arg
+    assert "%2F" in arg
+
+
+def test_list_zoomrooms_paginates() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {
+        "zoom_rooms": [{"id": "r1"}, {"id": "r2"}],
+        "next_page_token": "",
+    }
+
+    result = list(dashboard.list_zoomrooms(fake_client))
+
+    assert result == [{"id": "r1"}, {"id": "r2"}]
+    assert fake_client.get.call_args[0][0] == "/metrics/zoomrooms"
+
+
+def test_get_zoomroom_targets_correct_path() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"id": "r-1"}
+
+    dashboard.get_zoomroom(fake_client, "r-1")
+
+    fake_client.get.assert_called_once_with("/metrics/zoomrooms/r-1")
+
+
+def test_get_zoomroom_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {}
+
+    dashboard.get_zoomroom(fake_client, "weird/id")
+
+    assert fake_client.get.call_args[0][0] == "/metrics/zoomrooms/weird%2Fid"
+
+
+def test_allowed_meeting_metric_types_pinned() -> None:
+    assert dashboard.ALLOWED_MEETING_METRIC_TYPES == ("past", "live", "pastOne")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2517,3 +2517,196 @@ def test_reports_operationlogs_list_forwards_filters(
         "to": "2026-04-30",
         "category_type": "user",
     }
+
+
+# ---- #21: zoom dashboard CLI -------------------------------------------
+
+
+def _patch_dashboard_module(monkeypatch: pytest.MonkeyPatch, **funcs):
+    import zoom_cli.__main__ as main_mod
+
+    for name, fn in funcs.items():
+        monkeypatch.setattr(main_mod.dashboard, name, fn)
+    monkeypatch.setattr(
+        main_mod.oauth, "fetch_access_token", lambda *_a, **_k: _fake_access_token()
+    )
+
+
+def test_dashboard_meetings_list_requires_dates(runner: CliRunner) -> None:
+    _save_creds()
+    result = runner.invoke(main, ["dashboard", "meetings", "list"])
+    assert result.exit_code != 0
+
+
+def test_dashboard_meetings_list_prints_tab_separated(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+
+    def fake_list(_client, *, type, from_, to, page_size):
+        return iter(
+            [
+                {
+                    "uuid": "u-1",
+                    "id": 11,
+                    "topic": "T",
+                    "host": "alice@example.com",
+                    "participants": 5,
+                    "duration": 30,
+                    "start_time": "2026-04-28T10:00:00Z",
+                },
+            ]
+        )
+
+    _patch_dashboard_module(monkeypatch, list_meetings=fake_list)
+    result = runner.invoke(
+        main,
+        [
+            "dashboard",
+            "meetings",
+            "list",
+            "--from",
+            "2026-04-01",
+            "--to",
+            "2026-04-30",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    lines = result.output.strip().split("\n")
+    assert lines[0] == "uuid\tid\ttopic\thost\tparticipants\tduration\tstart_time"
+    assert lines[1] == "u-1\t11\tT\talice@example.com\t5\t30\t2026-04-28T10:00:00Z"
+
+
+def test_dashboard_meetings_list_forwards_type(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured = {}
+
+    def fake_list(_client, *, type, from_, to, page_size):
+        captured["type"] = type
+        return iter([])
+
+    _patch_dashboard_module(monkeypatch, list_meetings=fake_list)
+    result = runner.invoke(
+        main,
+        [
+            "dashboard",
+            "meetings",
+            "list",
+            "--from",
+            "2026-04-01",
+            "--to",
+            "2026-04-30",
+            "--type",
+            "live",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["type"] == "live"
+
+
+def test_dashboard_meetings_list_rejects_invalid_type(runner: CliRunner) -> None:
+    _save_creds()
+    result = runner.invoke(
+        main,
+        [
+            "dashboard",
+            "meetings",
+            "list",
+            "--from",
+            "2026-04-01",
+            "--to",
+            "2026-04-30",
+            "--type",
+            "garbage",
+        ],
+    )
+    assert result.exit_code != 0
+
+
+def test_dashboard_meetings_get_prints_json(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+
+    def fake_get(_client, meeting_id):
+        return {"id": meeting_id, "topic": "M", "duration": 45}
+
+    _patch_dashboard_module(monkeypatch, get_meeting=fake_get)
+    result = runner.invoke(main, ["dashboard", "meetings", "get", "12345"])
+    assert result.exit_code == 0, result.output
+    import json as _json
+
+    parsed = _json.loads(result.output)
+    assert parsed["id"] == "12345"
+
+
+def test_dashboard_meetings_participants_prints_tab_separated(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+
+    def fake_list(_client, meeting_id, *, type, page_size):
+        return iter(
+            [
+                {
+                    "id": "p-1",
+                    "user_id": "u-1",
+                    "user_name": "Alice",
+                    "join_time": "2026-04-28T10:00:00Z",
+                    "leave_time": "2026-04-28T10:30:00Z",
+                    "duration": 1800,
+                },
+            ]
+        )
+
+    _patch_dashboard_module(monkeypatch, list_meeting_participants=fake_list)
+    result = runner.invoke(main, ["dashboard", "meetings", "participants", "12345"])
+    assert result.exit_code == 0, result.output
+    lines = result.output.strip().split("\n")
+    assert lines[0] == "id\tuser_id\tuser_name\tjoin_time\tleave_time\tduration"
+    assert lines[1] == ("p-1\tu-1\tAlice\t2026-04-28T10:00:00Z\t2026-04-28T10:30:00Z\t1800")
+
+
+def test_dashboard_zoomrooms_list_prints_tab_separated(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+
+    def fake_list(_client, *, page_size):
+        return iter(
+            [
+                {
+                    "id": "r-1",
+                    "room_name": "Conference A",
+                    "status": "Available",
+                    "device_ip": "192.168.1.10",
+                    "last_start_time": "2026-04-28T08:00:00Z",
+                },
+            ]
+        )
+
+    _patch_dashboard_module(monkeypatch, list_zoomrooms=fake_list)
+    result = runner.invoke(main, ["dashboard", "zoomrooms", "list"])
+    assert result.exit_code == 0, result.output
+    lines = result.output.strip().split("\n")
+    assert lines[0] == "id\troom_name\tstatus\tdevice_ip\tlast_start_time"
+    assert lines[1] == ("r-1\tConference A\tAvailable\t192.168.1.10\t2026-04-28T08:00:00Z")
+
+
+def test_dashboard_zoomrooms_get_prints_json(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+
+    def fake_get(_client, room_id):
+        return {"id": room_id, "room_name": "Conference A", "status": "Available"}
+
+    _patch_dashboard_module(monkeypatch, get_zoomroom=fake_get)
+    result = runner.invoke(main, ["dashboard", "zoomrooms", "get", "r-1"])
+    assert result.exit_code == 0, result.output
+    import json as _json
+
+    parsed = _json.loads(result.output)
+    assert parsed["id"] == "r-1"

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -300,3 +300,22 @@ def test_tier_for_classifies_chat_endpoints(method: str, path: str, expected: Ti
 def test_tier_for_classifies_reports_endpoints_as_heavy(method: str, path: str) -> None:
     """All /report/* endpoints sit on Zoom's HEAVY tier (40/s + 60k/day)."""
     assert tier_for(method, path) == Tier.HEAVY
+
+
+# ---- #21 Zoom Dashboard tier mappings ----------------------------------
+
+
+@pytest.mark.parametrize(
+    "method,path",
+    [
+        ("GET", "/metrics/meetings"),
+        ("GET", "/metrics/meetings/12345"),
+        ("GET", "/metrics/meetings/12345/participants"),
+        ("GET", "/metrics/zoomrooms"),
+        ("GET", "/metrics/zoomrooms/r-1"),
+        ("GET", "/metrics/something/unmapped"),
+    ],
+)
+def test_tier_for_classifies_dashboard_endpoints_as_heavy(method: str, path: str) -> None:
+    """All /metrics/* endpoints are HEAVY per Zoom docs."""
+    assert tier_for(method, path) == Tier.HEAVY

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -10,6 +10,7 @@ from click_default_group import DefaultGroup
 from zoom_cli import auth
 from zoom_cli.api import (
     chat,
+    dashboard,
     meetings,
     oauth,
     phone,
@@ -1245,6 +1246,173 @@ def recordings_delete(meeting_id, file_id, action, yes, dry_run):
         _exit_on_api_error(exc)
     verb = "Deleted" if action == "delete" else "Trashed"
     click.echo(f"{verb} {target}.")
+
+
+# ---- Zoom Dashboard / Metrics ------------------------------------------
+
+
+@main.group(
+    "dashboard",
+    help=(
+        "Zoom Dashboard / Metrics API (Business+ plans only). "
+        "https://developers.zoom.us/docs/api/dashboards/"
+    ),
+)
+def dashboard_cmd():
+    """Group for ``zoom dashboard ...``. All endpoints sit on the HEAVY
+    rate-limit tier (40/s + 60k/day)."""
+
+
+@dashboard_cmd.group("meetings", help="Dashboard meeting metrics.")
+def dashboard_meetings_cmd():
+    pass
+
+
+@dashboard_meetings_cmd.command("list", help="List meetings with metrics (paginated).")
+@click.option(
+    "--type",
+    "type_",
+    type=click.Choice(list(dashboard.ALLOWED_MEETING_METRIC_TYPES)),
+    default="past",
+    show_default=True,
+)
+@click.option("--from", "from_", required=True, metavar="YYYY-MM-DD")
+@click.option("--to", required=True, metavar="YYYY-MM-DD")
+@click.option(
+    "--page-size",
+    type=click.IntRange(1, 300),
+    default=300,
+    show_default=True,
+)
+@_translate_keyring_errors
+def dashboard_meetings_list(type_, from_, to, page_size):
+    """TSV: uuid\\tid\\ttopic\\thost\\tparticipants\\tduration\\tstart_time."""
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            click.echo("uuid\tid\ttopic\thost\tparticipants\tduration\tstart_time")
+            for m in dashboard.list_meetings(
+                client,
+                type=type_,
+                from_=from_,
+                to=to,
+                page_size=page_size,
+            ):
+                click.echo(
+                    f"{m.get('uuid', '')}\t"
+                    f"{m.get('id', '')}\t"
+                    f"{m.get('topic', '')}\t"
+                    f"{m.get('host', '')}\t"
+                    f"{m.get('participants', '')}\t"
+                    f"{m.get('duration', '')}\t"
+                    f"{m.get('start_time', '')}"
+                )
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+
+
+@dashboard_meetings_cmd.command("get", help="Print one meeting's dashboard metrics (JSON).")
+@click.argument("meeting_id")
+@_translate_keyring_errors
+def dashboard_meetings_get(meeting_id):
+    import json as _json
+
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            envelope = dashboard.get_meeting(client, meeting_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(_json.dumps(envelope, indent=2, sort_keys=True))
+
+
+@dashboard_meetings_cmd.command(
+    "participants",
+    help="List participant metrics for one meeting (paginated).",
+)
+@click.argument("meeting_id")
+@click.option(
+    "--type",
+    "type_",
+    type=click.Choice(list(dashboard.ALLOWED_MEETING_METRIC_TYPES)),
+    default="past",
+    show_default=True,
+)
+@click.option(
+    "--page-size",
+    type=click.IntRange(1, 300),
+    default=300,
+    show_default=True,
+)
+@_translate_keyring_errors
+def dashboard_meetings_participants(meeting_id, type_, page_size):
+    """TSV: id\\tuser_id\\tuser_name\\tjoin_time\\tleave_time\\tduration."""
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            click.echo("id\tuser_id\tuser_name\tjoin_time\tleave_time\tduration")
+            for p in dashboard.list_meeting_participants(
+                client, meeting_id, type=type_, page_size=page_size
+            ):
+                click.echo(
+                    f"{p.get('id', '')}\t"
+                    f"{p.get('user_id', '')}\t"
+                    f"{p.get('user_name', '')}\t"
+                    f"{p.get('join_time', '')}\t"
+                    f"{p.get('leave_time', '')}\t"
+                    f"{p.get('duration', '')}"
+                )
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+
+
+@dashboard_cmd.group("zoomrooms", help="Zoom Rooms dashboard metrics.")
+def dashboard_zoomrooms_cmd():
+    pass
+
+
+@dashboard_zoomrooms_cmd.command("list", help="List Zoom Rooms with metrics (paginated).")
+@click.option(
+    "--page-size",
+    type=click.IntRange(1, 300),
+    default=300,
+    show_default=True,
+)
+@_translate_keyring_errors
+def dashboard_zoomrooms_list(page_size):
+    """TSV: id\\troom_name\\tstatus\\tdevice_ip\\tlast_start_time."""
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            click.echo("id\troom_name\tstatus\tdevice_ip\tlast_start_time")
+            for r in dashboard.list_zoomrooms(client, page_size=page_size):
+                click.echo(
+                    f"{r.get('id', '')}\t"
+                    f"{r.get('room_name', '')}\t"
+                    f"{r.get('status', '')}\t"
+                    f"{r.get('device_ip', '')}\t"
+                    f"{r.get('last_start_time', '')}"
+                )
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+
+
+@dashboard_zoomrooms_cmd.command(
+    "get",
+    help="Print one Zoom Room's dashboard metrics (JSON).",
+)
+@click.argument("room_id")
+@_translate_keyring_errors
+def dashboard_zoomrooms_get(room_id):
+    import json as _json
+
+    creds = _load_creds_or_exit()
+    try:
+        with ApiClient(creds) as client:
+            envelope = dashboard.get_zoomroom(client, room_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(_json.dumps(envelope, indent=2, sort_keys=True))
 
 
 # ---- Zoom Reports ------------------------------------------------------

--- a/zoom_cli/api/dashboard.py
+++ b/zoom_cli/api/dashboard.py
@@ -1,0 +1,123 @@
+"""Zoom Dashboard / Metrics API helpers (closes #21).
+
+Reference: https://developers.zoom.us/docs/api/dashboards/
+
+Requires Business+ plan on the Zoom account. Helpers return raw JSON
+envelopes / yield items via the paginate() helper, like the other API
+modules. Tier classification: all ``/metrics/*`` paths sit on Zoom's
+HEAVY tier (40/s + 60,000/day) per the published rate-limit table.
+
+Endpoints covered:
+
+  list_meetings(client, *, type="past", from_, to, page_size=300)
+      → GET /metrics/meetings (paginated)
+
+  get_meeting(client, meeting_id) -> dict
+      → GET /metrics/meetings/{meeting_id}
+
+  list_meeting_participants(client, meeting_id, *, type="past",
+                            page_size=300)
+      → GET /metrics/meetings/{meeting_id}/participants (paginated)
+
+  list_zoomrooms(client, *, page_size=300) -> Iterator[dict]
+      → GET /metrics/zoomrooms (paginated)
+
+  get_zoomroom(client, room_id) -> dict
+      → GET /metrics/zoomrooms/{zoomroom_id}
+
+``type`` controls live-vs-past selection on the metrics endpoints:
+``past`` (default), ``live``, or ``pastOne``. Mirrors the Zoom enum.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from urllib.parse import quote
+
+from zoom_cli.api.client import ApiClient
+from zoom_cli.api.pagination import DEFAULT_PAGE_SIZE, paginate
+
+#: Allowed values for ``list_meetings(type=...)`` / ``list_meeting_participants``.
+ALLOWED_MEETING_METRIC_TYPES: tuple[str, ...] = ("past", "live", "pastOne")
+
+
+def list_meetings(
+    client: ApiClient,
+    *,
+    type: str = "past",
+    from_: str,
+    to: str,
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> Iterator[dict[str, Any]]:
+    """``GET /metrics/meetings`` — paginated dashboard meetings list.
+
+    ``from_`` and ``to`` are ISO-8601 dates and required by Zoom.
+    ``type`` is one of :data:`ALLOWED_MEETING_METRIC_TYPES`. Required
+    scopes: ``dashboard:read:list_meetings``.
+    """
+    if type not in ALLOWED_MEETING_METRIC_TYPES:
+        raise ValueError(f"type must be one of {ALLOWED_MEETING_METRIC_TYPES!r}, got {type!r}")
+    return paginate(
+        client,
+        "/metrics/meetings",
+        item_key="meetings",
+        params={"type": type, "from": from_, "to": to},
+        page_size=page_size,
+    )
+
+
+def get_meeting(client: ApiClient, meeting_id: str | int) -> dict[str, Any]:
+    """``GET /metrics/meetings/{meeting_id}`` — single meeting metrics.
+
+    URL-encodes the path segment (Zoom UUIDs sometimes contain ``/``).
+    Required scopes: ``dashboard:read:meeting``.
+    """
+    return client.get(f"/metrics/meetings/{quote(str(meeting_id), safe='')}")
+
+
+def list_meeting_participants(
+    client: ApiClient,
+    meeting_id: str | int,
+    *,
+    type: str = "past",
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> Iterator[dict[str, Any]]:
+    """``GET /metrics/meetings/{meeting_id}/participants`` — paginated.
+
+    Required scopes: ``dashboard:read:meeting_participant``.
+    """
+    if type not in ALLOWED_MEETING_METRIC_TYPES:
+        raise ValueError(f"type must be one of {ALLOWED_MEETING_METRIC_TYPES!r}, got {type!r}")
+    return paginate(
+        client,
+        f"/metrics/meetings/{quote(str(meeting_id), safe='')}/participants",
+        item_key="participants",
+        params={"type": type},
+        page_size=page_size,
+    )
+
+
+def list_zoomrooms(
+    client: ApiClient,
+    *,
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> Iterator[dict[str, Any]]:
+    """``GET /metrics/zoomrooms`` — paginated Zoom Rooms metrics list.
+
+    Required scopes: ``dashboard:read:list_zoomrooms``.
+    """
+    return paginate(
+        client,
+        "/metrics/zoomrooms",
+        item_key="zoom_rooms",
+        page_size=page_size,
+    )
+
+
+def get_zoomroom(client: ApiClient, room_id: str) -> dict[str, Any]:
+    """``GET /metrics/zoomrooms/{room_id}`` — single Zoom Room metrics.
+
+    Required scopes: ``dashboard:read:zoomroom``.
+    """
+    return client.get(f"/metrics/zoomrooms/{quote(room_id, safe='')}")

--- a/zoom_cli/api/rate_limit.py
+++ b/zoom_cli/api/rate_limit.py
@@ -119,6 +119,8 @@ _TIER_RULES: list[tuple[str, re.Pattern[str], Tier]] = [
     ("POST", re.compile(r"/chat/users/[^/]+/messages"), Tier.MEDIUM),
     # ---- Zoom Reports (#20) — all HEAVY per Zoom docs (40/s + 60k/day)
     ("GET", re.compile(r"/report/.*"), Tier.HEAVY),
+    # ---- Zoom Dashboard / Metrics (#21) — also HEAVY per Zoom docs
+    ("GET", re.compile(r"/metrics/.*"), Tier.HEAVY),
 ]
 
 #: Default tier for unmapped endpoints. MEDIUM matches Zoom's most-common


### PR DESCRIPTION
## Summary

Closes #21. Last phase-3 endpoint surface — the Zoom Dashboard / Metrics API for Business+ plans. Mirrors the Reports module shape from PR #63.

| Command | Endpoint | Tier |
|---|---|---|
| \`zoom dashboard meetings list\` | \`/metrics/meetings\` (paginated) | HEAVY |
| \`zoom dashboard meetings get <id>\` | \`/metrics/meetings/<id>\` | HEAVY |
| \`zoom dashboard meetings participants <id>\` | \`/metrics/meetings/<id>/participants\` (paginated) | HEAVY |
| \`zoom dashboard zoomrooms list\` | \`/metrics/zoomrooms\` (paginated) | HEAVY |
| \`zoom dashboard zoomrooms get <id>\` | \`/metrics/zoomrooms/<id>\` | HEAVY |

## What's new

### \`zoom_cli/api/dashboard.py\` (new)

\`\`\`python
ALLOWED_MEETING_METRIC_TYPES = ("past", "live", "pastOne")

list_meetings(client, *, type="past", from_, to, page_size=300) -> Iterator
get_meeting(client, meeting_id) -> dict
list_meeting_participants(client, meeting_id, *, type="past", page_size=300) -> Iterator
list_zoomrooms(client, *, page_size=300) -> Iterator
get_zoomroom(client, room_id) -> dict
\`\`\`

\`type\` is validated by both the API helper (\`raise ValueError\`) and the CLI (\`click.Choice\`). Path segments are URL-encoded — Zoom UUIDs sometimes contain \`/\`, so this is needed for correctness.

### Rate-limit tier mappings

\`\`\`
/metrics/.* (wildcard) → Tier.HEAVY (40/s + 60,000/day)
\`\`\`

Tests cover every endpoint plus an unmapped wildcard.

## Tests (+28 new)

| File | New | Covers |
|---|---|---|
| \`tests/test_api_dashboard.py\` | +14 | default type past; type forwarded + rejects bogus on both list_meetings and list_meeting_participants; pagination walk; URL-encoded UUIDs with slashes; zoomrooms list + get; ALLOWED_MEETING_METRIC_TYPES pinned |
| \`tests/test_rate_limit.py\` | +1 parametrized × 6 cases | every dashboard endpoint + unmapped wildcard → HEAVY |
| \`tests/test_cli.py\` | +8 | meetings list requires dates; TSV format; --type forwarding; rejects invalid --type; meetings get JSON; participants TSV; zoomrooms list TSV; zoomrooms get JSON |

## Verification

\`\`\`
ruff check .          # All checks passed!
ruff format --check . # 44 files already formatted
mypy                  # Success: no issues found in 20 source files
pytest -q             # 551 passed (was 523; +28)
\`\`\`

## Note: Dashboard API requires Business+ plan

The \`/metrics/*\` endpoints aren't available on Pro or lower-tier accounts. The CLI doesn't gate this client-side — the call to Zoom returns the standard \`ZoomApiError\` with a clear message. Documented in the module docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)