### PR TITLE
feat(webhooks): enforce X-Zm-Request-Timestamp skew window (post-#17 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Zoom Team Chat API (PR #62): closes #19. New `zoom chat channels list` and `zoom chat messages send` commands; `zoom_cli/api/chat.py`.
 > Zoom Reports API (PR #63): closes #20. New `zoom reports daily / meetings list / meetings participants / operationlogs list` commands; `zoom_cli/api/reports.py`; tier mappings extended for `/report/*` (HEAVY tier).
 > Zoom Dashboard API (PR #64): closes #21. New `zoom dashboard meetings list / get / participants` and `zoom dashboard zoomrooms list / get` commands; `zoom_cli/api/dashboard.py`; tier mappings extended for `/metrics/*` (HEAVY tier). Requires Business+ Zoom plan.
-> ApiClient user-OAuth integration (this branch): completes the user-OAuth story from #12. `ApiClient` now accepts either `S2SCredentials` or `UserOAuthCredentials`; the CLI prefers user-OAuth when both are configured.
+> ApiClient user-OAuth integration (PR #65): completes the user-OAuth story from #12. `ApiClient` now accepts either `S2SCredentials` or `UserOAuthCredentials`; the CLI prefers user-OAuth when both are configured.
+> Webhook timestamp-skew enforcement (this branch): closes the deferred replay-protection piece from #17. `MAX_TIMESTAMP_SKEW_SECONDS = 300` is now actually enforced — old / future-dated deliveries are rejected with 401 even if the signature verifies.
+
+### Added (post-#17 follow-up)
+- `webhook.is_timestamp_within_skew(timestamp_str, *, max_skew_seconds, now_ms)` — pure helper. Symmetric ±300s default window (rejects old replays AND future-dated spoofs); malformed / missing timestamps return False. Injectable `now_ms` for tests; defaults to `time.time() * 1000`.
+- `_make_handler(..., now_ms=None, max_skew_seconds=300)` — handler accepts injectable clock + skew so tests can pin time and bypass the wall clock.
+- Webhook handler now runs the timestamp-skew check **before** the signature check (parse failures and ancient timestamps are cheaper to reject than HMAC). All three rejection paths emit a stderr line for debugging.
+
+### Why this matters (security)
+Signature alone proves a `(body, timestamp)` pair was signed by someone with the secret — it does **not** prove the delivery is recent. Without timestamp enforcement, an attacker who captured an old signed delivery could replay it indefinitely. The ±300s window matches Zoom's documented tolerance.
 
 ### Added (post-#12 follow-up)
 - `ApiClient(credentials, ..., on_user_token_rotated=...)` — `credentials` now accepts either `S2SCredentials` or `UserOAuthCredentials`. For user-OAuth, every refresh rotates the persisted refresh_token (Zoom invalidates the old one immediately), and the optional callback fires with the new credentials so the caller can persist them.

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -107,16 +107,28 @@ def _free_port() -> int:
         s.close()
 
 
+#: Fixed pinned-time used by the webhook_server fixture so signed-event
+#: tests don't have to compute "now" each run. Choose any value within
+#: the skew window when generating test signatures.
+PINNED_NOW_MS = 1_745_000_000_000  # ~2025-04-18T15:33:20Z
+
+
 @pytest.fixture
 def webhook_server():
     """Spin up a real ``HTTPServer`` on an ephemeral loopback port and
-    yield (port, captured_events) for the test. Server thread is shut
-    down on teardown."""
+    yield (port, captured_events) for the test. The handler's clock is
+    pinned to :data:`PINNED_NOW_MS` so tests can use a fixed timestamp
+    that always sits inside the skew window, regardless of when CI runs.
+    Server thread is shut down on teardown."""
     from http.server import HTTPServer
 
     captured: list[dict] = []
     secret = "test-secret"
-    handler_cls = webhook._make_handler(secret, sink=captured.append)
+    handler_cls = webhook._make_handler(
+        secret,
+        sink=captured.append,
+        now_ms=lambda: PINNED_NOW_MS,
+    )
 
     port = _free_port()
     server = HTTPServer(("127.0.0.1", port), handler_cls)
@@ -164,7 +176,8 @@ def test_handler_responds_to_url_validation_handshake(webhook_server) -> None:
 def test_handler_accepts_valid_signed_event(webhook_server) -> None:
     secret, port, captured = webhook_server
     body = json.dumps({"event": "meeting.started", "payload": {"foo": "bar"}}).encode()
-    timestamp = "1660157595650"
+    # Inside the skew window relative to PINNED_NOW_MS.
+    timestamp = str(PINNED_NOW_MS)
     sig = webhook.compute_signature(secret, timestamp, body)
 
     status, _ = _post(
@@ -181,11 +194,13 @@ def test_handler_accepts_valid_signed_event(webhook_server) -> None:
 def test_handler_rejects_invalid_signature(webhook_server) -> None:
     _secret, port, captured = webhook_server
     body = b'{"event":"meeting.started","payload":{}}'
+    # Pass a timestamp inside the skew window so we exercise the
+    # signature-rejection path, not the timestamp-rejection path.
     status, response = _post(
         port,
         body,
         headers={
-            "X-Zm-Request-Timestamp": "1234",
+            "X-Zm-Request-Timestamp": str(PINNED_NOW_MS),
             "X-Zm-Signature": "v0=" + "0" * 64,  # wrong hex
         },
     )
@@ -216,10 +231,11 @@ def test_handler_rejects_invalid_json_body(webhook_server) -> None:
 def test_handler_rejects_tampered_body_after_signature(webhook_server) -> None:
     """Sign one body, send a different one — must be rejected. Pins the
     integrity guarantee against a man-in-the-middle who changes the body
-    in flight."""
+    in flight. Uses a timestamp inside the skew window so we exercise
+    the signature-mismatch path, not timestamp rejection."""
     secret, port, captured = webhook_server
     original = b'{"event":"meeting.started","payload":{"foo":"bar"}}'
-    timestamp = "1234"
+    timestamp = str(PINNED_NOW_MS)
     sig = webhook.compute_signature(secret, timestamp, original)
 
     # Send a different body with the original signature.
@@ -232,3 +248,110 @@ def test_handler_rejects_tampered_body_after_signature(webhook_server) -> None:
 
     assert status == 401
     assert captured == []
+
+
+# ---- timestamp skew enforcement (replay protection) ---------------------
+
+
+def test_is_timestamp_within_skew_accepts_now() -> None:
+    """A timestamp matching `now_ms` exactly is in-window."""
+    now = 1_745_000_000_000
+    assert webhook.is_timestamp_within_skew(str(now), now_ms=now) is True
+
+
+def test_is_timestamp_within_skew_accepts_inside_window() -> None:
+    """Both directions: 100s past, 100s future — both inside ±300s."""
+    now = 1_745_000_000_000
+    past = now - 100_000  # 100s ago
+    future = now + 100_000  # 100s in the future
+    assert webhook.is_timestamp_within_skew(str(past), now_ms=now) is True
+    assert webhook.is_timestamp_within_skew(str(future), now_ms=now) is True
+
+
+def test_is_timestamp_within_skew_rejects_old_outside_window() -> None:
+    """A timestamp 5 minutes + 1s old is outside the default ±300s window."""
+    now = 1_745_000_000_000
+    too_old = now - (301 * 1000)
+    assert webhook.is_timestamp_within_skew(str(too_old), now_ms=now) is False
+
+
+def test_is_timestamp_within_skew_rejects_future_outside_window() -> None:
+    """Symmetric upper bound — protects against client clock-spoofing too."""
+    now = 1_745_000_000_000
+    too_future = now + (301 * 1000)
+    assert webhook.is_timestamp_within_skew(str(too_future), now_ms=now) is False
+
+
+def test_is_timestamp_within_skew_rejects_malformed() -> None:
+    now = 1_745_000_000_000
+    assert webhook.is_timestamp_within_skew("not a number", now_ms=now) is False
+    assert webhook.is_timestamp_within_skew("", now_ms=now) is False
+    assert webhook.is_timestamp_within_skew("12.34.56", now_ms=now) is False
+
+
+def test_is_timestamp_within_skew_respects_max_skew_seconds() -> None:
+    """Caller can tighten or loosen the bound for tests / specific apps."""
+    now = 1_745_000_000_000
+    ts = str(now - 60_000)  # 60s old
+    assert webhook.is_timestamp_within_skew(ts, max_skew_seconds=30, now_ms=now) is False
+    assert webhook.is_timestamp_within_skew(ts, max_skew_seconds=120, now_ms=now) is True
+
+
+def test_handler_rejects_replayed_old_timestamp(webhook_server) -> None:
+    """Even with a perfectly valid signature, a stale timestamp is
+    rejected — closes the replay-attack window beyond what the
+    signature alone protects against."""
+    secret, port, captured = webhook_server
+    body = b'{"event":"meeting.started","payload":{}}'
+    # 10 minutes before PINNED_NOW_MS = way outside ±300s.
+    old_timestamp = str(PINNED_NOW_MS - 600_000)
+    sig = webhook.compute_signature(secret, old_timestamp, body)
+
+    status, response = _post(
+        port,
+        body,
+        headers={"X-Zm-Request-Timestamp": old_timestamp, "X-Zm-Signature": sig},
+    )
+
+    assert status == 401
+    assert b"timestamp outside acceptable skew" in response
+    assert captured == []  # sink never invoked on rejected events
+
+
+def test_handler_rejects_future_timestamp(webhook_server) -> None:
+    """Symmetric upper bound: a timestamp in the future is rejected too,
+    so a misconfigured / spoofed client can't pre-date deliveries to
+    bypass detection."""
+    secret, port, _captured = webhook_server
+    body = b'{"event":"meeting.started","payload":{}}'
+    future_timestamp = str(PINNED_NOW_MS + 600_000)  # 10 minutes future
+    sig = webhook.compute_signature(secret, future_timestamp, body)
+
+    status, response = _post(
+        port,
+        body,
+        headers={"X-Zm-Request-Timestamp": future_timestamp, "X-Zm-Signature": sig},
+    )
+
+    assert status == 401
+    assert b"timestamp outside acceptable skew" in response
+
+
+def test_handler_rejects_malformed_timestamp(webhook_server) -> None:
+    secret, port, _captured = webhook_server
+    body = b'{"event":"meeting.started","payload":{}}'
+    # Sign with a junk timestamp; even though signature would verify,
+    # the timestamp parse fails and we reject before signature check.
+    sig = webhook.compute_signature(secret, "not-a-timestamp", body)
+
+    status, response = _post(
+        port,
+        body,
+        headers={
+            "X-Zm-Request-Timestamp": "not-a-timestamp",
+            "X-Zm-Signature": sig,
+        },
+    )
+
+    assert status == 401
+    assert b"timestamp outside acceptable skew" in response

--- a/zoom_cli/api/webhook.py
+++ b/zoom_cli/api/webhook.py
@@ -39,6 +39,7 @@ import hashlib
 import hmac
 import json
 import sys
+import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any
 
@@ -81,6 +82,36 @@ def verify_signature(
     return hmac.compare_digest(expected, signature)
 
 
+def is_timestamp_within_skew(
+    timestamp_str: str,
+    *,
+    max_skew_seconds: int = MAX_TIMESTAMP_SKEW_SECONDS,
+    now_ms: int | None = None,
+) -> bool:
+    """Return ``True`` if ``timestamp_str`` is within ``max_skew_seconds``
+    of the current wall clock (in either direction).
+
+    Zoom sends the timestamp as a millisecond Unix epoch string. Both
+    ancient timestamps (replay attacks) and far-future timestamps
+    (clock-skew or client-side spoofing) are rejected — symmetric
+    bounds keep the check simple and the failure mode obvious.
+
+    Malformed or missing timestamps return ``False`` (the handler
+    treats this as "rejected").
+
+    ``now_ms`` is injectable for tests; defaults to ``time.time() * 1000``.
+    """
+    if not timestamp_str:
+        return False
+    try:
+        ts_ms = int(timestamp_str)
+    except (TypeError, ValueError):
+        return False
+    current_ms = now_ms if now_ms is not None else int(time.time() * 1000)
+    skew_ms = max_skew_seconds * 1000
+    return abs(current_ms - ts_ms) <= skew_ms
+
+
 def compute_url_validation_response(secret_token: str, plain_token: str) -> dict[str, str]:
     """Build the response body for Zoom's endpoint.url_validation handshake.
 
@@ -95,10 +126,22 @@ def compute_url_validation_response(secret_token: str, plain_token: str) -> dict
     return {"plainToken": plain_token, "encryptedToken": digest}
 
 
-def _make_handler(secret_token: str, *, sink=None):
+def _make_handler(
+    secret_token: str,
+    *,
+    sink=None,
+    now_ms: Any = None,
+    max_skew_seconds: int = MAX_TIMESTAMP_SKEW_SECONDS,
+):
     """Build a :class:`BaseHTTPRequestHandler` subclass closed over
     ``secret_token``. ``sink`` is a callable taking the parsed event dict
     (default: dump as one-line JSON to stdout); useful for tests.
+
+    ``now_ms`` is an optional callable returning the current epoch
+    milliseconds — used by the timestamp-skew check. Tests inject a
+    fixed value; production leaves it ``None`` (uses ``time.time()``).
+    ``max_skew_seconds`` overrides :data:`MAX_TIMESTAMP_SKEW_SECONDS`
+    for tests that want a tighter or looser bound.
     """
     if sink is None:
 
@@ -136,6 +179,26 @@ def _make_handler(secret_token: str, *, sink=None):
             if not signature or not timestamp:
                 self._respond(401, b'{"error":"missing signature headers"}')
                 sys.stderr.write("webhook: rejected — missing signature headers\n")
+                return
+
+            # Timestamp-skew check (replay protection): even with a
+            # valid signature, reject deliveries whose timestamp is
+            # outside the ±MAX_TIMESTAMP_SKEW_SECONDS window. The
+            # signature alone proves a body+timestamp pair was signed
+            # by someone with the secret; it does NOT prove the
+            # delivery is recent. An attacker who replays an old
+            # signed delivery would otherwise pass.
+            current_ms = now_ms() if callable(now_ms) else now_ms
+            if not is_timestamp_within_skew(
+                timestamp,
+                max_skew_seconds=max_skew_seconds,
+                now_ms=current_ms,
+            ):
+                self._respond(401, b'{"error":"timestamp outside acceptable skew"}')
+                sys.stderr.write(
+                    f"webhook: rejected — timestamp {timestamp!r} outside "
+                    f"±{max_skew_seconds}s skew window\n"
+                )
                 return
 
             if not verify_signature(secret_token, timestamp, body, signature):


### PR DESCRIPTION
## Summary

PR #60 landed the HMAC verification + the pinned \`MAX_TIMESTAMP_SKEW_SECONDS = 300\` constant but never actually wired the skew check. Without it, an attacker who captured an old signed delivery could replay it indefinitely — signature alone proves the \`(body, timestamp)\` pair was signed by someone with the secret, **not** that the delivery is recent.

This PR enforces the ±300s window symmetrically (rejects both old replays and future-dated spoofs).

## What's new

### \`zoom_cli/api/webhook.py\`

\`\`\`python
def is_timestamp_within_skew(
    timestamp_str: str,
    *,
    max_skew_seconds: int = MAX_TIMESTAMP_SKEW_SECONDS,
    now_ms: int | None = None,
) -> bool
\`\`\`

Pure helper, symmetric bounds, malformed → False, injectable clock for tests.

\`_make_handler\` accepts \`now_ms\` (callable returning epoch ms) and \`max_skew_seconds\` so tests can pin time.

The handler's rejection order:

1. invalid JSON body → 400
2. \`endpoint.url_validation\` handshake (special) → 200
3. missing signature headers → 401
4. **timestamp outside skew → 401** ← new
5. invalid signature → 401
6. signed + within-window → 200 + sink

The skew check runs **before** HMAC because it's cheap (parse + arithmetic) and HMAC is not.

## Tests (+9 new, 3 existing updated)

| What | Coverage |
|---|---|
| New: pure helper | now-exact + inside ±300 (past + future); rejects 301s old; rejects 301s future; rejects malformed (3 vectors); respects custom \`max_skew_seconds\` |
| New: handler integration | rejects replayed-old with 401 + sink not invoked; rejects future-dated timestamp; rejects malformed timestamp (parse fails before HMAC) |
| Updated existing | \`test_handler_accepts_valid_signed_event\`, \`test_handler_rejects_invalid_signature\`, \`test_handler_rejects_tampered_body_after_signature\` now use \`PINNED_NOW_MS\` so they exercise the intended rejection path. The \`webhook_server\` fixture pins the handler clock to \`PINNED_NOW_MS = 1_745_000_000_000\` (~2025-04-18) so CI clock drift can't flake them. |

## Verification

\`\`\`
ruff check .          # All checks passed!
ruff format --check . # 44 files already formatted
mypy                  # Success: no issues found in 20 source files
pytest -q             # 569 passed (was 560; +9)
\`\`\`

## Why this matters (security)

The signature alone is integrity, not freshness. Without a skew check, a captured signed delivery is replayable forever — the URL, secret, and signature don't change. The ±300s window matches Zoom's documented tolerance and is symmetric so a client clock-spoof in either direction fails closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)