### PR TITLE
feat(tooling): codegen --from-url flag (post-#22 ergonomic)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Webhook timestamp-skew enforcement (PR #66): closes the deferred replay-protection piece from #17. `MAX_TIMESTAMP_SKEW_SECONDS = 300` is now actually enforced — old / future-dated deliveries are rejected with 401 even if the signature verifies.
 > Phone call recording downloads (PR #67): closes the deferred download piece from #18. New `zoom phone recordings download <recording-id>` chains `get_phone_recording` (for the URL) with `ApiClient.stream_download` (atomic write).
 > PyPI release workflow (PR #68): closes the PyPI half of #10. New `.github/workflows/release.yml` builds + publishes on tag push via PyPI Trusted Publishing (OIDC, no token in secrets).
-> Users settings update (this branch): closes the deferred settings-update piece from #14. New `zoom users settings update [user-id] --from-json FILE` rounds out the get → edit → PATCH workflow.
+> Users settings update (PR #69): closes the deferred settings-update piece from #14. New `zoom users settings update [user-id] --from-json FILE` rounds out the get → edit → PATCH workflow.
+> Codegen `--from-url` (this branch): scripts/codegen.py can now fetch the OpenAPI spec directly instead of requiring a separate `curl` step.
+
+### Changed (post-#22 follow-up)
+- `scripts/codegen.py` accepts `--from-url URL` as an alternative to the positional spec path. Mutually exclusive — exactly one source must be provided. Fetches via `httpx` (already a runtime dep, public unauthenticated endpoint), writes to `$TMPDIR/zoom-openapi.*.json`, then runs the existing codegen flow on that tempfile. Failure during fetch surfaces as exit 1 with the underlying error.
+- README "Codegen" section updated with the one-step workflow.
 
 ### Added (post-#14 follow-up)
 - `users.update_user_settings(client, user_id, payload)` — `PATCH /users/<user-id>/settings`. Zoom's PATCH semantics leave omitted fields untouched, so callers can pass any subset.

--- a/README.md
+++ b/README.md
@@ -181,11 +181,14 @@ For developers who want statically-typed Pydantic v2 models instead of `dict[str
 # Install the codegen extra (only needed when running the script)
 pip install -e '.[codegen]'
 
-# Fetch Zoom's OpenAPI spec (URL changes occasionally — see Zoom developer docs)
-curl -o /tmp/zoom-openapi.json https://developers.zoom.us/openapi-spec/...
+# Option A: fetch + generate in one step
+python scripts/codegen.py --from-url https://developers.zoom.us/openapi-spec/...
 
-# Run the generator (or `--dry-run` to inspect the invocation first)
+# Option B: fetch separately (useful if you want to inspect / edit the spec first)
+curl -o /tmp/zoom-openapi.json https://developers.zoom.us/openapi-spec/...
 python scripts/codegen.py /tmp/zoom-openapi.json
+
+# Or `--dry-run` against either path to inspect the invocation first.
 ```
 
 The generated models land in `zoom_cli/api/_generated/` and are gitignored by default. Existing helpers (`users.py`, `meetings.py`, `recordings.py`) still return raw dicts; migrating each to typed return shapes is opt-in per endpoint.

--- a/scripts/codegen.py
+++ b/scripts/codegen.py
@@ -78,14 +78,54 @@ def _build_argv(spec_path: Path, output_dir: Path) -> list[str]:
     ]
 
 
+def _fetch_spec_to_tempfile(url: str) -> Path:
+    """Fetch ``url`` over HTTPS via httpx (already a runtime dep) and write
+    to a tempfile under ``$TMPDIR``. Returns the tempfile path; the
+    caller owns cleanup (we don't unlink — the spec is small enough to
+    leak harmlessly and useful to inspect on failure).
+
+    Pulled out for testability. We don't reuse the project's ApiClient
+    because the OpenAPI spec is hosted on a public HTTP endpoint with
+    no authentication, and ApiClient would inject a bearer token.
+    """
+    import tempfile
+
+    import httpx
+
+    with httpx.Client(timeout=30.0, follow_redirects=True) as client:
+        response = client.get(url)
+        response.raise_for_status()
+        body = response.content
+
+    fd, path = tempfile.mkstemp(prefix="zoom-openapi.", suffix=".json")
+    with open(fd, "wb") as f:
+        f.write(body)
+    return Path(path)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Generate Pydantic v2 models from a Zoom OpenAPI spec.",
     )
-    parser.add_argument(
+    # `spec` and `--from-url` are mutually exclusive: exactly one must
+    # be provided. argparse handles the required+exclusive contract.
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
         "spec",
+        nargs="?",
         type=Path,
+        default=None,
         help="Path to a local Zoom OpenAPI 3 spec (JSON or YAML).",
+    )
+    source.add_argument(
+        "--from-url",
+        dest="from_url",
+        metavar="URL",
+        help=(
+            "Fetch the spec from a URL (HTTPS) and run codegen on it. "
+            "Saves a `curl` step; the fetched spec is left in $TMPDIR "
+            "for inspection."
+        ),
     )
     parser.add_argument(
         "--output-dir",
@@ -100,9 +140,19 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    if not args.spec.exists():
-        print(f"error: spec file not found: {args.spec}", file=sys.stderr)
-        return 1
+    # Resolve the input source.
+    if args.from_url is not None:
+        try:
+            spec_path = _fetch_spec_to_tempfile(args.from_url)
+        except Exception as exc:
+            print(f"error: failed to fetch spec from {args.from_url}: {exc}", file=sys.stderr)
+            return 1
+        print(f"Fetched spec from {args.from_url} -> {spec_path}")
+    else:
+        spec_path = args.spec
+        if not spec_path.exists():
+            print(f"error: spec file not found: {spec_path}", file=sys.stderr)
+            return 1
 
     if shutil.which("datamodel-codegen") is None:
         print(
@@ -112,13 +162,13 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
-    cmd = _build_argv(args.spec, args.output_dir)
+    cmd = _build_argv(spec_path, args.output_dir)
 
     if args.dry_run:
         print("Would run:", " ".join(cmd))
         return 0
 
-    print(f"Generating Pydantic models from {args.spec} -> {args.output_dir} ...")
+    print(f"Generating Pydantic models from {spec_path} -> {args.output_dir} ...")
     # The argv here is constructed from a literal command name +
     # explicit flags + caller-controlled paths; safe from shell injection
     # (no shell, list-form argv).

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -178,3 +178,129 @@ def test_default_output_dir_pinned() -> None:
     """A move would silently break collaborators' git status / .gitignore."""
     codegen = _load_codegen()
     assert Path("zoom_cli/api/_generated") == codegen.DEFAULT_OUTPUT_DIR
+
+
+# ---- --from-url mode ----------------------------------------------------
+
+
+def test_main_requires_spec_or_url(capsys: pytest.CaptureFixture) -> None:
+    """argparse mutually-exclusive required group enforces this."""
+    codegen = _load_codegen()
+    with pytest.raises(SystemExit) as excinfo:
+        codegen.main([])  # neither positional spec nor --from-url
+    assert excinfo.value.code == 2  # argparse error exit
+    err = capsys.readouterr().err
+    assert "required" in err.lower() or "one of" in err.lower()
+
+
+def test_main_rejects_both_spec_and_url(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    """Mutually exclusive — passing both should error."""
+    codegen = _load_codegen()
+    spec = tmp_path / "spec.json"
+    spec.write_text("{}")
+    with pytest.raises(SystemExit) as excinfo:
+        codegen.main([str(spec), "--from-url", "https://example.com/spec.json"])
+    assert excinfo.value.code == 2
+
+
+def test_main_from_url_fetches_spec(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """--from-url calls _fetch_spec_to_tempfile and feeds the result to
+    the codegen invocation."""
+    codegen = _load_codegen()
+
+    fetched_url = {"url": None}
+    fake_path = tmp_path / "fetched.json"
+    fake_path.write_text("{}")
+
+    def fake_fetch(url: str) -> Path:
+        fetched_url["url"] = url
+        return fake_path
+
+    monkeypatch.setattr(codegen, "_fetch_spec_to_tempfile", fake_fetch)
+
+    captured_cmd: list = []
+
+    def fake_run(cmd, check=False):
+        captured_cmd.extend(cmd)
+
+        class Result:
+            returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr(codegen.shutil, "which", lambda _cmd: "/path/datamodel-codegen")
+    monkeypatch.setattr(codegen.subprocess, "run", fake_run)
+
+    rc = codegen.main(
+        [
+            "--from-url",
+            "https://developers.zoom.us/openapi-spec/api.json",
+            "--output-dir",
+            str(tmp_path / "out"),
+        ]
+    )
+    assert rc == 0
+    assert fetched_url["url"] == "https://developers.zoom.us/openapi-spec/api.json"
+    # The fetched tempfile path should appear in the codegen invocation.
+    assert str(fake_path) in captured_cmd
+    out = capsys.readouterr().out
+    assert "Fetched spec from" in out
+
+
+def test_main_from_url_propagates_fetch_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Network failure during fetch → exit 1 with a clear message."""
+    codegen = _load_codegen()
+
+    def boom(_url: str) -> Path:
+        raise RuntimeError("simulated DNS failure")
+
+    monkeypatch.setattr(codegen, "_fetch_spec_to_tempfile", boom)
+    rc = codegen.main(
+        [
+            "--from-url",
+            "https://example.com/spec.json",
+            "--output-dir",
+            str(tmp_path / "out"),
+        ]
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "failed to fetch spec" in err
+    assert "simulated DNS failure" in err
+
+
+def test_fetch_spec_to_tempfile_writes_response_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end smoke of the helper using httpx.MockTransport.
+
+    The helper does ``import httpx`` lazily inside, so patching
+    ``httpx.Client`` on the real httpx module is what the function
+    picks up at call time.
+    """
+    import httpx
+
+    codegen = _load_codegen()
+
+    body = b'{"openapi":"3.0.0","info":{"title":"Test"}}'
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=body)
+
+    real_client = httpx.Client
+
+    class _Mocked(real_client):
+        def __init__(self, *_a, **_kw):
+            super().__init__(transport=httpx.MockTransport(handler))
+
+    monkeypatch.setattr(httpx, "Client", _Mocked)
+
+    path = codegen._fetch_spec_to_tempfile("https://example.com/spec.json")
+    try:
+        assert path.read_bytes() == body
+    finally:
+        path.unlink()


### PR DESCRIPTION
## Summary

Saves a \`curl\` step in the codegen workflow.

**Before:**
\`\`\`bash
curl -o /tmp/zoom-openapi.json https://developers.zoom.us/openapi-spec/...
python scripts/codegen.py /tmp/zoom-openapi.json
\`\`\`

**After:**
\`\`\`bash
python scripts/codegen.py --from-url https://developers.zoom.us/openapi-spec/...
\`\`\`

## What's new

### \`scripts/codegen.py\`

\`--from-url URL\` is mutually exclusive with the positional spec path; argparse enforces "exactly one". New \`_fetch_spec_to_tempfile(url)\` helper:

- Uses \`httpx\` (already a runtime dep)
- \`follow_redirects=True\` (Zoom's spec URL redirects through a CDN)
- Writes to \`$TMPDIR/zoom-openapi.*.json\` via \`tempfile.mkstemp\`
- Caller owns cleanup — leaves the file for inspection on failure
- Doesn't reuse the project's \`ApiClient\` because the spec endpoint is public/unauthenticated and \`ApiClient\` would inject a bearer token unnecessarily

### README

Codegen section now shows both workflows side by side.

## Tests (+5)

| Test | Covers |
|---|---|
| requires either spec or --from-url | argparse exit 2 on neither |
| rejects both | mutually exclusive enforcement |
| --from-url calls _fetch + uses tempfile | spec path flows through to codegen invocation |
| --from-url propagates fetch failures | exit 1 + underlying error visible in stderr |
| _fetch_spec_to_tempfile end-to-end | httpx.MockTransport smoke test |

## Verification

\`\`\`
ruff check .          # All checks passed!
ruff format --check . # 44 files already formatted
mypy                  # Success: no issues found in 20 source files
pytest -q             # 591 passed (was 586; +5)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)