### PR TITLE
feat(phone): zoom phone recordings download (post-#18 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Zoom Reports API (PR #63): closes #20. New `zoom reports daily / meetings list / meetings participants / operationlogs list` commands; `zoom_cli/api/reports.py`; tier mappings extended for `/report/*` (HEAVY tier).
 > Zoom Dashboard API (PR #64): closes #21. New `zoom dashboard meetings list / get / participants` and `zoom dashboard zoomrooms list / get` commands; `zoom_cli/api/dashboard.py`; tier mappings extended for `/metrics/*` (HEAVY tier). Requires Business+ Zoom plan.
 > ApiClient user-OAuth integration (PR #65): completes the user-OAuth story from #12. `ApiClient` now accepts either `S2SCredentials` or `UserOAuthCredentials`; the CLI prefers user-OAuth when both are configured.
-> Webhook timestamp-skew enforcement (this branch): closes the deferred replay-protection piece from #17. `MAX_TIMESTAMP_SKEW_SECONDS = 300` is now actually enforced — old / future-dated deliveries are rejected with 401 even if the signature verifies.
+> Webhook timestamp-skew enforcement (PR #66): closes the deferred replay-protection piece from #17. `MAX_TIMESTAMP_SKEW_SECONDS = 300` is now actually enforced — old / future-dated deliveries are rejected with 401 even if the signature verifies.
+> Phone call recording downloads (this branch): closes the deferred download piece from #18. New `zoom phone recordings download <recording-id>` chains `get_phone_recording` (for the URL) with `ApiClient.stream_download` (atomic write).
+
+### Added (post-#18 follow-up)
+- `phone.get_phone_recording(client, recording_id)` — `GET /phone/recordings/<id>`. Returns the single recording's metadata including `download_url` and `file_extension`. URL-encodes the path segment.
+- `zoom phone recordings download <recording-id> [--out-dir DIR]` — fetches the metadata, then streams the audio file to disk via `ApiClient.stream_download` (atomic tempfile + os.replace from PR #54). Filename convention: `<recording_id>.<file_extension>`. Errors with exit 1 + clear message if the recording has no `download_url` (deleted/trashed).
+- `rate_limit.ENDPOINT_TIERS` adds `GET /phone/recordings/<id>` → `Tier.LIGHT` (single-resource read; the listing stays MEDIUM).
 
 ### Added (post-#17 follow-up)
 - `webhook.is_timestamp_within_skew(timestamp_str, *, max_skew_seconds, now_ms)` — pure helper. Symmetric ±300s default window (rejects old replays AND future-dated spoofs); malformed / missing timestamps return False. Injectable `now_ms` for tests; defaults to `time.time() * 1000`.

--- a/tests/test_api_phone.py
+++ b/tests/test_api_phone.py
@@ -123,3 +123,31 @@ def test_list_phone_recordings_forwards_date_filters() -> None:
     params = fake_client.get.call_args[1]["params"]
     assert params["from"] == "2026-04-01"
     assert params["to"] == "2026-04-30"
+
+
+# ---- get_phone_recording (single-recording metadata + download) --------
+
+
+def test_get_phone_recording_targets_correct_path() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {
+        "id": "rec-1",
+        "download_url": "https://files.zoom.us/rec/abc",
+        "file_extension": "MP3",
+    }
+
+    result = phone.get_phone_recording(fake_client, "rec-1")
+
+    fake_client.get.assert_called_once_with("/phone/recordings/rec-1")
+    assert result["download_url"] == "https://files.zoom.us/rec/abc"
+
+
+def test_get_phone_recording_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {}
+
+    phone.get_phone_recording(fake_client, "rec/with/slashes")
+
+    arg = fake_client.get.call_args[0][0]
+    assert "rec/with/slashes" not in arg
+    assert "%2F" in arg

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2812,3 +2812,93 @@ def test_build_api_client_no_callback_for_s2s() -> None:
         assert client._on_user_token_rotated is None
     finally:
         client.close()
+
+
+# ---- phone recordings download (#18 follow-up) -------------------------
+
+
+def test_phone_recordings_download_writes_file(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Streams the recording to disk via stream_download. Filename
+    convention: <recording_id>.<file_extension>."""
+    _save_creds()
+
+    def fake_get(_client, recording_id):
+        return {
+            "id": recording_id,
+            "download_url": "https://files.zoom.us/rec/abc",
+            "file_extension": "MP3",
+            "duration": 120,
+        }
+
+    written: list = []
+
+    def fake_stream(self, url, dest):
+        with open(dest, "wb") as f:
+            f.write(b"fake audio")
+        written.append((url, dest))
+        return 10
+
+    _patch_phone_module(monkeypatch, get_phone_recording=fake_get)
+    monkeypatch.setattr("zoom_cli.api.client.ApiClient.stream_download", fake_stream)
+
+    out_dir = tmp_path / "downloads"
+    result = runner.invoke(
+        main, ["phone", "recordings", "download", "rec-1", "--out-dir", str(out_dir)]
+    )
+    assert result.exit_code == 0, result.output
+    assert len(written) == 1
+    url, dest = written[0]
+    assert url == "https://files.zoom.us/rec/abc"
+    assert dest.endswith("rec-1.mp3")
+    assert "Downloaded" in result.output
+
+
+def test_phone_recordings_download_errors_on_missing_url(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Recording without download_url (deleted / trashed) → exit 1 with
+    a clear message; nothing written to disk."""
+    _save_creds()
+
+    def fake_get(_client, recording_id):
+        # No download_url field — recording is trashed.
+        return {"id": recording_id, "file_extension": "MP3"}
+
+    _patch_phone_module(monkeypatch, get_phone_recording=fake_get)
+
+    result = runner.invoke(
+        main, ["phone", "recordings", "download", "rec-1", "--out-dir", str(tmp_path)]
+    )
+    assert result.exit_code == 1
+    assert "No download_url" in result.output
+    # Nothing written.
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_phone_recordings_download_defaults_extension_when_missing(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+
+    def fake_get(_client, recording_id):
+        # Some recordings don't include file_extension; default to mp3.
+        return {"id": recording_id, "download_url": "https://x"}
+
+    written: list = []
+
+    def fake_stream(self, _url, dest):
+        with open(dest, "wb") as f:
+            f.write(b"x")
+        written.append(dest)
+        return 1
+
+    _patch_phone_module(monkeypatch, get_phone_recording=fake_get)
+    monkeypatch.setattr("zoom_cli.api.client.ApiClient.stream_download", fake_stream)
+
+    result = runner.invoke(
+        main, ["phone", "recordings", "download", "rec-X", "--out-dir", str(tmp_path)]
+    )
+    assert result.exit_code == 0, result.output
+    assert written[0].endswith("rec-X.mp3")

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -319,3 +319,13 @@ def test_tier_for_classifies_reports_endpoints_as_heavy(method: str, path: str) 
 def test_tier_for_classifies_dashboard_endpoints_as_heavy(method: str, path: str) -> None:
     """All /metrics/* endpoints are HEAVY per Zoom docs."""
     assert tier_for(method, path) == Tier.HEAVY
+
+
+# ---- phone single-recording (#18 follow-up) → LIGHT --------------------
+
+
+def test_tier_for_phone_single_recording_is_light() -> None:
+    """Single-resource phone recording GET is LIGHT (vs MEDIUM for the
+    listing). Same shape as users/<id> vs users."""
+    assert tier_for("GET", "/phone/recordings/rec-1") == Tier.LIGHT
+    assert tier_for("GET", "/phone/recordings") == Tier.MEDIUM

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -1843,6 +1843,49 @@ def phone_recordings_cmd():
     pass
 
 
+@phone_recordings_cmd.command(
+    "download",
+    help="Download a single phone call recording to disk.",
+)
+@click.argument("recording_id")
+@click.option(
+    "--out-dir",
+    type=click.Path(file_okay=False, writable=True, resolve_path=True),
+    default=".",
+    show_default=True,
+    help="Directory to write the file into. Created automatically if missing.",
+)
+@_translate_keyring_errors
+def phone_recordings_download(recording_id, out_dir):
+    """Fetches the recording's metadata to learn the download_url, then
+    streams it to disk via the same atomic tempfile + os.replace path
+    used by `zoom recordings download`. Filename convention:
+    ``<recording_id>.<file_extension>``."""
+    import os
+    import pathlib
+
+    pathlib.Path(out_dir).mkdir(parents=True, exist_ok=True)
+
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            rec = phone.get_phone_recording(client, recording_id)
+            url = rec.get("download_url")
+            if not url:
+                click.echo(
+                    f"No download_url for recording {recording_id} "
+                    "(may already be deleted or trashed).",
+                    err=True,
+                )
+                raise click.exceptions.Exit(code=1)
+            ext = (rec.get("file_extension") or "mp3").lower()
+            dest = os.path.join(out_dir, f"{recording_id}.{ext}")
+            bytes_written = client.stream_download(url, dest)
+            click.echo(f"Downloaded {dest} ({bytes_written} bytes)")
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+
+
 @phone_recordings_cmd.command("list", help="List phone call recordings (paginated).")
 @click.option(
     "--user-id",

--- a/zoom_cli/api/phone.py
+++ b/zoom_cli/api/phone.py
@@ -123,6 +123,22 @@ def list_call_queues(
     )
 
 
+def get_phone_recording(client: ApiClient, recording_id: str) -> dict[str, Any]:
+    """``GET /phone/recordings/{recording_id}`` — single recording metadata.
+
+    Returns the recording's envelope including ``download_url``,
+    ``file_extension``, ``duration``, etc. The CLI ``zoom phone
+    recordings download`` chains this with
+    :meth:`ApiClient.stream_download` to fetch the actual audio file.
+
+    URL-encodes the path segment.
+
+    Required scopes: ``phone:read:call_recording`` (or admin
+    equivalent).
+    """
+    return client.get(f"/phone/recordings/{quote(recording_id, safe='')}")
+
+
 def list_phone_recordings(
     client: ApiClient,
     *,

--- a/zoom_cli/api/rate_limit.py
+++ b/zoom_cli/api/rate_limit.py
@@ -113,6 +113,7 @@ _TIER_RULES: list[tuple[str, re.Pattern[str], Tier]] = [
     ("GET", re.compile(r"/phone/users"), Tier.MEDIUM),
     ("GET", re.compile(r"/phone/call_logs"), Tier.MEDIUM),
     ("GET", re.compile(r"/phone/call_queues"), Tier.MEDIUM),
+    ("GET", re.compile(r"/phone/recordings/[^/]+"), Tier.LIGHT),
     ("GET", re.compile(r"/phone/recordings"), Tier.MEDIUM),
     # ---- Zoom Team Chat (#19)
     ("GET", re.compile(r"/chat/users/[^/]+/channels"), Tier.MEDIUM),


### PR DESCRIPTION
## Summary

PR #61 landed phone listings + tier mappings but deferred the **download** of individual call recordings to a follow-up. This is that follow-up, following the same shape as \`zoom recordings download\` from PR #54.

## What's new

### \`zoom_cli/api/phone.py\`

\`\`\`python
get_phone_recording(client, recording_id) -> dict
    → GET /phone/recordings/<id>
\`\`\`

Returns the single recording's metadata including \`download_url\` and \`file_extension\`. URL-encodes the path segment.

### CLI

\`\`\`bash
zoom phone recordings download <recording-id> [--out-dir DIR]
\`\`\`

Two-step:

1. \`get_phone_recording(recording_id)\` → metadata + download_url
2. \`client.stream_download(download_url, dest_path)\` → atomic write (tempfile + os.replace from PR #54)

Filename convention: \`<recording_id>.<file_extension>\`. Errors with exit 1 + clear message if \`download_url\` is absent (recording deleted/trashed).

### Rate-limit tier mapping

| Path | Tier |
|---|---|
| \`GET /phone/recordings/<id>\` | LIGHT (single-resource) |
| \`GET /phone/recordings\` | MEDIUM (listing — already mapped) |

## Tests (+6)

| File | New | Covers |
|---|---|---|
| \`tests/test_api_phone.py\` | +2 | get_phone_recording targets correct path; URL-encodes id with slashes |
| \`tests/test_rate_limit.py\` | +1 | single-resource phone recording is LIGHT vs MEDIUM listing |
| \`tests/test_cli.py\` | +3 | download writes file with correct filename convention; missing download_url → exit 1 + nothing written; missing file_extension defaults to mp3 |

## Verification

\`\`\`
ruff check .          # All checks passed!
ruff format --check . # 44 files already formatted
mypy                  # Success: no issues found in 20 source files
pytest -q             # 575 passed (was 569; +6)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)