### PR TITLE
ci: add PyPI release workflow via Trusted Publishing (closes #10 partial)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release
+
+# Builds and publishes the package to PyPI on tag push.
+#
+# Closes the PyPI half of issue #10. Uses PyPI's Trusted Publishing
+# (OIDC) so no API token needs to live in GitHub secrets — the
+# publishing identity is the workflow itself, scoped to the repo +
+# workflow filename + environment name.
+#
+# Setup checklist (one-time, on PyPI side):
+#   1. Create the project on PyPI (or claim it).
+#   2. PyPI project page → Settings → Publishing → Add a Trusted
+#      Publisher with:
+#        - Owner:        jordan8037310
+#        - Repo name:    zoom-cli
+#        - Workflow:     release.yml
+#        - Environment:  pypi
+#   3. Push a tag that matches `v*` (e.g. `git tag v1.2.0 && git push --tags`).
+#
+# The workflow can also be triggered manually via "Run workflow" in
+# the Actions tab, which is useful for the very first release (before
+# the tag-trigger has been exercised).
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build only — skip the PyPI upload step"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false  # never cancel a release mid-publish
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install build deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build sdist + wheel
+        run: python -m build
+      - name: Verify the build
+        run: |
+          ls -la dist/
+          python -m pip install dist/*.whl
+          python -c "import zoom_cli; print('package version:', zoom_cli.__version__)"
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+
+  publish:
+    name: Publish to PyPI (Trusted Publishing / OIDC)
+    needs: build
+    runs-on: ubuntu-latest
+    # Skip on a dry-run dispatch — the build job's artifacts are still
+    # available for inspection.
+    if: github.event_name == 'push' || github.event.inputs.dry_run != 'true'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/zoom-cli
+    permissions:
+      id-token: write  # OIDC token for Trusted Publishing
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # No `password:` because Trusted Publishing uses OIDC.
+        # Configure the Trusted Publisher entry on PyPI as documented
+        # at the top of this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Zoom Dashboard API (PR #64): closes #21. New `zoom dashboard meetings list / get / participants` and `zoom dashboard zoomrooms list / get` commands; `zoom_cli/api/dashboard.py`; tier mappings extended for `/metrics/*` (HEAVY tier). Requires Business+ Zoom plan.
 > ApiClient user-OAuth integration (PR #65): completes the user-OAuth story from #12. `ApiClient` now accepts either `S2SCredentials` or `UserOAuthCredentials`; the CLI prefers user-OAuth when both are configured.
 > Webhook timestamp-skew enforcement (PR #66): closes the deferred replay-protection piece from #17. `MAX_TIMESTAMP_SKEW_SECONDS = 300` is now actually enforced — old / future-dated deliveries are rejected with 401 even if the signature verifies.
-> Phone call recording downloads (this branch): closes the deferred download piece from #18. New `zoom phone recordings download <recording-id>` chains `get_phone_recording` (for the URL) with `ApiClient.stream_download` (atomic write).
+> Phone call recording downloads (PR #67): closes the deferred download piece from #18. New `zoom phone recordings download <recording-id>` chains `get_phone_recording` (for the URL) with `ApiClient.stream_download` (atomic write).
+> PyPI release workflow (this branch): closes the PyPI half of #10. New `.github/workflows/release.yml` builds + publishes on tag push via PyPI Trusted Publishing (OIDC, no token in secrets).
+
+### Added (issue #10, PyPI half)
+- `.github/workflows/release.yml` — three-stage workflow:
+  1. Build sdist + wheel via `python -m build`.
+  2. Verify by installing the wheel into a fresh interpreter and importing `zoom_cli`.
+  3. Publish to PyPI via the official `pypa/gh-action-pypi-publish@release/v1` action using **Trusted Publishing (OIDC)** — no `PYPI_API_TOKEN` secret needed.
+- Triggers on `git push` to a `v*` tag, **and** on manual `workflow_dispatch` (with a `dry_run` checkbox that skips the upload step — handy for verifying the build before the first real release).
+- README "Releases" section documents the one-time PyPI Trusted Publisher setup.
+
+### One-time setup (action required to actually publish)
+The workflow lands inert. To activate publishes, on PyPI:
+1. Create the `zoom-cli` project (or claim it).
+2. PyPI → project Settings → Publishing → Add Trusted Publisher with `Owner=jordan8037310`, `Repo=zoom-cli`, `Workflow=release.yml`, `Environment=pypi`.
+3. Tag a release: `git tag vX.Y.Z && git push --tags`.
 
 ### Added (post-#18 follow-up)
 - `phone.get_phone_recording(client, recording_id)` — `GET /phone/recordings/<id>`. Returns the single recording's metadata including `download_url` and `file_extension`. URL-encodes the path segment.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,20 @@ zoom webhook serve --secret-token TOKEN [--bind 127.0.0.1] [--port 8000]
 
 Streams verified events to stdout as one-line JSON; rejected deliveries get a 401 + a stderr line. Use with `ngrok http 8000` (or similar) to expose to the public internet during development; the receiver itself binds to loopback by default.
 
+## Releases
+
+Releases publish to PyPI on tag push via [`.github/workflows/release.yml`](.github/workflows/release.yml). The workflow uses [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) — no API token lives in GitHub secrets. **One-time setup on PyPI:**
+
+1. Create the `zoom-cli` project on PyPI (or claim it).
+2. PyPI project → Settings → Publishing → "Add a new pending publisher" with:
+   - **Owner:** `jordan8037310`
+   - **Repo name:** `zoom-cli`
+   - **Workflow:** `release.yml`
+   - **Environment:** `pypi`
+3. After that's set, cut a release with `git tag vX.Y.Z && git push --tags`.
+
+The workflow can also be triggered manually via the Actions tab ("Run workflow"), with a `dry_run` checkbox that builds the artifacts without uploading — useful for verifying the build before the first real publish.
+
 ## Codegen (optional, dev tool)
 
 For developers who want statically-typed Pydantic v2 models instead of `dict[str, Any]`, [`scripts/codegen.py`](scripts/codegen.py) wraps `datamodel-code-generator` against Zoom's published OpenAPI spec.


### PR DESCRIPTION
## Summary

CI matrix landed in PR #25 long ago; this closes the PyPI half of #10. New three-stage release workflow that publishes to PyPI on tag push using **Trusted Publishing (OIDC)** — no \`PYPI_API_TOKEN\` lives in GitHub secrets.

## What's new

### \`.github/workflows/release.yml\`

| Job | What it does |
|---|---|
| **build** | \`python -m build\` → sdist + wheel; uploaded as artifact |
| **verify** (in build job) | installs the wheel into a fresh interpreter, imports \`zoom_cli\`, prints the version |
| **publish** | \`pypa/gh-action-pypi-publish@release/v1\` via OIDC; environment \`pypi\` |

**Triggers:**
- \`push\` to a \`v*\` tag → automatic publish
- \`workflow_dispatch\` with optional \`dry_run\` checkbox → build only, skip the upload (handy for verifying the build before the first real release)

Concurrency group set to **never cancel a release mid-publish** (unlike CI runs).

### Why Trusted Publishing (not API tokens)

- Zero secrets in GitHub.
- Publishing identity = the workflow itself, scoped to (repo, workflow filename, environment).
- No token to rotate, revoke, or accidentally leak.
- PyPA's recommended pattern since 2023.

### README

New "Releases" section documenting the one-time PyPI Trusted Publisher setup + tag-push flow.

## Verification

- Workflow YAML parses (\`yaml.safe_load\` round-trip)
- \`ruff check\` + format clean, \`mypy\` clean (no source changes)
- 575 pytest passing (unchanged)

## Activation (one-time, blocked on you — can't be automated)

The workflow lands **inert** until you set up Trusted Publishing on PyPI:

1. Create / claim the \`zoom-cli\` project on PyPI.
2. PyPI project → Settings → Publishing → Add a new pending publisher with:
   - **Owner:** \`jordan8037310\`
   - **Repo name:** \`zoom-cli\`
   - **Workflow:** \`release.yml\`
   - **Environment:** \`pypi\`
3. Tag a release: \`git tag vX.Y.Z && git push --tags\`.

Or trigger \`workflow_dispatch\` from the Actions tab with \`dry_run: true\` first to verify the build pipeline before the real publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)