### PR TITLE
feat(meetings): polls depth-completion (list/get/create/update/delete/results)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Users settings update (PR #69): closes the deferred settings-update piece from #14. New `zoom users settings update [user-id] --from-json FILE` rounds out the get → edit → PATCH workflow.
 > Codegen `--from-url` (this branch): scripts/codegen.py can now fetch the OpenAPI spec directly instead of requiring a separate `curl` step.
 > Meetings create/update `--from-json` (this branch): `zoom meetings create` and `zoom meetings update` now accept a `--from-json FILE` (or `-` for stdin) payload-construction mode. Mutually exclusive with the per-field flags. Use this for `recurrence` and `settings` sub-objects that the field flags don't expose.
-> Meeting registrants surface (this branch): full registrant management — list / add / approve / deny / cancel / questions get / questions update — under `zoom meetings registrants`. First entry in the depth-first push to bring Meetings from ~15% → ~80% of Zoom's documented surface.
+> Meeting registrants surface (PR #72): full registrant management — list / add / approve / deny / cancel / questions get / questions update — under `zoom meetings registrants`. First entry in the depth-first push to bring Meetings from ~15% → ~80% of Zoom's documented surface.
+> Meeting polls surface (this branch): list / get / create / update / delete plus past-meeting `results` — under `zoom meetings polls`. Second iteration of the depth-first push.
+
+### Added (post-#13 depth-completion: polls)
+- `zoom meetings polls list <meeting-id>` — TSV output (id / title / status / anonymous).
+- `zoom meetings polls get <meeting-id> <poll-id>` — raw JSON output (round-trips into `polls update --from-json`).
+- `zoom meetings polls create <meeting-id> --from-json FILE` — JSON-only because polls nest deep (questions / answers / right_answers / answer_required) and per-field flags would be unusable.
+- `zoom meetings polls update <meeting-id> <poll-id> --from-json FILE` — full PUT replace per Zoom's spec (NOT a merge); confirms by default since omitted fields are dropped.
+- `zoom meetings polls delete <meeting-id> <poll-id>` — confirms by default; `--yes` to skip.
+- `zoom meetings polls results <meeting-id>` — past-meeting poll results from a different namespace (`/past_meetings/<id>/polls`); JSON output.
+- New API helpers: `meetings.list_polls`, `meetings.get_poll`, `meetings.create_poll`, `meetings.update_poll` (PUT semantics), `meetings.delete_poll`, `meetings.list_past_poll_results`.
 
 ### Added (post-#13 depth-completion: registrants)
 - `zoom meetings registrants list <meeting-id> [--status pending|approved|denied]` — paginated TSV output (id / email / first_name / last_name / status). Default status `pending` mirrors Zoom's own default (the approval queue admins care about).

--- a/tests/test_api_meetings.py
+++ b/tests/test_api_meetings.py
@@ -330,3 +330,122 @@ def test_allowed_registrant_actions_pinned() -> None:
     assert "approve" in meetings.ALLOWED_REGISTRANT_ACTIONS
     assert "deny" in meetings.ALLOWED_REGISTRANT_ACTIONS
     assert "cancel" in meetings.ALLOWED_REGISTRANT_ACTIONS
+
+
+# ---- polls depth-completion (post-#13 follow-up) --------------------------
+
+
+def test_list_polls_targets_meeting_path() -> None:
+    """Polls list is a single GET (not paginated — Zoom returns the
+    entire poll set inline) so we surface the raw envelope."""
+    fake_client = MagicMock()
+    fake_client.get.return_value = {
+        "total_records": 1,
+        "polls": [{"id": "p-1", "title": "Q1"}],
+    }
+
+    result = meetings.list_polls(fake_client, 123)
+
+    fake_client.get.assert_called_once_with("/meetings/123/polls")
+    assert result["polls"][0]["id"] == "p-1"
+
+
+def test_list_polls_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"polls": []}
+
+    meetings.list_polls(fake_client, "evil/../99")
+    arg = fake_client.get.call_args[0][0]
+    assert "/.." not in arg
+    assert "%2F" in arg
+
+
+def test_get_poll_targets_correct_path() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"id": "p-1", "title": "Q1"}
+
+    result = meetings.get_poll(fake_client, 123, "p-1")
+
+    fake_client.get.assert_called_once_with("/meetings/123/polls/p-1")
+    assert result["id"] == "p-1"
+
+
+def test_get_poll_url_encodes_both_segments() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {}
+
+    meetings.get_poll(fake_client, "m/../1", "p/../2")
+    arg = fake_client.get.call_args[0][0]
+    # Each segment has 2 slashes → 2*2 == 4 encoded chars total.
+    assert arg.count("%2F") == 4
+    assert "/.." not in arg
+
+
+def test_create_poll_posts_payload() -> None:
+    fake_client = MagicMock()
+    fake_client.post.return_value = {"id": "p-new", "title": "T"}
+
+    payload = {
+        "title": "T",
+        "questions": [{"name": "Q1", "type": "single", "answers": ["A", "B"]}],
+    }
+    result = meetings.create_poll(fake_client, 123, payload)
+
+    fake_client.post.assert_called_once_with("/meetings/123/polls", json=payload)
+    assert result["id"] == "p-new"
+
+
+def test_update_poll_puts_full_payload() -> None:
+    """Per Zoom's spec the poll update is a PUT (full replace) — make
+    that explicit in the helper rather than masquerading as PATCH."""
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+
+    payload = {"title": "T2", "questions": []}
+    meetings.update_poll(fake_client, 123, "p-1", payload)
+
+    fake_client.put.assert_called_once_with("/meetings/123/polls/p-1", json=payload)
+
+
+def test_update_poll_url_encodes_both_segments() -> None:
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+
+    meetings.update_poll(fake_client, "m/../1", "p/../2", {"title": ""})
+    arg = fake_client.put.call_args[0][0]
+    assert arg.count("%2F") == 4
+    assert "/.." not in arg
+
+
+def test_delete_poll_targets_correct_path() -> None:
+    fake_client = MagicMock()
+    fake_client.delete.return_value = {}
+
+    meetings.delete_poll(fake_client, 123, "p-1")
+
+    fake_client.delete.assert_called_once_with("/meetings/123/polls/p-1")
+
+
+def test_delete_poll_url_encodes_both_segments() -> None:
+    fake_client = MagicMock()
+    fake_client.delete.return_value = {}
+
+    meetings.delete_poll(fake_client, "m/../1", "p/../2")
+    arg = fake_client.delete.call_args[0][0]
+    assert arg.count("%2F") == 4
+    assert "/.." not in arg
+
+
+def test_list_past_poll_results_targets_past_meetings_endpoint() -> None:
+    """Past-meeting poll RESULTS live under /past_meetings (not /meetings) —
+    different namespace, identical resource shape."""
+    fake_client = MagicMock()
+    fake_client.get.return_value = {
+        "id": 123,
+        "questions": [{"name": "Q1", "question_details": []}],
+    }
+
+    result = meetings.list_past_poll_results(fake_client, 123)
+
+    fake_client.get.assert_called_once_with("/past_meetings/123/polls")
+    assert "questions" in result

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1692,6 +1692,197 @@ def test_meetings_registrants_questions_update_yes_calls_patch(
     assert captured["payload"] == {"questions": [{"field_name": "country", "required": False}]}
 
 
+# ---- meeting polls (depth-completion follow-up to #13) -----------------
+
+
+def test_meetings_polls_list_prints_tsv(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    _save_creds()
+
+    def fake_list(_client, meeting_id):
+        assert meeting_id == "12345"
+        return {
+            "total_records": 2,
+            "polls": [
+                {"id": "p-1", "title": "Q1", "status": "started", "anonymous": False},
+                {"id": "p-2", "title": "Q2", "status": "ended", "anonymous": True},
+            ],
+        }
+
+    _patch_meetings_module(monkeypatch, list_polls=fake_list)
+    result = runner.invoke(main, ["meetings", "polls", "list", "12345"])
+    assert result.exit_code == 0, result.output
+    assert "id\ttitle\tstatus\tanonymous" in result.output
+    assert "p-1\tQ1\tstarted\tFalse" in result.output
+    assert "p-2\tQ2\tended\tTrue" in result.output
+
+
+def test_meetings_polls_get_prints_json(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    _save_creds()
+    payload = {"id": "p-1", "title": "Q1", "questions": []}
+
+    def fake_get(_client, meeting_id, poll_id):
+        assert (meeting_id, poll_id) == ("12345", "p-1")
+        return payload
+
+    _patch_meetings_module(monkeypatch, get_poll=fake_get)
+    result = runner.invoke(main, ["meetings", "polls", "get", "12345", "p-1"])
+    assert result.exit_code == 0, result.output
+    import json as _json
+
+    assert _json.loads(result.output) == payload
+
+
+def test_meetings_polls_create_sends_payload(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+    json_file = tmp_path / "poll.json"
+    json_file.write_text(
+        '{"title": "T", "questions": [{"name": "Q1", "type": "single", "answers": ["A", "B"]}]}'
+    )
+    captured: dict[str, object] = {}
+
+    def fake_create(_client, meeting_id, payload):
+        captured["meeting_id"] = meeting_id
+        captured["payload"] = payload
+        return {"id": "p-new", "title": "T"}
+
+    _patch_meetings_module(monkeypatch, create_poll=fake_create)
+    result = runner.invoke(
+        main,
+        ["meetings", "polls", "create", "12345", "--from-json", str(json_file)],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["meeting_id"] == "12345"
+    assert captured["payload"]["title"] == "T"
+    assert "Created poll" in result.output
+    assert "p-new" in result.output
+
+
+def test_meetings_polls_create_rejects_invalid_json(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+    json_file = tmp_path / "poll.json"
+    json_file.write_text("not valid json {{{")
+    _patch_meetings_module(monkeypatch, create_poll=lambda *_a, **_k: {})
+    result = runner.invoke(
+        main, ["meetings", "polls", "create", "12345", "--from-json", str(json_file)]
+    )
+    assert result.exit_code == 1
+    assert "Invalid JSON" in result.output
+
+
+def test_meetings_polls_update_yes_skips_confirm(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+    json_file = tmp_path / "poll.json"
+    json_file.write_text('{"title": "T2", "questions": []}')
+    captured: dict[str, object] = {}
+
+    def fake_update(_client, meeting_id, poll_id, payload):
+        captured["meeting_id"] = meeting_id
+        captured["poll_id"] = poll_id
+        captured["payload"] = payload
+
+    _patch_meetings_module(monkeypatch, update_poll=fake_update)
+    result = runner.invoke(
+        main,
+        [
+            "meetings",
+            "polls",
+            "update",
+            "12345",
+            "p-1",
+            "--from-json",
+            str(json_file),
+            "--yes",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["poll_id"] == "p-1"
+    assert "Updated poll" in result.output
+
+
+def test_meetings_polls_update_confirms_and_aborts(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Without --yes, an explicit 'n' aborts and the API is not called."""
+    _save_creds()
+    json_file = tmp_path / "poll.json"
+    json_file.write_text('{"title": "T2", "questions": []}')
+    called = {"n": 0}
+
+    def fake_update(*_a, **_k):
+        called["n"] += 1
+
+    _patch_meetings_module(monkeypatch, update_poll=fake_update)
+    result = runner.invoke(
+        main,
+        ["meetings", "polls", "update", "12345", "p-1", "--from-json", str(json_file)],
+        input="n\n",
+    )
+    assert result.exit_code == 0, result.output
+    assert "Aborted" in result.output
+    assert called["n"] == 0
+
+
+def test_meetings_polls_delete_yes_calls_api(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_delete(_client, meeting_id, poll_id):
+        captured["meeting_id"] = meeting_id
+        captured["poll_id"] = poll_id
+
+    _patch_meetings_module(monkeypatch, delete_poll=fake_delete)
+    result = runner.invoke(main, ["meetings", "polls", "delete", "12345", "p-1", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert captured == {"meeting_id": "12345", "poll_id": "p-1"}
+    assert "Deleted poll p-1" in result.output
+
+
+def test_meetings_polls_delete_confirms_and_aborts(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    called = {"n": 0}
+
+    def fake_delete(*_a, **_k):
+        called["n"] += 1
+
+    _patch_meetings_module(monkeypatch, delete_poll=fake_delete)
+    result = runner.invoke(main, ["meetings", "polls", "delete", "12345", "p-1"], input="n\n")
+    assert result.exit_code == 0, result.output
+    assert "Aborted" in result.output
+    assert called["n"] == 0
+
+
+def test_meetings_polls_results_prints_json(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Past-meeting poll results — different namespace, JSON output."""
+    _save_creds()
+    payload = {
+        "id": 12345,
+        "questions": [{"name": "Q1", "question_details": [{"answer": "A", "count": 3}]}],
+    }
+
+    def fake_results(_client, meeting_id):
+        assert meeting_id == "12345"
+        return payload
+
+    _patch_meetings_module(monkeypatch, list_past_poll_results=fake_results)
+    result = runner.invoke(main, ["meetings", "polls", "results", "12345"])
+    assert result.exit_code == 0, result.output
+    import json as _json
+
+    assert _json.loads(result.output) == payload
+
+
 # ---- #14 (write): zoom users create / delete / settings get -------------
 
 

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -1473,6 +1473,175 @@ def meetings_registrants_questions_update(meeting_id, from_json, yes):
     click.echo(f"Updated registration questions for meeting {meeting_id}.")
 
 
+# ---- Meeting polls (depth-completion follow-up to #13) -----------------
+#
+# Poll payloads are nested (questions[]/answers[]/right_answers[]/
+# answer_required) so create/update are JSON-only. The list/get/delete
+# commands keep the simple shape from the rest of the CLI.
+
+
+@meetings_cmd.group("polls", help="Manage in-meeting polls.")
+def meetings_polls_cmd():
+    """Group for ``zoom meetings polls ...``."""
+
+
+@meetings_polls_cmd.command("list", help="List polls on a meeting (GET /meetings/<id>/polls).")
+@click.argument("meeting_id")
+@_translate_keyring_errors
+def meetings_polls_list(meeting_id):
+    """TSV output (id\\ttitle\\tstatus\\tanonymous)."""
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            data = meetings.list_polls(client, meeting_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo("id\ttitle\tstatus\tanonymous")
+    for p in data.get("polls", []):
+        click.echo(
+            f"{p.get('id', '')}\t"
+            f"{p.get('title', '')}\t"
+            f"{p.get('status', '')}\t"
+            f"{p.get('anonymous', '')}"
+        )
+
+
+@meetings_polls_cmd.command(
+    "get", help="Print one poll's full detail as JSON (GET /meetings/<id>/polls/<poll-id>)."
+)
+@click.argument("meeting_id")
+@click.argument("poll_id")
+@_translate_keyring_errors
+def meetings_polls_get(meeting_id, poll_id):
+    """Output is raw JSON so it round-trips into ``polls update --from-json``."""
+    import json as _json
+
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            data = meetings.get_poll(client, meeting_id, poll_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(_json.dumps(data, indent=2))
+
+
+@meetings_polls_cmd.command("create", help="Add a poll to a meeting (POST /meetings/<id>/polls).")
+@click.argument("meeting_id")
+@click.option(
+    "--from-json",
+    "from_json",
+    type=click.File("r", encoding="utf-8"),
+    required=True,
+    help=(
+        "Read the full poll body from a JSON file (or '-' for stdin). "
+        "Polls are nested enough (questions/answers/right_answers/"
+        "answer_required) that per-field flags would be unusable — "
+        "JSON-only by design."
+    ),
+)
+@_translate_keyring_errors
+def meetings_polls_create(meeting_id, from_json):
+    """Returns the created poll's id and title on success."""
+    payload = _load_json_payload_or_exit(from_json, label="--from-json input")
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            result = meetings.create_poll(client, meeting_id, payload)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Created poll. id: {result.get('id', '')}, title: {result.get('title', '')}")
+
+
+@meetings_polls_cmd.command(
+    "update",
+    help="Replace a poll wholesale (PUT /meetings/<id>/polls/<poll-id>).",
+)
+@click.argument("meeting_id")
+@click.argument("poll_id")
+@click.option(
+    "--from-json",
+    "from_json",
+    type=click.File("r", encoding="utf-8"),
+    required=True,
+    help="Read the full poll body from a JSON file (or '-' for stdin).",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@_translate_keyring_errors
+def meetings_polls_update(meeting_id, poll_id, from_json, yes):
+    """Zoom's poll update is a PUT — full replace, NOT a merge. Round-trip
+    via ``polls get`` first to pick up the existing shape."""
+    payload = _load_json_payload_or_exit(from_json, label="--from-json input")
+    if not yes and not click.confirm(
+        f"Replace poll {poll_id} on meeting {meeting_id}? (omitted fields will be dropped)",
+        default=False,
+    ):
+        click.echo("Aborted.")
+        return
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            meetings.update_poll(client, meeting_id, poll_id, payload)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Updated poll {poll_id} on meeting {meeting_id}.")
+
+
+@meetings_polls_cmd.command(
+    "delete",
+    help="Delete a poll (DELETE /meetings/<id>/polls/<poll-id>).",
+)
+@click.argument("meeting_id")
+@click.argument("poll_id")
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@_translate_keyring_errors
+def meetings_polls_delete(meeting_id, poll_id, yes):
+    if not yes and not click.confirm(
+        f"Delete poll {poll_id} from meeting {meeting_id}?", default=False
+    ):
+        click.echo("Aborted.")
+        return
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            meetings.delete_poll(client, meeting_id, poll_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Deleted poll {poll_id} from meeting {meeting_id}.")
+
+
+@meetings_polls_cmd.command(
+    "results",
+    help="Print poll RESULTS for a past meeting (GET /past_meetings/<id>/polls).",
+)
+@click.argument("meeting_id")
+@_translate_keyring_errors
+def meetings_polls_results(meeting_id):
+    """Different namespace from the live polls endpoints — results live
+    under /past_meetings, not /meetings. Output is raw JSON because the
+    per-question result breakdowns nest deeper than TSV can express."""
+    import json as _json
+
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            data = meetings.list_past_poll_results(client, meeting_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(_json.dumps(data, indent=2))
+
+
 # ---- Zoom Cloud Recordings ----------------------------------------------
 #
 # Closes #15. Same confirmation-flow design as `meetings delete`:

--- a/zoom_cli/api/meetings.py
+++ b/zoom_cli/api/meetings.py
@@ -298,3 +298,92 @@ def update_registration_questions(
         f"/meetings/{quote(str(meeting_id), safe='')}/registrants/questions",
         json=payload,
     )
+
+
+# ---- polls surface (in-meeting Q&A; structured single-/multi-/matching --
+# question shapes — payload is complex enough that the CLI is JSON-only) --
+
+
+def list_polls(client: ApiClient, meeting_id: str | int) -> dict[str, Any]:
+    """``GET /meetings/{meeting_id}/polls`` — return the poll envelope.
+
+    Not paginated: Zoom returns the full poll set inline (typically a
+    handful of polls per meeting). The caller gets back the raw envelope
+    so the ``total_records`` field is available for downstream display.
+
+    Required scopes: ``meeting:read:meeting``.
+    """
+    return client.get(f"/meetings/{quote(str(meeting_id), safe='')}/polls")
+
+
+def get_poll(client: ApiClient, meeting_id: str | int, poll_id: str) -> dict[str, Any]:
+    """``GET /meetings/{meeting_id}/polls/{poll_id}`` — one poll's detail.
+
+    Required scopes: ``meeting:read:meeting``.
+    """
+    return client.get(
+        f"/meetings/{quote(str(meeting_id), safe='')}/polls/{quote(poll_id, safe='')}"
+    )
+
+
+def create_poll(
+    client: ApiClient, meeting_id: str | int, payload: dict[str, Any]
+) -> dict[str, Any]:
+    """``POST /meetings/{meeting_id}/polls`` — add a poll.
+
+    ``payload`` is the full Zoom poll body (``title``, ``poll_type``,
+    ``anonymous``, and a ``questions`` array of question dicts with
+    nested ``answers`` / ``right_answers`` / ``answer_required``).
+
+    Returns the created poll's full detail object.
+
+    Required scopes: ``meeting:write:meeting``.
+    """
+    return client.post(f"/meetings/{quote(str(meeting_id), safe='')}/polls", json=payload)
+
+
+def update_poll(
+    client: ApiClient,
+    meeting_id: str | int,
+    poll_id: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """``PUT /meetings/{meeting_id}/polls/{poll_id}`` — full replace.
+
+    Note Zoom's poll update is a PUT (full replace), not a PATCH —
+    omitted fields are dropped. Round-trip via :func:`get_poll` first
+    to pick up the existing shape, edit, then submit.
+
+    Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``meeting:write:meeting``.
+    """
+    return client.put(
+        f"/meetings/{quote(str(meeting_id), safe='')}/polls/{quote(poll_id, safe='')}",
+        json=payload,
+    )
+
+
+def delete_poll(client: ApiClient, meeting_id: str | int, poll_id: str) -> dict[str, Any]:
+    """``DELETE /meetings/{meeting_id}/polls/{poll_id}`` — remove a poll.
+
+    Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``meeting:write:meeting``.
+    """
+    return client.delete(
+        f"/meetings/{quote(str(meeting_id), safe='')}/polls/{quote(poll_id, safe='')}"
+    )
+
+
+def list_past_poll_results(client: ApiClient, meeting_id: str | int) -> dict[str, Any]:
+    """``GET /past_meetings/{meeting_id}/polls`` — poll RESULTS (not
+    config) for a meeting that has already ended.
+
+    Different namespace from the live polls endpoints: results live
+    under ``/past_meetings``, not ``/meetings``. Same resource shape
+    (questions with per-answer breakdowns).
+
+    Required scopes: ``meeting:read:meeting``.
+    """
+    return client.get(f"/past_meetings/{quote(str(meeting_id), safe='')}/polls")


### PR DESCRIPTION
## Summary
Second iteration of the depth-first push on Meetings. Adds the full poll management surface (5 endpoints) plus past-meeting poll **results** from the separate \`/past_meetings\` namespace.

## Why
Polls are the next-most-asked-for thing on a meeting after registrants — and the live polls + past-meeting results pair is naturally one chunk because the data shape is identical and the use cases (configure beforehand, view results after) are sequential.

## What changed
**API helpers** (\`zoom_cli/api/meetings.py\`):
- \`list_polls\` — single GET, not paginated (Zoom returns the poll set inline).
- \`get_poll\`
- \`create_poll\`
- \`update_poll\` — PUT semantics (full replace). The helper makes this explicit so callers don't accidentally treat it like a PATCH/merge and lose fields.
- \`delete_poll\`
- \`list_past_poll_results\` — \`/past_meetings/{id}/polls\` (different namespace, identical shape).

**CLI** (under \`zoom meetings polls\`):
- \`list\` (TSV: id / title / status / anonymous)
- \`get\` (JSON, round-trips into update)
- \`create\` (\`--from-json FILE\` — JSON-only; nested poll payloads make per-field flags unusable)
- \`update\` (\`--from-json FILE\` + \`--yes\` guard; confirms by default since omitted fields are dropped)
- \`delete\` (\`--yes\` guard; confirms by default)
- \`results\` (past-meeting poll results, JSON output)

## Test plan
- [x] \`pytest -q\` — 645 pass (626 → 645, 10 new API + 9 new CLI)
- [x] \`ruff check . && ruff format --check .\` — clean
- [x] \`mypy\` — clean
- [x] Smoke: \`zoom meetings polls --help\` shows all six subcommands
- [ ] CI passes on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)