### PR TITLE
feat(meetings): survey + token + batch register + in-meeting controls (closes Meetings to ~80%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Meeting registrants surface (PR #72): full registrant management — list / add / approve / deny / cancel / questions get / questions update — under `zoom meetings registrants`. First entry in the depth-first push to bring Meetings from ~15% → ~80% of Zoom's documented surface.
 > Meeting polls surface (PR #73): list / get / create / update / delete plus past-meeting `results` — under `zoom meetings polls`. Second iteration of the depth-first push.
 > Meeting livestream surface (PR #74): get / update RTMP config + start/stop the livestream — under `zoom meetings livestream`. Third iteration of the depth-first push.
-> Past instances + invitation + recover (this branch): `zoom meetings invitation`, `zoom meetings recover`, and a new `zoom meetings past` subgroup with `instances / get / participants`. Fourth iteration of the depth-first push.
+> Past instances + invitation + recover (PR #75): `zoom meetings invitation`, `zoom meetings recover`, and a new `zoom meetings past` subgroup with `instances / get / participants`. Fourth iteration of the depth-first push.
+> Survey + token + batch register + in-meeting controls (this branch): `zoom meetings survey [get/update/delete]`, `zoom meetings token`, `zoom meetings registrants batch`, `zoom meetings control`. Fifth iteration of the depth-first push — closes Meetings to ~80% of Zoom's documented surface.
+
+### Added (post-#13 depth-completion: survey + token + batch + control)
+- `zoom meetings survey get|update|delete <meeting-id>` — manage the post-meeting survey shown to attendees. `update --from-json FILE` (JSON-only because surveys nest deep). All mutating verbs confirm by default; `--yes` to skip.
+- `zoom meetings token <meeting-id> [--type zak|zpk]` — fetch the start-meeting token (sensitive — anyone with it can start the meeting as the host). Default `zak` mirrors Zoom's own default.
+- `zoom meetings registrants batch <meeting-id> --from-json FILE` — bulk-register up to 30 attendees in one call. Returns Zoom's per-attendee join_url array.
+- `zoom meetings control <meeting-id> --from-json FILE` — send an in-meeting control event (invite, mute_participants, etc.). Lives in the `/live_meetings` namespace (NOT `/meetings`) — different scopes apply. Confirms by default since these affect a meeting in progress.
+- New API helpers: `meetings.get_survey`, `meetings.update_survey`, `meetings.delete_survey`, `meetings.get_token` (validated against `ALLOWED_TOKEN_TYPES = ("zak", "zpk")`), `meetings.batch_register`, `meetings.in_meeting_control`.
 
 ### Added (post-#13 depth-completion: past instances + invitation + recover)
 - `zoom meetings invitation <meeting-id>` — print the canonical email invitation text Zoom builds for the meeting.

--- a/tests/test_api_meetings.py
+++ b/tests/test_api_meetings.py
@@ -660,3 +660,129 @@ def test_recover_meeting_url_encodes_id() -> None:
     arg = fake_client.put.call_args[0][0]
     assert "/.." not in arg
     assert "%2F" in arg
+
+
+# ---- survey + token + batch register + in-meeting controls -------------
+
+
+def test_get_survey_targets_correct_path() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"questions": [{"name": "Q1"}]}
+
+    result = meetings.get_survey(fake_client, 123)
+
+    fake_client.get.assert_called_once_with("/meetings/123/survey")
+    assert result["questions"][0]["name"] == "Q1"
+
+
+def test_update_survey_patches_with_payload() -> None:
+    fake_client = MagicMock()
+    fake_client.patch.return_value = {}
+
+    payload = {"questions": [{"name": "Rating", "type": "single"}], "show_in_browser": True}
+    meetings.update_survey(fake_client, 123, payload)
+
+    fake_client.patch.assert_called_once_with("/meetings/123/survey", json=payload)
+
+
+def test_delete_survey_uses_delete() -> None:
+    fake_client = MagicMock()
+    fake_client.delete.return_value = {}
+
+    meetings.delete_survey(fake_client, 123)
+
+    fake_client.delete.assert_called_once_with("/meetings/123/survey")
+
+
+def test_survey_url_encodes_id() -> None:
+    """Cross-cutting: all three survey verbs encode their path segment."""
+    fake_client = MagicMock()
+    fake_client.get.return_value = {}
+    fake_client.patch.return_value = {}
+    fake_client.delete.return_value = {}
+
+    meetings.get_survey(fake_client, "evil/../1")
+    meetings.update_survey(fake_client, "evil/../1", {})
+    meetings.delete_survey(fake_client, "evil/../1")
+
+    for call in (
+        fake_client.get.call_args[0][0],
+        fake_client.patch.call_args[0][0],
+        fake_client.delete.call_args[0][0],
+    ):
+        assert "/.." not in call
+        assert "%2F" in call
+
+
+def test_get_token_default_type_is_zak() -> None:
+    """Zoom defaults the token endpoint to ZAK (the most common: needed
+    to start a meeting on someone's behalf). Keep that as our default."""
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"token": "abc.def.ghi"}
+
+    result = meetings.get_token(fake_client, 123)
+
+    fake_client.get.assert_called_once_with("/meetings/123/token", params={"type": "zak"})
+    assert result["token"] == "abc.def.ghi"
+
+
+def test_get_token_forwards_type_filter() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"token": "x"}
+
+    meetings.get_token(fake_client, 123, token_type="zpk")
+
+    fake_client.get.assert_called_once_with("/meetings/123/token", params={"type": "zpk"})
+
+
+@pytest.mark.parametrize("bad_type", ["bogus", "", "ZAK", "z a k"])
+def test_get_token_rejects_unknown_type(bad_type: str) -> None:
+    fake_client = MagicMock()
+    with pytest.raises(ValueError, match="token_type"):
+        meetings.get_token(fake_client, 123, token_type=bad_type)
+
+
+def test_allowed_token_types_pinned() -> None:
+    assert "zak" in meetings.ALLOWED_TOKEN_TYPES
+
+
+def test_batch_register_posts_payload() -> None:
+    """Bulk registration: payload contains an array of registrants under
+    the ``registrants`` key. Returns Zoom's bulk response with one
+    join_url per accepted entry."""
+    fake_client = MagicMock()
+    fake_client.post.return_value = {
+        "registrants": [{"email": "a@e.com", "join_url": "https://zoom.us/w/1?tk=A"}]
+    }
+
+    payload = {
+        "auto_approve": True,
+        "registrants_confirmation_email": False,
+        "registrants": [{"email": "a@e.com", "first_name": "A"}],
+    }
+    result = meetings.batch_register(fake_client, 123, payload)
+
+    fake_client.post.assert_called_once_with("/meetings/123/batch_registrants", json=payload)
+    assert result["registrants"][0]["email"] == "a@e.com"
+
+
+def test_in_meeting_control_patches_live_meetings_path() -> None:
+    """In-meeting control sits under /live_meetings (NOT /meetings) —
+    distinct namespace, action verbs like 'invite' / 'mute_participants'."""
+    fake_client = MagicMock()
+    fake_client.patch.return_value = {}
+
+    payload = {"method": "invite", "params": {"contacts": [{"email": "a@e.com"}]}}
+    meetings.in_meeting_control(fake_client, 123, payload)
+
+    fake_client.patch.assert_called_once_with("/live_meetings/123/events", json=payload)
+
+
+def test_in_meeting_control_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.patch.return_value = {}
+
+    meetings.in_meeting_control(fake_client, "evil/../1", {})
+    arg = fake_client.patch.call_args[0][0]
+    assert "/.." not in arg
+    assert "%2F" in arg

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2209,6 +2209,204 @@ def test_meetings_past_participants_prints_tsv(
     assert "p-2\tBob\tb@e.com\tT3\tT4" in result.output
 
 
+# ---- survey + token + batch register + control (depth-completion) ------
+
+
+def test_meetings_survey_get_prints_json(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    payload = {"questions": [{"name": "Rating", "type": "single"}]}
+
+    def fake_get(_client, mid):
+        assert mid == "12345"
+        return payload
+
+    _patch_meetings_module(monkeypatch, get_survey=fake_get)
+    result = runner.invoke(main, ["meetings", "survey", "get", "12345"])
+    assert result.exit_code == 0, result.output
+    import json as _json
+
+    assert _json.loads(result.output) == payload
+
+
+def test_meetings_survey_update_yes_calls_patch(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+    json_file = tmp_path / "s.json"
+    json_file.write_text('{"questions": [{"name": "Rating"}], "show_in_browser": true}')
+    captured: dict[str, object] = {}
+
+    def fake_update(_client, mid, payload):
+        captured["mid"] = mid
+        captured["payload"] = payload
+
+    _patch_meetings_module(monkeypatch, update_survey=fake_update)
+    result = runner.invoke(
+        main,
+        ["meetings", "survey", "update", "12345", "--from-json", str(json_file), "--yes"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["mid"] == "12345"
+    assert captured["payload"] == {
+        "questions": [{"name": "Rating"}],
+        "show_in_browser": True,
+    }
+    assert "Updated survey" in result.output
+
+
+def test_meetings_survey_update_confirms_and_aborts(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+    json_file = tmp_path / "s.json"
+    json_file.write_text("{}")
+    called = {"n": 0}
+    _patch_meetings_module(
+        monkeypatch, update_survey=lambda *_a, **_k: called.__setitem__("n", called["n"] + 1)
+    )
+    result = runner.invoke(
+        main,
+        ["meetings", "survey", "update", "12345", "--from-json", str(json_file)],
+        input="n\n",
+    )
+    assert result.exit_code == 0, result.output
+    assert "Aborted" in result.output
+    assert called["n"] == 0
+
+
+def test_meetings_survey_delete_yes_calls_api(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_delete(_client, mid):
+        captured["mid"] = mid
+
+    _patch_meetings_module(monkeypatch, delete_survey=fake_delete)
+    result = runner.invoke(main, ["meetings", "survey", "delete", "12345", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert captured["mid"] == "12345"
+    assert "Deleted survey" in result.output
+
+
+def test_meetings_token_default_zak(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_token(_client, mid, *, token_type):
+        captured["mid"] = mid
+        captured["type"] = token_type
+        return {"token": "abc.def.ghi"}
+
+    _patch_meetings_module(monkeypatch, get_token=fake_token)
+    result = runner.invoke(main, ["meetings", "token", "12345"])
+    assert result.exit_code == 0, result.output
+    assert captured["type"] == "zak"
+    assert "abc.def.ghi" in result.output
+
+
+def test_meetings_token_forwards_type(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_token(_client, _mid, *, token_type):
+        captured["type"] = token_type
+        return {"token": "x"}
+
+    _patch_meetings_module(monkeypatch, get_token=fake_token)
+    result = runner.invoke(main, ["meetings", "token", "12345", "--type", "zpk"])
+    assert result.exit_code == 0, result.output
+    assert captured["type"] == "zpk"
+
+
+def test_meetings_registrants_batch_sends_payload(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+    json_file = tmp_path / "batch.json"
+    json_file.write_text(
+        '{"auto_approve": true, "registrants": ['
+        '{"email": "a@e.com", "first_name": "A"}, '
+        '{"email": "b@e.com", "first_name": "B"}]}'
+    )
+    captured: dict[str, object] = {}
+
+    def fake_batch(_client, mid, payload):
+        captured["mid"] = mid
+        captured["payload"] = payload
+        return {
+            "registrants": [
+                {"email": "a@e.com", "join_url": "https://zoom.us/w/12345?tk=A"},
+                {"email": "b@e.com", "join_url": "https://zoom.us/w/12345?tk=B"},
+            ]
+        }
+
+    _patch_meetings_module(monkeypatch, batch_register=fake_batch)
+    result = runner.invoke(
+        main,
+        [
+            "meetings",
+            "registrants",
+            "batch",
+            "12345",
+            "--from-json",
+            str(json_file),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["mid"] == "12345"
+    assert len(captured["payload"]["registrants"]) == 2  # type: ignore[index]
+    assert "Registered 2 attendee(s)" in result.output
+
+
+def test_meetings_control_yes_sends_payload(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+    json_file = tmp_path / "ctrl.json"
+    json_file.write_text('{"method": "invite", "params": {"contacts": [{"email": "a@e.com"}]}}')
+    captured: dict[str, object] = {}
+
+    def fake_ctrl(_client, mid, payload):
+        captured["mid"] = mid
+        captured["payload"] = payload
+
+    _patch_meetings_module(monkeypatch, in_meeting_control=fake_ctrl)
+    result = runner.invoke(
+        main,
+        ["meetings", "control", "12345", "--from-json", str(json_file), "--yes"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["mid"] == "12345"
+    assert captured["payload"]["method"] == "invite"  # type: ignore[index]
+    assert "Sent in-meeting control 'invite'" in result.output
+
+
+def test_meetings_control_confirms_and_aborts(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+    json_file = tmp_path / "ctrl.json"
+    json_file.write_text('{"method": "mute_participants", "params": {}}')
+    called = {"n": 0}
+    _patch_meetings_module(
+        monkeypatch,
+        in_meeting_control=lambda *_a, **_k: called.__setitem__("n", called["n"] + 1),
+    )
+    result = runner.invoke(
+        main,
+        ["meetings", "control", "12345", "--from-json", str(json_file)],
+        input="n\n",
+    )
+    assert result.exit_code == 0, result.output
+    assert "Aborted" in result.output
+    assert "mute_participants" in result.output  # confirmation surfaced the verb
+    assert called["n"] == 0
+
+
 # ---- #14 (write): zoom users create / delete / settings get -------------
 
 

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -1956,6 +1956,196 @@ def meetings_past_participants(meeting_id_or_uuid, page_size):
         _exit_on_api_error(exc)
 
 
+# ---- Survey + token + batch register + in-meeting controls -------------
+
+
+@meetings_cmd.group("survey", help="Manage the post-meeting survey shown to attendees.")
+def meetings_survey_cmd():
+    """Group for ``zoom meetings survey ...``."""
+
+
+@meetings_survey_cmd.command(
+    "get", help="Print the survey config as JSON (GET /meetings/<id>/survey)."
+)
+@click.argument("meeting_id")
+@_translate_keyring_errors
+def meetings_survey_get(meeting_id):
+    """JSON output so it round-trips into ``survey update --from-json``."""
+    import json as _json
+
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            data = meetings.get_survey(client, meeting_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(_json.dumps(data, indent=2))
+
+
+@meetings_survey_cmd.command(
+    "update",
+    help="Replace the survey config (PATCH /meetings/<id>/survey).",
+)
+@click.argument("meeting_id")
+@click.option(
+    "--from-json",
+    "from_json",
+    type=click.File("r", encoding="utf-8"),
+    required=True,
+    help="Read the survey body from a JSON file (or '-' for stdin).",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@_translate_keyring_errors
+def meetings_survey_update(meeting_id, from_json, yes):
+    """Surveys nest deep (questions[]/custom_survey/show_in_browser/
+    third_party_survey) — JSON-only by design. Round-trip via
+    ``survey get`` first."""
+    payload = _load_json_payload_or_exit(from_json, label="--from-json input")
+    if not yes and not click.confirm(f"Replace survey on meeting {meeting_id}?", default=False):
+        click.echo("Aborted.")
+        return
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            meetings.update_survey(client, meeting_id, payload)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Updated survey for meeting {meeting_id}.")
+
+
+@meetings_survey_cmd.command("delete", help="Remove the survey (DELETE /meetings/<id>/survey).")
+@click.argument("meeting_id")
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@_translate_keyring_errors
+def meetings_survey_delete(meeting_id, yes):
+    if not yes and not click.confirm(f"Delete survey on meeting {meeting_id}?", default=False):
+        click.echo("Aborted.")
+        return
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            meetings.delete_survey(client, meeting_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Deleted survey from meeting {meeting_id}.")
+
+
+@meetings_cmd.command(
+    "token",
+    help="Get the start-meeting token (GET /meetings/<id>/token; sensitive).",
+)
+@click.argument("meeting_id")
+@click.option(
+    "--type",
+    "token_type",
+    type=click.Choice(list(meetings.ALLOWED_TOKEN_TYPES)),
+    default="zak",
+    show_default=True,
+    help="Token type. Default zak (start-meeting).",
+)
+@_translate_keyring_errors
+def meetings_token(meeting_id, token_type):
+    """Output is the raw token string. Sensitive — anyone with this
+    can start the meeting as the host. Don't paste into chat / tickets."""
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            data = meetings.get_token(client, meeting_id, token_type=token_type)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(data.get("token", ""))
+
+
+@meetings_registrants_cmd.command(
+    "batch",
+    help="Bulk-register up to 30 attendees (POST /meetings/<id>/batch_registrants).",
+)
+@click.argument("meeting_id")
+@click.option(
+    "--from-json",
+    "from_json",
+    type=click.File("r", encoding="utf-8"),
+    required=True,
+    help=(
+        "JSON file (or '-' for stdin) containing the bulk registration body. "
+        "Required shape: {registrants: [{email, first_name, ...}, ...], "
+        "auto_approve?, registrants_confirmation_email?}."
+    ),
+)
+@_translate_keyring_errors
+def meetings_registrants_batch(meeting_id, from_json):
+    """Returns one accepted entry per registrant with the per-attendee
+    join_url. Useful for "register the whole team in one shot" flows."""
+    import json as _json
+
+    payload = _load_json_payload_or_exit(from_json, label="--from-json input")
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            result = meetings.batch_register(client, meeting_id, payload)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    accepted = result.get("registrants", [])
+    click.echo(f"Registered {len(accepted)} attendee(s).")
+    click.echo(_json.dumps(result, indent=2))
+
+
+@meetings_cmd.command(
+    "control",
+    help="Send an in-meeting control event (PATCH /live_meetings/<id>/events).",
+)
+@click.argument("meeting_id")
+@click.option(
+    "--from-json",
+    "from_json",
+    type=click.File("r", encoding="utf-8"),
+    required=True,
+    help=(
+        "JSON file (or '-' for stdin) with {method, params}. Examples: "
+        '{"method": "invite", "params": {"contacts": [{"email": "a@e.com"}]}} '
+        'or {"method": "mute_participants", "params": {}}.'
+    ),
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@_translate_keyring_errors
+def meetings_control(meeting_id, from_json, yes):
+    """Lives in the /live_meetings namespace (NOT /meetings). Confirms by
+    default since these actions affect a meeting in progress (mute /
+    invite / etc. are user-visible)."""
+    payload = _load_json_payload_or_exit(from_json, label="--from-json input")
+    method = payload.get("method", "<unknown>")
+    if not yes and not click.confirm(
+        f"Send in-meeting control '{method}' to meeting {meeting_id}?", default=False
+    ):
+        click.echo("Aborted.")
+        return
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            meetings.in_meeting_control(client, meeting_id, payload)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Sent in-meeting control '{method}' to meeting {meeting_id}.")
+
+
 # ---- Zoom Cloud Recordings ----------------------------------------------
 #
 # Closes #15. Same confirmation-flow design as `meetings delete`:

--- a/zoom_cli/api/meetings.py
+++ b/zoom_cli/api/meetings.py
@@ -538,3 +538,120 @@ def recover_meeting(client: ApiClient, meeting_id: str | int) -> dict[str, Any]:
         f"/meetings/{quote(str(meeting_id), safe='')}/status",
         json={"action": "recover"},
     )
+
+
+# ---- post-meeting survey ------------------------------------------------
+
+
+def get_survey(client: ApiClient, meeting_id: str | int) -> dict[str, Any]:
+    """``GET /meetings/{meeting_id}/survey`` — fetch the post-meeting
+    survey config (questions + display options).
+
+    Required scopes: ``meeting:read:meeting``.
+    """
+    return client.get(f"/meetings/{quote(str(meeting_id), safe='')}/survey")
+
+
+def update_survey(
+    client: ApiClient, meeting_id: str | int, payload: dict[str, Any]
+) -> dict[str, Any]:
+    """``PATCH /meetings/{meeting_id}/survey`` — replace survey config.
+
+    ``payload`` accepts ``questions``, ``custom_survey``,
+    ``show_in_browser``, ``third_party_survey`` (for external survey
+    URLs). Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``meeting:write:meeting``.
+    """
+    return client.patch(f"/meetings/{quote(str(meeting_id), safe='')}/survey", json=payload)
+
+
+def delete_survey(client: ApiClient, meeting_id: str | int) -> dict[str, Any]:
+    """``DELETE /meetings/{meeting_id}/survey`` — remove the survey.
+
+    Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``meeting:write:meeting``.
+    """
+    return client.delete(f"/meetings/{quote(str(meeting_id), safe='')}/survey")
+
+
+# ---- meeting token (ZAK / ZPK) -----------------------------------------
+
+#: Allowed values for ``get_token(token_type=...)``. Zoom's ``type``
+#: query param. ``zak`` is the start-meeting token (most common);
+#: ``zpk`` is the host-presence token used by some embed flows.
+ALLOWED_TOKEN_TYPES: tuple[str, ...] = ("zak", "zpk")
+
+
+def get_token(
+    client: ApiClient,
+    meeting_id: str | int,
+    *,
+    token_type: str = "zak",  # noqa: S107 — "zak" is Zoom's token-type enum value, not a credential
+) -> dict[str, Any]:
+    """``GET /meetings/{meeting_id}/token`` — fetch a JWT-style token
+    used to start the meeting on the host's behalf.
+
+    Args:
+        client: Authenticated :class:`ApiClient`.
+        meeting_id: Numeric Zoom meeting ID.
+        token_type: One of :data:`ALLOWED_TOKEN_TYPES`. Default
+            ``"zak"`` mirrors Zoom's own default (the start-meeting
+            token used by SDK embeds).
+
+    Returns ``{token: str}``. The value is sensitive — anyone with it
+    can start the meeting as the host.
+
+    Required scopes: ``meeting:read:meeting`` (or admin equivalent).
+    """
+    if token_type not in ALLOWED_TOKEN_TYPES:
+        raise ValueError(f"token_type must be one of {ALLOWED_TOKEN_TYPES!r}, got {token_type!r}")
+    return client.get(
+        f"/meetings/{quote(str(meeting_id), safe='')}/token",
+        params={"type": token_type},
+    )
+
+
+# ---- bulk registration --------------------------------------------------
+
+
+def batch_register(
+    client: ApiClient, meeting_id: str | int, payload: dict[str, Any]
+) -> dict[str, Any]:
+    """``POST /meetings/{meeting_id}/batch_registrants`` — register up
+    to 30 attendees in one call.
+
+    ``payload`` should contain ``registrants`` (an array of
+    ``{email, first_name, last_name?}`` dicts) plus optional
+    ``auto_approve`` (default false) and
+    ``registrants_confirmation_email`` (default true). Returns Zoom's
+    bulk response with a ``registrants`` array — one entry per accepted
+    registrant including the per-attendee ``join_url``.
+
+    Required scopes: ``meeting:write:registrant``.
+    """
+    return client.post(
+        f"/meetings/{quote(str(meeting_id), safe='')}/batch_registrants",
+        json=payload,
+    )
+
+
+# ---- in-meeting control (live actions) ---------------------------------
+
+
+def in_meeting_control(
+    client: ApiClient, meeting_id: str | int, payload: dict[str, Any]
+) -> dict[str, Any]:
+    """``PATCH /live_meetings/{meeting_id}/events`` — perform an in-
+    meeting action (invite, mute_participants, etc.).
+
+    ``payload`` is ``{method: <action>, params: {...}}``. Note this
+    endpoint lives under the separate ``/live_meetings`` namespace
+    (not ``/meetings``) — different scopes apply.
+
+    Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``meeting:control:in_meeting`` or admin.
+    """
+    return client.patch(f"/live_meetings/{quote(str(meeting_id), safe='')}/events", json=payload)


### PR DESCRIPTION
## Summary
Fifth (and capping) iteration of the depth-first push on Meetings. Adds 6 endpoints across four small surfaces — survey CRUD, start-meeting token, bulk registration, in-meeting control. With this PR Meetings reaches ~80% of Zoom's documented endpoints (the original parity audit target).

## Why
After registrants (#72), polls (#73), livestream (#74), and past/invitation/recover (#75), what's left on Meetings is a long tail of small, mostly-independent endpoints. Bundling them as one PR because each is too small to ship alone, none share state, and they're all tested with the same shape (TDD red → green for the helper, then a confirm/--yes-guarded CLI test).

## What changed
**API helpers** (\`zoom_cli/api/meetings.py\`):
- \`get_survey / update_survey / delete_survey\` — \`/meetings/<id>/survey\`.
- \`get_token(*, token_type=\"zak\")\` — validated against \`ALLOWED_TOKEN_TYPES = (\"zak\", \"zpk\")\`. Default mirrors Zoom's own.
- \`batch_register\` — \`POST /meetings/<id>/batch_registrants\` (up to 30 attendees per call).
- \`in_meeting_control\` — \`PATCH /live_meetings/<id>/events\`. Lives in the \`/live_meetings\` namespace, NOT \`/meetings\` — different scopes.

**CLI**:
- \`zoom meetings survey get|update|delete\` — \`update --from-json FILE\` (JSON-only since surveys nest deep). All mutating verbs confirm by default.
- \`zoom meetings token <id> [--type zak|zpk]\` — sensitive output (anyone with the token can start the meeting as host); flagged in help text.
- \`zoom meetings registrants batch <id> --from-json FILE\` — bulk register; prints accepted count + per-attendee join_urls.
- \`zoom meetings control <id> --from-json FILE\` — confirms by default since these affect a meeting in progress; \`--yes\` to skip. Confirmation message surfaces the verb being sent.

## Coverage update
With this PR landed, Meetings goes from ~15% (just CRUD + end) to **~80% of Zoom's documented Meetings surface**. Remaining tail: meeting templates, branding, live-streaming token, scheduler-link share — small enough that they can pick up later as one-off PRs without a dedicated push.

Next up the depth-first queue: User surface (currently ~25% → target ~80%) — presence/status, virtual backgrounds, schedulers, vanity URL.

## Test plan
- [x] \`pytest -q\` — 703 pass (680 → 703, 14 new API + 9 new CLI)
- [x] \`ruff check . && ruff format --check .\` — clean
- [x] \`mypy\` — clean
- [x] Smoke: \`zoom meetings --help\` shows the new \`survey / token / control\` entries; \`zoom meetings registrants --help\` shows the new \`batch\` entry
- [ ] CI passes on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)