### PR TITLE
feat(api,cli): wire user-OAuth credentials into ApiClient (post-#12 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Zoom Phone API (PR #61): closes #18 (read-only piece). New `zoom phone users / call-logs / queues / recordings list/get` commands; `zoom_cli/api/phone.py`; tier mappings extended for `/phone/*` endpoints.
 > Zoom Team Chat API (PR #62): closes #19. New `zoom chat channels list` and `zoom chat messages send` commands; `zoom_cli/api/chat.py`.
 > Zoom Reports API (PR #63): closes #20. New `zoom reports daily / meetings list / meetings participants / operationlogs list` commands; `zoom_cli/api/reports.py`; tier mappings extended for `/report/*` (HEAVY tier).
-> Zoom Dashboard API (this branch): closes #21. New `zoom dashboard meetings list / get / participants` and `zoom dashboard zoomrooms list / get` commands; `zoom_cli/api/dashboard.py`; tier mappings extended for `/metrics/*` (HEAVY tier). Requires Business+ Zoom plan.
+> Zoom Dashboard API (PR #64): closes #21. New `zoom dashboard meetings list / get / participants` and `zoom dashboard zoomrooms list / get` commands; `zoom_cli/api/dashboard.py`; tier mappings extended for `/metrics/*` (HEAVY tier). Requires Business+ Zoom plan.
+> ApiClient user-OAuth integration (this branch): completes the user-OAuth story from #12. `ApiClient` now accepts either `S2SCredentials` or `UserOAuthCredentials`; the CLI prefers user-OAuth when both are configured.
+
+### Added (post-#12 follow-up)
+- `ApiClient(credentials, ..., on_user_token_rotated=...)` — `credentials` now accepts either `S2SCredentials` or `UserOAuthCredentials`. For user-OAuth, every refresh rotates the persisted refresh_token (Zoom invalidates the old one immediately), and the optional callback fires with the new credentials so the caller can persist them.
+- `_load_creds_or_exit()` (CLI) — resolves user-OAuth first, falls back to S2S, then exits with a friendly two-path message if neither is set.
+- `_build_api_client(creds)` (CLI) — wires `on_user_token_rotated=auth.save_user_oauth_credentials` automatically for user-OAuth credentials so rotated refresh tokens persist transactionally (mirrors the #35 pattern).
+- All 32 `ApiClient(creds)` call sites in `__main__.py` switched to `_build_api_client(creds)` so every API command (users, meetings, recordings, phone, chat, reports, dashboard) works with either auth surface.
+
+### Net effect
+After `zoom auth login --client-id ID`, every existing API command (`zoom users me`, `zoom meetings list`, etc.) Just Works with the user-OAuth refresh token. No more "user OAuth is configured but nothing uses it" gap.
 
 ### Added (issue #21)
 - `zoom_cli/api/dashboard.py` — `list_meetings(client, *, type, from_, to)`, `get_meeting(client, meeting_id)`, `list_meeting_participants(client, meeting_id, *, type)`, `list_zoomrooms(client)`, `get_zoomroom(client, room_id)`. `type` validated against `ALLOWED_MEETING_METRIC_TYPES = ("past", "live", "pastOne")`. URL-encodes meeting_id and room_id.

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -749,3 +749,138 @@ def test_apiclient_rate_limiter_acquires_before_send(
     # ApiClient passes the full path (including /v2) to the limiter;
     # tier_for() strips the version prefix before matching.
     assert captured == [("GET", "/v2/users/me")]
+
+
+# ---- ApiClient with UserOAuthCredentials --------------------------------
+
+
+def test_apiclient_with_user_oauth_creds_uses_refresh_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ApiClient routes to user_oauth.refresh_user_tokens when given
+    UserOAuthCredentials instead of S2SCredentials."""
+    from zoom_cli.api import user_oauth as uo
+    from zoom_cli.auth import UserOAuthCredentials
+
+    fetch_calls = {"n": 0}
+
+    def fake_refresh(*, refresh_token, client_id, http=None):
+        fetch_calls["n"] += 1
+        return uo.UserOAuthTokens(
+            access_token=f"acc-{fetch_calls['n']}",
+            refresh_token=f"rotated-refresh-{fetch_calls['n']}",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            scopes=("user:read",),
+        )
+
+    monkeypatch.setattr(uo, "refresh_user_tokens", fake_refresh)
+
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json={"id": "u-me"})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    user_creds = UserOAuthCredentials(refresh_token="initial-refresh", client_id="cid-X")
+    with ApiClient(user_creds, http_client=http) as c:
+        c.get("/users/me")
+
+    assert fetch_calls["n"] == 1
+    # The refreshed access token is what gets sent as Bearer.
+    assert captured["auth"] == "Bearer acc-1"
+
+
+def test_apiclient_with_user_oauth_creds_invokes_rotation_callback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Refresh tokens are rotated by Zoom — the callback must fire so the
+    caller can persist the new value (the old one is invalidated
+    immediately)."""
+    from zoom_cli.api import user_oauth as uo
+    from zoom_cli.auth import UserOAuthCredentials
+
+    def fake_refresh(*, refresh_token, client_id, http=None):
+        return uo.UserOAuthTokens(
+            access_token="acc",
+            refresh_token="ROTATED",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            scopes=(),
+        )
+
+    monkeypatch.setattr(uo, "refresh_user_tokens", fake_refresh)
+
+    rotated_calls: list[UserOAuthCredentials] = []
+
+    def on_rotated(new_creds):
+        rotated_calls.append(new_creds)
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    user_creds = UserOAuthCredentials(refresh_token="OLD", client_id="cid-X")
+    with ApiClient(user_creds, http_client=http, on_user_token_rotated=on_rotated) as c:
+        c.get("/users/me")
+
+    assert len(rotated_calls) == 1
+    assert rotated_calls[0].refresh_token == "ROTATED"
+    assert rotated_calls[0].client_id == "cid-X"
+
+
+def test_apiclient_user_oauth_401_retry_uses_fresh_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The 401 retry path force-refreshes the cached token; for user
+    OAuth that means calling refresh_user_tokens again (and re-rotating)."""
+    from zoom_cli.api import user_oauth as uo
+    from zoom_cli.auth import UserOAuthCredentials
+
+    refresh_calls = {"n": 0}
+
+    def fake_refresh(*, refresh_token, client_id, http=None):
+        refresh_calls["n"] += 1
+        return uo.UserOAuthTokens(
+            access_token=f"acc-{refresh_calls['n']}",
+            refresh_token=f"rot-{refresh_calls['n']}",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            scopes=(),
+        )
+
+    monkeypatch.setattr(uo, "refresh_user_tokens", fake_refresh)
+
+    request_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        request_count["n"] += 1
+        if request_count["n"] == 1:
+            return httpx.Response(401, json={"code": 124, "message": "expired"})
+        # Second attempt should use the fresh access token (acc-2).
+        assert request.headers["Authorization"] == "Bearer acc-2"
+        return httpx.Response(200, json={"id": "u-me"})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    user_creds = UserOAuthCredentials(refresh_token="initial", client_id="cid-X")
+    with ApiClient(user_creds, http_client=http) as c:
+        result = c.get("/users/me")
+
+    assert result == {"id": "u-me"}
+    assert refresh_calls["n"] == 2  # initial + force-refresh after 401
+    assert request_count["n"] == 2
+
+
+def test_apiclient_s2s_creds_path_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Existing S2S behaviour is not affected by the user-OAuth additions."""
+    monkeypatch.setattr(oauth, "fetch_access_token", lambda *_a, **_k: _fresh_token("s2s-tok"))
+
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json={})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler))
+    with ApiClient(_creds(), http_client=http) as c:
+        c.get("/users/me")
+
+    assert captured["auth"] == "Bearer s2s-tok"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2710,3 +2710,105 @@ def test_dashboard_zoomrooms_get_prints_json(
 
     parsed = _json.loads(result.output)
     assert parsed["id"] == "r-1"
+
+
+# ---- _load_creds_or_exit + _build_api_client (user-OAuth integration) ---
+
+
+def test_load_creds_prefers_user_oauth_when_both_configured(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When both auth surfaces are configured, user-OAuth wins. This is
+    the developer-friendly default — `zoom auth login` is the personal
+    flow, S2S is the org flow."""
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+    auth.save_user_oauth_credentials(
+        auth.UserOAuthCredentials(refresh_token="user-rt", client_id="user-cid")
+    )
+
+    captured = {"creds_type": None}
+
+    # `zoom users me` is the simplest path that exercises _load_creds_or_exit.
+    def fake_get_me(_client):
+        return {"id": "u-1", "email": "x@y", "display_name": "X"}
+
+    def fake_build(creds):
+        captured["creds_type"] = type(creds).__name__
+        # Return a fake client context manager — the test only cares which
+        # creds were chosen.
+        from contextlib import nullcontext
+
+        return nullcontext(enter_result=object())
+
+    monkeypatch.setattr(main_mod.users, "get_me", fake_get_me)
+    monkeypatch.setattr(main_mod, "_build_api_client", fake_build)
+
+    result = runner.invoke(main, ["users", "me"])
+    assert result.exit_code == 0, result.output
+    assert captured["creds_type"] == "UserOAuthCredentials"
+
+
+def test_load_creds_falls_back_to_s2s_when_only_s2s_configured(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+
+    auth.save_s2s_credentials(auth.S2SCredentials(account_id="a", client_id="b", client_secret="c"))
+
+    captured = {"creds_type": None}
+
+    def fake_get_me(_client):
+        return {"id": "u-1", "email": "x@y"}
+
+    def fake_build(creds):
+        captured["creds_type"] = type(creds).__name__
+        from contextlib import nullcontext
+
+        return nullcontext(enter_result=object())
+
+    monkeypatch.setattr(main_mod.users, "get_me", fake_get_me)
+    monkeypatch.setattr(main_mod, "_build_api_client", fake_build)
+
+    result = runner.invoke(main, ["users", "me"])
+    assert result.exit_code == 0, result.output
+    assert captured["creds_type"] == "S2SCredentials"
+
+
+def test_load_creds_friendly_message_when_neither_configured(runner: CliRunner) -> None:
+    """No auth configured at all → mention BOTH setup paths."""
+    result = runner.invoke(main, ["users", "me"])
+    assert result.exit_code == 1
+    assert "zoom auth s2s set" in result.output
+    assert "zoom auth login" in result.output
+
+
+def test_build_api_client_wires_rotation_callback_for_user_oauth() -> None:
+    """_build_api_client should pass on_user_token_rotated for user-OAuth
+    creds so rotated refresh tokens get persisted."""
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+
+    user_creds = auth.UserOAuthCredentials(refresh_token="rt", client_id="cid")
+    client = main_mod._build_api_client(user_creds)
+    try:
+        # The callback should be auth.save_user_oauth_credentials.
+        assert client._on_user_token_rotated is auth.save_user_oauth_credentials
+    finally:
+        client.close()
+
+
+def test_build_api_client_no_callback_for_s2s() -> None:
+    """S2S doesn't have rotation; on_user_token_rotated should stay None."""
+    import zoom_cli.__main__ as main_mod
+    from zoom_cli import auth
+
+    s2s = auth.S2SCredentials(account_id="a", client_id="b", client_secret="c")
+    client = main_mod._build_api_client(s2s)
+    try:
+        assert client._on_user_token_rotated is None
+    finally:
+        client.close()

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -443,12 +443,47 @@ def _print_user_profile(profile: dict) -> None:
 
 
 def _load_creds_or_exit():
-    """Load S2S creds, exit cleanly with a friendly message if not configured."""
-    creds = auth.load_s2s_credentials()
-    if creds is None:
-        click.echo("No Server-to-Server OAuth credentials saved. Run `zoom auth s2s set` first.")
-        raise click.exceptions.Exit(code=1)
-    return creds
+    """Load credentials for an API call; preferring user-OAuth when configured.
+
+    Resolution order (newer auth surfaces win):
+      1. User-OAuth (``zoom auth login`` / PKCE) — preferred when set.
+      2. S2S OAuth (``zoom auth s2s set``) — the original flow.
+      3. Neither → exit 1 with a friendly message pointing at both
+         setup commands.
+
+    Backward compat: if a CLI command tests for the legacy "No Server-
+    to-Server OAuth credentials saved" message, it'll still match for
+    the no-creds-at-all case (the message starts with that line).
+    """
+    user_creds = auth.load_user_oauth_credentials()
+    if user_creds is not None:
+        return user_creds
+    s2s_creds = auth.load_s2s_credentials()
+    if s2s_creds is not None:
+        return s2s_creds
+    click.echo(
+        "No Server-to-Server OAuth credentials saved. Run one of:\n"
+        "  zoom auth s2s set                       # Server-to-Server OAuth\n"
+        "  zoom auth login --client-id ID          # 3-legged user OAuth"
+    )
+    raise click.exceptions.Exit(code=1)
+
+
+def _build_api_client(creds):
+    """Construct an ``ApiClient`` with the right callbacks for the cred type.
+
+    For user-OAuth credentials, every refresh rotates the persisted
+    refresh_token (Zoom invalidates the old one immediately), so we pass
+    a callback that writes the new value back to the keyring
+    transactionally (mirrors the #35 rollback pattern) — without it,
+    the next CLI invocation would have a dead refresh_token.
+    """
+    if isinstance(creds, auth.UserOAuthCredentials):
+        return ApiClient(
+            creds,
+            on_user_token_rotated=auth.save_user_oauth_credentials,
+        )
+    return ApiClient(creds)
 
 
 def _exit_on_api_error(exc: Exception) -> None:
@@ -477,7 +512,7 @@ def _exit_on_api_error(exc: Exception) -> None:
 def users_me():
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             profile = users.get_me(client)
     except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
         _exit_on_api_error(exc)
@@ -493,7 +528,7 @@ def users_get(user_id):
     follow-up that needs separate confirmation-flow design."""
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             profile = users.get_user(client, user_id)
     except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
         _exit_on_api_error(exc)
@@ -525,7 +560,7 @@ def users_list(status, page_size):
     PR #48 / issue #16."""
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             click.echo("user_id\temail\ttype\tstatus")
             for user in users.list_users(client, status=status, page_size=page_size):
                 click.echo(
@@ -579,7 +614,7 @@ def meetings_get(meeting_id):
     that needs separate confirmation-flow design."""
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             meeting = meetings.get_meeting(client, meeting_id)
     except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
         _exit_on_api_error(exc)
@@ -617,7 +652,7 @@ def meetings_list(user_id, meeting_type, page_size):
     (PR #48 / #16). Closes #13 (read-only piece)."""
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             click.echo("id\ttopic\ttype\tstart_time\tduration")
             for meeting in meetings.list_meetings(
                 client,
@@ -687,7 +722,7 @@ def users_create(email, user_type, first_name, last_name, display_name, password
 
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             created = users.create_user(client, user_info, action=action)
     except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
         _exit_on_api_error(exc)
@@ -773,7 +808,7 @@ def users_delete(
 
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             users.delete_user(
                 client,
                 user_id,
@@ -811,7 +846,7 @@ def users_settings_get(user_id):
 
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             settings = users.get_user_settings(client, user_id)
     except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
         _exit_on_api_error(exc)
@@ -901,7 +936,7 @@ def meetings_create(topic, meeting_type, start_time, duration, tz, password, age
     )
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             created = meetings.create_meeting(client, payload, user_id=user_id)
     except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
         _exit_on_api_error(exc)
@@ -940,7 +975,7 @@ def meetings_update(meeting_id, topic, meeting_type, start_time, duration, tz, p
         raise click.exceptions.Exit(code=1)
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             meetings.update_meeting(client, meeting_id, payload)
     except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
         _exit_on_api_error(exc)
@@ -992,7 +1027,7 @@ def meetings_delete(meeting_id, yes, dry_run, notify_host, notify_registrants):
 
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             meetings.delete_meeting(
                 client,
                 meeting_id,
@@ -1028,7 +1063,7 @@ def meetings_end(meeting_id, yes):
 
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             meetings.end_meeting(client, meeting_id)
     except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
         _exit_on_api_error(exc)
@@ -1083,7 +1118,7 @@ def recordings_list(user_id, from_, to, page_size):
     so it pipes into cut/awk/column."""
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             click.echo("uuid\tmeeting_id\ttopic\tstart_time\tfile_count")
             for meeting in recordings.list_recordings(
                 client,
@@ -1116,7 +1151,7 @@ def recordings_get(meeting_id):
 
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             envelope = recordings.get_recordings(client, meeting_id)
     except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
         _exit_on_api_error(exc)
@@ -1160,7 +1195,7 @@ def recordings_download(meeting_id, out_dir, file_type):
 
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             envelope = recordings.get_recordings(client, meeting_id)
             files = envelope.get("recording_files", []) or []
             if type_filter is not None:
@@ -1237,7 +1272,7 @@ def recordings_delete(meeting_id, file_id, action, yes, dry_run):
 
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             if file_id:
                 recordings.delete_recording_file(client, meeting_id, file_id, action=action)
             else:
@@ -1289,7 +1324,7 @@ def dashboard_meetings_list(type_, from_, to, page_size):
     """TSV: uuid\\tid\\ttopic\\thost\\tparticipants\\tduration\\tstart_time."""
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             click.echo("uuid\tid\ttopic\thost\tparticipants\tduration\tstart_time")
             for m in dashboard.list_meetings(
                 client,
@@ -1319,7 +1354,7 @@ def dashboard_meetings_get(meeting_id):
 
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             envelope = dashboard.get_meeting(client, meeting_id)
     except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
         _exit_on_api_error(exc)
@@ -1349,7 +1384,7 @@ def dashboard_meetings_participants(meeting_id, type_, page_size):
     """TSV: id\\tuser_id\\tuser_name\\tjoin_time\\tleave_time\\tduration."""
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             click.echo("id\tuser_id\tuser_name\tjoin_time\tleave_time\tduration")
             for p in dashboard.list_meeting_participants(
                 client, meeting_id, type=type_, page_size=page_size
@@ -1383,7 +1418,7 @@ def dashboard_zoomrooms_list(page_size):
     """TSV: id\\troom_name\\tstatus\\tdevice_ip\\tlast_start_time."""
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             click.echo("id\troom_name\tstatus\tdevice_ip\tlast_start_time")
             for r in dashboard.list_zoomrooms(client, page_size=page_size):
                 click.echo(
@@ -1408,7 +1443,7 @@ def dashboard_zoomrooms_get(room_id):
 
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             envelope = dashboard.get_zoomroom(client, room_id)
     except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
         _exit_on_api_error(exc)
@@ -1441,7 +1476,7 @@ def reports_daily(year, month):
 
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             envelope = reports.get_daily(client, year=year, month=month)
     except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
         _exit_on_api_error(exc)
@@ -1481,7 +1516,7 @@ def reports_meetings_list(user_id, from_, to, meeting_type, page_size):
     """TSV: uuid\\tid\\ttopic\\tuser_email\\tstart_time\\tduration\\tparticipants_count."""
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             click.echo("uuid\tid\ttopic\tuser_email\tstart_time\tduration\tparticipants_count")
             for m in reports.list_meetings_report(
                 client,
@@ -1520,7 +1555,7 @@ def reports_meetings_participants(meeting_id, page_size):
     """TSV: id\\tname\\tuser_email\\tjoin_time\\tleave_time\\tduration."""
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             click.echo("id\tname\tuser_email\tjoin_time\tleave_time\tduration")
             for p in reports.list_meeting_participants(client, meeting_id, page_size=page_size):
                 click.echo(
@@ -1558,7 +1593,7 @@ def reports_operationlogs_list(from_, to, category_type, page_size):
     """TSV: time\\toperator\\tcategory_type\\taction\\toperation_detail."""
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             click.echo("time\toperator\tcategory_type\taction\toperation_detail")
             for entry in reports.list_operation_logs(
                 client,
@@ -1613,7 +1648,7 @@ def chat_channels_list(user_id, page_size):
     """TSV: id\\tname\\ttype\\tchannel_settings.posting_permissions."""
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             click.echo("id\tname\ttype")
             for ch in chat.list_channels(client, user_id=user_id, page_size=page_size):
                 click.echo(f"{ch.get('id', '')}\t{ch.get('name', '')}\t{ch.get('type', '')}")
@@ -1657,7 +1692,7 @@ def chat_messages_send(message_text, to_channel, to_contact, user_id, reply_main
 
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             result = chat.send_message(
                 client,
                 message=message_text,
@@ -1700,7 +1735,7 @@ def phone_users_list(page_size):
     """TSV: id\\temail\\textension_number\\tstatus."""
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             click.echo("id\temail\textension_number\tstatus")
             for u in phone.list_phone_users(client, page_size=page_size):
                 click.echo(
@@ -1721,7 +1756,7 @@ def phone_users_get(user_id):
 
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             profile = phone.get_phone_user(client, user_id)
     except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
         _exit_on_api_error(exc)
@@ -1752,7 +1787,7 @@ def phone_call_logs_list(user_id, from_, to, page_size):
     """TSV: id\\tdirection\\tcaller_number\\tcallee_number\\tstart_time\\tduration."""
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             click.echo("id\tdirection\tcaller_number\tcallee_number\tstart_time\tduration")
             for entry in phone.list_call_logs(
                 client,
@@ -1790,7 +1825,7 @@ def phone_queues_list(page_size):
     """TSV: id\\tname\\textension_number\\tsite_name."""
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             click.echo("id\tname\textension_number\tsite_name")
             for q in phone.list_call_queues(client, page_size=page_size):
                 click.echo(
@@ -1827,7 +1862,7 @@ def phone_recordings_list(user_id, from_, to, page_size):
     """TSV: id\\tcaller_number\\tcallee_number\\tdate_time\\tduration."""
     creds = _load_creds_or_exit()
     try:
-        with ApiClient(creds) as client:
+        with _build_api_client(creds) as client:
             click.echo("id\tcaller_number\tcallee_number\tdate_time\tduration")
             for r in phone.list_phone_recordings(
                 client,

--- a/zoom_cli/api/client.py
+++ b/zoom_cli/api/client.py
@@ -36,9 +36,9 @@ from typing import Any
 
 import httpx
 
-from zoom_cli.api import oauth
+from zoom_cli.api import oauth, user_oauth
 from zoom_cli.api.rate_limit import RateLimiter
-from zoom_cli.auth import S2SCredentials
+from zoom_cli.auth import S2SCredentials, UserOAuthCredentials
 
 #: Zoom REST API base URL. All paths are relative to this.
 API_BASE_URL = "https://api.zoom.us/v2"
@@ -128,28 +128,40 @@ class ApiClient:
 
     def __init__(
         self,
-        credentials: S2SCredentials,
+        credentials: S2SCredentials | UserOAuthCredentials,
         *,
         http_client: httpx.Client | None = None,
         timeout: float = DEFAULT_TIMEOUT_SECONDS,
         rate_limiter: RateLimiter | None = None,
+        on_user_token_rotated: Any = None,
     ) -> None:
         """Construct an ApiClient.
 
-        ``rate_limiter`` (closes #49): if set, ``acquire(method, url)`` is
-        called before every request to throttle against Zoom's per-tier
-        per-account limits. Default ``None`` = no proactive limiting; the
-        429/Retry-After backoff from #16 still catches reactive
-        throttling. Pass an instance for batch / long-running automation:
+        Accepts either S2S or user-OAuth credentials — the auth flow
+        chooses itself based on the type passed in.
 
-            from zoom_cli.api.rate_limit import RateLimiter
-            client = ApiClient(creds, rate_limiter=RateLimiter())
+          - :class:`~zoom_cli.auth.S2SCredentials` → standard S2S
+            ``account_credentials`` token exchange.
+          - :class:`~zoom_cli.auth.UserOAuthCredentials` → uses the
+            persisted refresh_token to mint access tokens via
+            :func:`zoom_cli.api.user_oauth.refresh_user_tokens`. Zoom
+            **rotates** the refresh_token on every refresh (~14-day
+            lifetime), so ``on_user_token_rotated(new_creds)`` is
+            invoked after every successful refresh — the CLI hooks
+            this to persist the rotated value back to the OS keyring
+            via :func:`zoom_cli.auth.save_user_oauth_credentials`.
+
+        ``rate_limiter`` (closes #49): if set, ``acquire(method, url)``
+        is called before every request to throttle against Zoom's
+        per-tier per-account limits.
         """
         self._credentials = credentials
         self._owns_client = http_client is None
         self._http = http_client if http_client is not None else httpx.Client(timeout=timeout)
         self._cached_token: oauth.AccessToken | None = None
         self._rate_limiter = rate_limiter
+        # User-OAuth specific: callback to persist rotated refresh tokens.
+        self._on_user_token_rotated = on_user_token_rotated
 
     # ---- context-manager hooks ---------------------------------------
 
@@ -176,10 +188,39 @@ class ApiClient:
         ``force_refresh=True`` is used by the 401 retry path: even if the
         cached token *thinks* it's still valid, the server has told us
         otherwise, so we drop the cache and re-fetch.
+
+        Routes to S2S or user-OAuth refresh based on the credentials
+        type. User-OAuth refresh ALWAYS rotates the refresh_token and
+        invokes ``on_user_token_rotated`` so the caller can persist the
+        new value (Zoom invalidates the old refresh_token immediately).
         """
         if force_refresh:
             self._cached_token = None
-        if self._cached_token is None or self._cached_token.is_expired:
+        if self._cached_token is not None and not self._cached_token.is_expired:
+            return self._cached_token
+
+        if isinstance(self._credentials, UserOAuthCredentials):
+            tokens = user_oauth.refresh_user_tokens(
+                refresh_token=self._credentials.refresh_token,
+                client_id=self._credentials.client_id,
+                http=self._http,
+            )
+            # Refresh tokens are rotated — the new value invalidates the
+            # old, so persisting immediately is critical for the next
+            # session. Update our in-memory creds and notify the caller.
+            new_creds = UserOAuthCredentials(
+                refresh_token=tokens.refresh_token,
+                client_id=self._credentials.client_id,
+            )
+            self._credentials = new_creds
+            if self._on_user_token_rotated is not None:
+                self._on_user_token_rotated(new_creds)
+            self._cached_token = oauth.AccessToken(
+                value=tokens.access_token,
+                expires_at=tokens.expires_at,
+                scopes=tokens.scopes,
+            )
+        else:
             self._cached_token = oauth.fetch_access_token(self._credentials, client=self._http)
         return self._cached_token
 


### PR DESCRIPTION
## Summary

Completes the user-OAuth story from #12. PR #55 landed \`zoom auth login\` and persisted the refresh token, but no API command actually used it — every \`with ApiClient(creds) as client\` hardcoded S2S. This wires it through end-to-end.

After this PR: \`zoom auth login --client-id ID\` → every existing API command (\`zoom users me\`, \`zoom meetings list\`, \`zoom recordings download\`, etc.) Just Works with the user-OAuth refresh token.

## What's new

### \`zoom_cli/api/client.py\`

\`ApiClient.__init__\` now accepts \`credentials: S2SCredentials | UserOAuthCredentials\` plus an optional \`on_user_token_rotated\` callback.

\`_access_token()\` routes by credentials type. For user-OAuth, every refresh:

1. Calls \`user_oauth.refresh_user_tokens(refresh_token, client_id)\`
2. Receives a new access_token **and a rotated refresh_token** (Zoom invalidates the old one immediately)
3. Updates \`self._credentials\` with the new refresh_token
4. Invokes \`on_user_token_rotated(new_creds)\` so the caller persists the rotated value to the keyring

The 401 force-refresh path from PR #47 still works — a 401 on a user-OAuth request triggers a fresh \`refresh_user_tokens\` call (and re-rotates).

### \`zoom_cli/__main__.py\`

\`_load_creds_or_exit()\` resolves in this order:

1. **User-OAuth** (preferred — \`zoom auth login\` is the personal flow)
2. **S2S**
3. **Neither** → friendly two-path error mentioning both \`zoom auth s2s set\` and \`zoom auth login\`

\`_build_api_client(creds)\` factory wires \`on_user_token_rotated=auth.save_user_oauth_credentials\` for user-OAuth so rotation persists transactionally. All 32 \`with ApiClient(creds) as client:\` call sites switched to \`with _build_api_client(creds) as client:\` via a single bulk replacement.

## Tests (+9 new)

| File | New | Covers |
|---|---|---|
| \`tests/test_api_client.py\` | +4 | ApiClient w/ UserOAuthCredentials uses refresh_user_tokens; rotation callback fires with new refresh; 401 retry calls refresh_user_tokens again (re-rotates); S2S path unchanged |
| \`tests/test_cli.py\` | +5 | _load_creds_or_exit prefers user-OAuth; falls back to S2S when only S2S; friendly message when neither configured; _build_api_client wires save_user_oauth_credentials for user-OAuth; leaves it None for S2S |

## Verification

\`\`\`
ruff check .          # All checks passed!
ruff format --check . # 44 files already formatted
mypy                  # Success: no issues found in 20 source files
pytest -q             # 560 passed (was 551; +9)
\`\`\`

## Out of scope (still deferred from #12)

- **Auto-refresh on near-expiry without a 401** — currently we refresh when \`is_expired\` (with the 60s skew from #47). Long-running scripts that hold the client past 1 hour will refresh naturally on the next call; explicit periodic refresh is not needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)