### PR TITLE
feat(api,cli): zoom users settings update --from-json (post-#14 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > ApiClient user-OAuth integration (PR #65): completes the user-OAuth story from #12. `ApiClient` now accepts either `S2SCredentials` or `UserOAuthCredentials`; the CLI prefers user-OAuth when both are configured.
 > Webhook timestamp-skew enforcement (PR #66): closes the deferred replay-protection piece from #17. `MAX_TIMESTAMP_SKEW_SECONDS = 300` is now actually enforced — old / future-dated deliveries are rejected with 401 even if the signature verifies.
 > Phone call recording downloads (PR #67): closes the deferred download piece from #18. New `zoom phone recordings download <recording-id>` chains `get_phone_recording` (for the URL) with `ApiClient.stream_download` (atomic write).
-> PyPI release workflow (this branch): closes the PyPI half of #10. New `.github/workflows/release.yml` builds + publishes on tag push via PyPI Trusted Publishing (OIDC, no token in secrets).
+> PyPI release workflow (PR #68): closes the PyPI half of #10. New `.github/workflows/release.yml` builds + publishes on tag push via PyPI Trusted Publishing (OIDC, no token in secrets).
+> Users settings update (this branch): closes the deferred settings-update piece from #14. New `zoom users settings update [user-id] --from-json FILE` rounds out the get → edit → PATCH workflow.
+
+### Added (post-#14 follow-up)
+- `users.update_user_settings(client, user_id, payload)` — `PATCH /users/<user-id>/settings`. Zoom's PATCH semantics leave omitted fields untouched, so callers can pass any subset.
+- `zoom users settings update [user-id] --from-json FILE [--yes] [--dry-run]` — CLI completes the round trip:
+
+  ```bash
+  zoom users settings get me > settings.json   # dump
+  # edit settings.json
+  zoom users settings update me --from-json settings.json   # PATCH back
+  ```
+
+  Validates that `--from-json` parses as a JSON object (rejects arrays / scalars). Always confirms unless `--yes` (settings changes can disable security features like waiting rooms / private chat); the prompt surfaces top-level keys being changed so the user sees the scope without scrolling. `--dry-run` previews the parsed payload without calling the API. `--from-json -` reads from stdin, so `... | zoom users settings update --from-json -` works.
+- `rate_limit.ENDPOINT_TIERS` adds `PATCH /users/<id>/settings` → `Tier.MEDIUM` (write); the GET stays LIGHT.
+
+### Why round-trip instead of per-field flags
+The settings payload has ~50 fields across nested categories (`feature`, `in_meeting`, `email_notification`, `recording`, etc.). Mirroring all of them as flags would be a sprawling surface that drifts whenever Zoom adds a field. The dump-edit-PATCH flow scales to whatever Zoom adds without code changes.
 
 ### Added (issue #10, PyPI half)
 - `.github/workflows/release.yml` — three-stage workflow:

--- a/tests/test_api_users.py
+++ b/tests/test_api_users.py
@@ -236,3 +236,44 @@ def test_allowed_create_actions_pinned() -> None:
 
 def test_allowed_delete_actions_pinned() -> None:
     assert users.ALLOWED_DELETE_ACTIONS == ("disassociate", "delete")
+
+
+# ---- update_user_settings (PATCH partial) -------------------------------
+
+
+def test_update_user_settings_patches_correct_path() -> None:
+    fake_client = MagicMock()
+    fake_client.patch.return_value = {}
+
+    users.update_user_settings(fake_client, "u-1", {"in_meeting": {"chat": False}})
+
+    fake_client.patch.assert_called_once_with(
+        "/users/u-1/settings", json={"in_meeting": {"chat": False}}
+    )
+
+
+def test_update_user_settings_url_encodes_user_id() -> None:
+    fake_client = MagicMock()
+    fake_client.patch.return_value = {}
+
+    users.update_user_settings(fake_client, "alice@example.com", {"x": 1})
+
+    arg = fake_client.patch.call_args[0][0]
+    assert arg == "/users/alice%40example.com/settings"
+
+
+def test_update_user_settings_passes_payload_through() -> None:
+    """Payload is forwarded as-is — no validation, no field-coverage
+    requirement (the CLI dumps then re-PATCHes, which is the typical
+    workflow)."""
+    fake_client = MagicMock()
+    fake_client.patch.return_value = {}
+
+    payload = {
+        "feature": {"meeting_capacity": 100},
+        "in_meeting": {"chat": True, "private_chat": False},
+        "email_notification": {"jbh_reminder": True},
+    }
+    users.update_user_settings(fake_client, "me", payload)
+
+    assert fake_client.patch.call_args[1]["json"] == payload

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2902,3 +2902,171 @@ def test_phone_recordings_download_defaults_extension_when_missing(
     )
     assert result.exit_code == 0, result.output
     assert written[0].endswith("rec-X.mp3")
+
+
+# ---- users settings update --from-json -----------------------------------
+
+
+def test_users_settings_update_requires_from_json(runner: CliRunner) -> None:
+    _save_creds()
+    result = runner.invoke(main, ["users", "settings", "update", "u-1"])
+    assert result.exit_code != 0
+    assert "from-json" in result.output.lower() or "missing" in result.output.lower()
+
+
+def test_users_settings_update_dry_run_prints_payload_no_api(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+    json_file = tmp_path / "settings.json"
+    json_file.write_text('{"in_meeting": {"chat": false}}')
+
+    called = {"n": 0}
+
+    def fake_update(*_a, **_k):
+        called["n"] += 1
+
+    _patch_users_module(monkeypatch, update_user_settings=fake_update)
+    result = runner.invoke(
+        main,
+        [
+            "users",
+            "settings",
+            "update",
+            "u-1",
+            "--from-json",
+            str(json_file),
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "[dry-run]" in result.output
+    assert "in_meeting" in result.output
+    assert called["n"] == 0
+
+
+def test_users_settings_update_yes_skips_confirmation(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+    json_file = tmp_path / "settings.json"
+    json_file.write_text('{"in_meeting": {"chat": false}}')
+
+    captured = {}
+
+    def fake_update(_client, user_id, payload):
+        captured.update({"user_id": user_id, "payload": payload})
+
+    _patch_users_module(monkeypatch, update_user_settings=fake_update)
+    result = runner.invoke(
+        main,
+        [
+            "users",
+            "settings",
+            "update",
+            "u-1",
+            "--from-json",
+            str(json_file),
+            "--yes",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["user_id"] == "u-1"
+    assert captured["payload"] == {"in_meeting": {"chat": False}}
+    assert "Updated settings for user u-1" in result.output
+
+
+def test_users_settings_update_confirms_and_aborts(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Without --yes, an explicit 'n' aborts and the API is not called."""
+    _save_creds()
+    json_file = tmp_path / "settings.json"
+    json_file.write_text('{"feature": {"meeting_capacity": 100}}')
+
+    called = {"n": 0}
+
+    def fake_update(*_a, **_k):
+        called["n"] += 1
+
+    _patch_users_module(monkeypatch, update_user_settings=fake_update)
+    result = runner.invoke(
+        main,
+        ["users", "settings", "update", "u-1", "--from-json", str(json_file)],
+        input="n\n",
+    )
+    assert result.exit_code == 0, result.output
+    assert "Aborted" in result.output
+    assert "feature" in result.output  # confirmation surfaced top-level key
+    assert called["n"] == 0
+
+
+def test_users_settings_update_rejects_invalid_json(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+    json_file = tmp_path / "settings.json"
+    json_file.write_text("not valid json {{{")
+
+    _patch_users_module(monkeypatch, update_user_settings=lambda *_a, **_k: None)
+    result = runner.invoke(
+        main,
+        [
+            "users",
+            "settings",
+            "update",
+            "u-1",
+            "--from-json",
+            str(json_file),
+            "--yes",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Invalid JSON" in result.output
+
+
+def test_users_settings_update_rejects_non_dict_payload(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """--from-json must contain a JSON object; arrays / scalars are
+    rejected (Zoom's PATCH expects a dict)."""
+    _save_creds()
+    json_file = tmp_path / "settings.json"
+    json_file.write_text('["not", "a", "dict"]')
+
+    _patch_users_module(monkeypatch, update_user_settings=lambda *_a, **_k: None)
+    result = runner.invoke(
+        main,
+        [
+            "users",
+            "settings",
+            "update",
+            "u-1",
+            "--from-json",
+            str(json_file),
+            "--yes",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "must be a JSON object" in result.output
+
+
+def test_users_settings_update_default_user_me(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Positional user_id defaults to 'me'."""
+    _save_creds()
+    json_file = tmp_path / "settings.json"
+    json_file.write_text('{"feature": {}}')
+
+    captured = {}
+
+    def fake_update(_client, user_id, payload):
+        captured["user_id"] = user_id
+
+    _patch_users_module(monkeypatch, update_user_settings=fake_update)
+    result = runner.invoke(
+        main, ["users", "settings", "update", "--from-json", str(json_file), "--yes"]
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["user_id"] == "me"

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -329,3 +329,13 @@ def test_tier_for_phone_single_recording_is_light() -> None:
     listing). Same shape as users/<id> vs users."""
     assert tier_for("GET", "/phone/recordings/rec-1") == Tier.LIGHT
     assert tier_for("GET", "/phone/recordings") == Tier.MEDIUM
+
+
+# ---- users settings PATCH tier classification --------------------------
+
+
+def test_tier_for_users_settings_patch_is_medium() -> None:
+    """PATCH /users/<id>/settings is a write — MEDIUM tier."""
+    assert tier_for("PATCH", "/users/u-1/settings") == Tier.MEDIUM
+    # Read stays LIGHT.
+    assert tier_for("GET", "/users/u-1/settings") == Tier.LIGHT

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -826,10 +826,17 @@ def users_delete(
 
 @users_cmd.group("settings", help="Read or update a user's account settings.")
 def users_settings_cmd():
-    """Group for ``zoom users settings ...``. Currently only ``get`` is
-    implemented; ``update`` (PATCH /users/<id>/settings) is deferred to
-    a follow-up — the settings payload has ~50 fields and needs design
-    work to map to flags coherently."""
+    """Group for ``zoom users settings ...``.
+
+    Two-step round trip for mass updates:
+
+      zoom users settings get me > settings.json   # dump
+      # edit settings.json
+      zoom users settings update me --from-json settings.json   # patch back
+
+    Per-field flags aren't exposed (~50 fields across nested
+    categories); the round-trip flow is more practical and avoids the
+    coverage / staleness problem of mirroring Zoom's full schema."""
 
 
 @users_settings_cmd.command(
@@ -851,6 +858,81 @@ def users_settings_get(user_id):
     except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
         _exit_on_api_error(exc)
     click.echo(_json.dumps(settings, indent=2, sort_keys=True))
+
+
+@users_settings_cmd.command(
+    "update",
+    help="PATCH a user's settings from a JSON file (PATCH /users/<user-id>/settings).",
+)
+@click.argument("user_id", default="me", required=False)
+@click.option(
+    "--from-json",
+    "from_json",
+    type=click.File("r", encoding="utf-8"),
+    required=True,
+    help=(
+        "Path to a JSON file containing the (sub-)payload to PATCH. "
+        "Use '-' for stdin. Typical workflow: pipe `zoom users settings "
+        "get me` through `jq`, edit, then PATCH back."
+    ),
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Print the parsed payload without calling the API.",
+)
+@_translate_keyring_errors
+def users_settings_update(user_id, from_json, yes, dry_run):
+    """Zoom PATCH semantics: omitted keys are left untouched, so passing
+    a partial dict only changes the keys you include. Always confirms
+    unless ``--yes`` (settings changes can be invasive — disabling
+    waiting rooms, screen sharing, etc. has security implications)."""
+    import json as _json
+
+    try:
+        payload = _json.load(from_json)
+    except _json.JSONDecodeError as exc:
+        click.echo(f"Invalid JSON in --from-json input: {exc}", err=True)
+        raise click.exceptions.Exit(code=1) from exc
+
+    if not isinstance(payload, dict):
+        click.echo(
+            f"--from-json input must be a JSON object (dict), got {type(payload).__name__}.",
+            err=True,
+        )
+        raise click.exceptions.Exit(code=1)
+
+    if dry_run:
+        click.echo(f"[dry-run] Would PATCH /users/{user_id}/settings with:")
+        click.echo(_json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    if not yes:
+        # Surface the top-level keys being changed so the user knows
+        # what they're agreeing to without having to scroll the body.
+        keys = ", ".join(sorted(payload.keys())) or "(empty)"
+        if not click.confirm(
+            f"Update settings for user {user_id}? Top-level keys: {keys}",
+            default=False,
+        ):
+            click.echo("Aborted.")
+            return
+
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            users.update_user_settings(client, user_id, payload)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Updated settings for user {user_id}.")
 
 
 # ---- Zoom Meetings — write commands -------------------------------------

--- a/zoom_cli/api/rate_limit.py
+++ b/zoom_cli/api/rate_limit.py
@@ -82,6 +82,8 @@ _TIER_RULES: list[tuple[str, re.Pattern[str], Tier]] = [
     ("GET", re.compile(r"/users"), Tier.MEDIUM),
     # GET /users/<id>/settings — single-user metadata
     ("GET", re.compile(r"/users/[^/]+/settings"), Tier.LIGHT),
+    # PATCH /users/<id>/settings — write
+    ("PATCH", re.compile(r"/users/[^/]+/settings"), Tier.MEDIUM),
     # GET /users/<id>/meetings — listing for a user
     ("GET", re.compile(r"/users/[^/]+/meetings"), Tier.MEDIUM),
     # GET /users/<id>/recordings — listing recordings

--- a/zoom_cli/api/users.py
+++ b/zoom_cli/api/users.py
@@ -135,13 +135,33 @@ def get_user_settings(client: ApiClient, user_id: str = "me") -> dict[str, Any]:
 
     The settings payload has ~50 fields across nested categories
     (``feature``, ``in_meeting``, ``email_notification``, etc.). The CLI
-    just dumps the JSON; callers wanting to mutate settings should use
-    :func:`update_user_settings` (or wait for a follow-up issue that
-    adds individual flags).
+    dumps the JSON; round-trip mutate via :func:`update_user_settings`
+    after editing the dump.
 
     Required scopes: ``user:read:settings`` or ``user:read:admin``.
     """
     return client.get(f"/users/{quote(user_id, safe='')}/settings")
+
+
+def update_user_settings(
+    client: ApiClient, user_id: str, payload: dict[str, Any]
+) -> dict[str, Any]:
+    """``PATCH /users/{user_id}/settings`` — partial-update settings.
+
+    ``payload`` is the (sub-)dict to merge — Zoom's PATCH semantics
+    leave omitted fields untouched. Typical workflow:
+
+        # 1. Dump current settings to a JSON file
+        zoom users settings get me > settings.json
+        # 2. Edit settings.json
+        # 3. PATCH back
+        zoom users settings update me --from-json settings.json
+
+    Returns ``{}`` (Zoom responds with ``204 No Content``).
+
+    Required scopes: ``user:write:settings`` or ``user:write:admin``.
+    """
+    return client.patch(f"/users/{quote(user_id, safe='')}/settings", json=payload)
 
 
 def list_users(


### PR DESCRIPTION
## Summary

PR #53 deferred the settings-update piece because the surface is ~50 fields across nested categories. Solved with a round-trip flow instead of per-field flags.

\`\`\`bash
zoom users settings get me > settings.json
# edit settings.json
zoom users settings update me --from-json settings.json
\`\`\`

\`--from-json -\` reads from stdin, so this works too:

\`\`\`bash
zoom users settings get me | jq '.in_meeting.chat = false' | \\
  zoom users settings update --from-json -
\`\`\`

## What's new

### \`zoom_cli/api/users.py\`

\`\`\`python
update_user_settings(client, user_id, payload) -> dict
    # PATCH /users/<id>/settings (partial — omitted keys untouched)
\`\`\`

### CLI

\`zoom users settings update [user-id] --from-json FILE [--yes] [--dry-run]\`

| Validation | Behaviour |
|---|---|
| JSON parses | exit 1 + \"Invalid JSON\" on failure |
| Top-level is a dict | exit 1 + \"must be a JSON object\" if array/scalar (Zoom PATCH expects a dict) |
| \`--dry-run\` | print parsed payload, skip API |
| \`--yes\` | skip confirm |
| Without \`--yes\` | confirm prompt surfaces top-level keys being changed (so the user sees scope before agreeing) |

### Rate-limit tier mapping

| Path | Tier |
|---|---|
| \`PATCH /users/<id>/settings\` | MEDIUM (new) |
| \`GET /users/<id>/settings\` | LIGHT (unchanged) |

## Tests (+11 new)

| File | New | Covers |
|---|---|---|
| \`tests/test_api_users.py\` | +3 | patches correct path; URL-encodes user_id; payload forwarded as-is |
| \`tests/test_rate_limit.py\` | +1 | PATCH → MEDIUM, GET stays LIGHT |
| \`tests/test_cli.py\` | +7 | requires --from-json; --dry-run prints + skips API; --yes skips confirm + persists; without --yes 'n' aborts + prompt surfaces top-level keys; rejects invalid JSON; rejects non-dict payload; default user_id is 'me' |

## Why round-trip instead of per-field flags

Settings has ~50 fields across nested categories (\`feature\`, \`in_meeting\`, \`email_notification\`, \`recording\`, etc.). Mirroring them as flags would drift every time Zoom adds a field. The dump-edit-PATCH flow scales to whatever Zoom adds without code changes — and the \`--dry-run\` + confirmation surface keeps the loud-failure-mode obvious.

## Verification

\`\`\`
ruff check .          # All checks passed!
ruff format --check . # 44 files already formatted
mypy                  # Success: no issues found in 20 source files
pytest -q             # 586 passed (was 575; +11)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)