### PR TITLE
feat(users): status + password + email + token + permissions (depth-completion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Meeting polls surface (PR #73): list / get / create / update / delete plus past-meeting `results` — under `zoom meetings polls`. Second iteration of the depth-first push.
 > Meeting livestream surface (PR #74): get / update RTMP config + start/stop the livestream — under `zoom meetings livestream`. Third iteration of the depth-first push.
 > Past instances + invitation + recover (PR #75): `zoom meetings invitation`, `zoom meetings recover`, and a new `zoom meetings past` subgroup with `instances / get / participants`. Fourth iteration of the depth-first push.
-> Survey + token + batch register + in-meeting controls (this branch): `zoom meetings survey [get/update/delete]`, `zoom meetings token`, `zoom meetings registrants batch`, `zoom meetings control`. Fifth iteration of the depth-first push — closes Meetings to ~80% of Zoom's documented surface.
+> Survey + token + batch register + in-meeting controls (PR #76): `zoom meetings survey [get/update/delete]`, `zoom meetings token`, `zoom meetings registrants batch`, `zoom meetings control`. Fifth iteration of the depth-first push — closes Meetings to ~80% of Zoom's documented surface.
+> Users status + password + email + token + permissions (this branch): `zoom users [activate|deactivate|password|email|token|permissions]`. First iteration of the Users depth-first push (~25% → target ~80%).
+
+### Added (post-#14 depth-completion: status + password + email + token + permissions)
+- `zoom users activate|deactivate <user-id>` — toggle account status. Confirms by default; `--yes` to skip. Same factory pattern as the meeting registrant status verbs.
+- `zoom users password <user-id>` — reset password. Reads via `getpass.getpass` — never via argv, never via env var. Asks for confirmation (matches the new vs confirm prompt) before sending. Empty / mismatched passwords abort with exit 1.
+- `zoom users email <user-id> <new-email>` — initiate email change. Zoom sends a confirmation link to the new address; the change isn't active until the user clicks. Confirmation prompt surfaces the target email so the operator sees what's about to change.
+- `zoom users token <user-id> [--type zak|token|zpk]` — fetch user-level token. Sensitive — anyone with a `zak` can start the user's meetings as them. Flagged in help text + docstring.
+- `zoom users permissions <user-id>` — list assigned role + permissions; one-per-line.
+- New API helpers: `users.update_user_status` (action validated against `ALLOWED_STATUS_ACTIONS = ("activate", "deactivate")`), `users.update_user_password`, `users.update_user_email`, `users.get_user_token` (validated against `ALLOWED_USER_TOKEN_TYPES = ("zak", "token", "zpk")`), `users.get_user_permissions`.
 
 ### Added (post-#13 depth-completion: survey + token + batch + control)
 - `zoom meetings survey get|update|delete <meeting-id>` — manage the post-meeting survey shown to attendees. `update --from-json FILE` (JSON-only because surveys nest deep). All mutating verbs confirm by default; `--yes` to skip.

--- a/tests/test_api_users.py
+++ b/tests/test_api_users.py
@@ -277,3 +277,143 @@ def test_update_user_settings_passes_payload_through() -> None:
     users.update_user_settings(fake_client, "me", payload)
 
     assert fake_client.patch.call_args[1]["json"] == payload
+
+
+# ---- depth-completion: status + password + email + token + permissions --
+
+
+def test_update_user_status_activate_puts_action() -> None:
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+
+    users.update_user_status(fake_client, "u-1", action="activate")
+
+    fake_client.put.assert_called_once_with("/users/u-1/status", json={"action": "activate"})
+
+
+def test_update_user_status_deactivate_puts_action() -> None:
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+
+    users.update_user_status(fake_client, "u-1", action="deactivate")
+
+    fake_client.put.assert_called_once_with("/users/u-1/status", json={"action": "deactivate"})
+
+
+@pytest.mark.parametrize("bad_action", ["bogus", "", "delete", "ACTIVATE"])
+def test_update_user_status_rejects_unknown_action(bad_action: str) -> None:
+    fake_client = MagicMock()
+    with pytest.raises(ValueError, match="action"):
+        users.update_user_status(fake_client, "u-1", action=bad_action)
+
+
+def test_update_user_status_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+    users.update_user_status(fake_client, "evil/../1", action="activate")
+    arg = fake_client.put.call_args[0][0]
+    assert "/.." not in arg
+    assert "%2F" in arg
+
+
+def test_allowed_status_actions_pinned() -> None:
+    assert "activate" in users.ALLOWED_STATUS_ACTIONS
+    assert "deactivate" in users.ALLOWED_STATUS_ACTIONS
+
+
+def test_update_user_password_puts_password_field() -> None:
+    """Password reset — Zoom expects ``{password: "..."}``. The helper
+    accepts it in cleartext (the CLI prompts via getpass; the secret
+    never reaches argv)."""
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+
+    users.update_user_password(fake_client, "u-1", new_password="hunter2hunter2")
+
+    fake_client.put.assert_called_once_with(
+        "/users/u-1/password", json={"password": "hunter2hunter2"}
+    )
+
+
+def test_update_user_password_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+    users.update_user_password(fake_client, "evil/../1", new_password="x12345678")
+    arg = fake_client.put.call_args[0][0]
+    assert "/.." not in arg
+    assert "%2F" in arg
+
+
+def test_update_user_email_puts_email_field() -> None:
+    """Email change triggers a Zoom confirmation flow — the new address
+    isn't active until the user clicks the confirmation link."""
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+
+    users.update_user_email(fake_client, "u-1", new_email="new@example.com")
+
+    fake_client.put.assert_called_once_with("/users/u-1/email", json={"email": "new@example.com"})
+
+
+def test_update_user_email_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+    users.update_user_email(fake_client, "evil/../1", new_email="x@e.com")
+    arg = fake_client.put.call_args[0][0]
+    assert "/.." not in arg
+    assert "%2F" in arg
+
+
+def test_get_user_token_default_zak() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"token": "abc.def.ghi"}
+
+    result = users.get_user_token(fake_client, "u-1")
+
+    fake_client.get.assert_called_once_with("/users/u-1/token", params={"type": "zak"})
+    assert result["token"] == "abc.def.ghi"
+
+
+def test_get_user_token_forwards_type() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"token": "x"}
+
+    users.get_user_token(fake_client, "u-1", token_type="token")
+
+    fake_client.get.assert_called_once_with("/users/u-1/token", params={"type": "token"})
+
+
+@pytest.mark.parametrize("bad_type", ["bogus", "", "ZAK", "z a k"])
+def test_get_user_token_rejects_unknown_type(bad_type: str) -> None:
+    fake_client = MagicMock()
+    with pytest.raises(ValueError, match="token_type"):
+        users.get_user_token(fake_client, "u-1", token_type=bad_type)
+
+
+def test_allowed_user_token_types_pinned() -> None:
+    """Pinned set — Zoom currently supports zak / token / zpk for
+    user-level token requests."""
+    assert "zak" in users.ALLOWED_USER_TOKEN_TYPES
+    assert "token" in users.ALLOWED_USER_TOKEN_TYPES
+    assert "zpk" in users.ALLOWED_USER_TOKEN_TYPES
+
+
+def test_get_user_permissions_targets_correct_path() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {
+        "permissions": ["AccountSettingPermission", "MeetingPermission"]
+    }
+
+    result = users.get_user_permissions(fake_client, "u-1")
+
+    fake_client.get.assert_called_once_with("/users/u-1/permissions")
+    assert "MeetingPermission" in result["permissions"]
+
+
+def test_get_user_permissions_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {}
+    users.get_user_permissions(fake_client, "evil/../1")
+    arg = fake_client.get.call_args[0][0]
+    assert "/.." not in arg
+    assert "%2F" in arg

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4183,3 +4183,197 @@ def test_users_settings_update_default_user_me(
     )
     assert result.exit_code == 0, result.output
     assert captured["user_id"] == "me"
+
+
+# ---- users depth-completion: status / password / email / token / perms --
+
+
+@pytest.mark.parametrize(
+    "subcmd,expected_action,past",
+    [
+        ("activate", "activate", "Activated"),
+        ("deactivate", "deactivate", "Deactivated"),
+    ],
+)
+def test_users_status_actions_send_correct_action(
+    runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+    subcmd: str,
+    expected_action: str,
+    past: str,
+) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_status(_client, user_id, *, action):
+        captured["user_id"] = user_id
+        captured["action"] = action
+
+    _patch_users_module(monkeypatch, update_user_status=fake_status)
+    result = runner.invoke(main, ["users", subcmd, "u-1", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert captured["user_id"] == "u-1"
+    assert captured["action"] == expected_action
+    assert past in result.output
+
+
+def test_users_activate_confirms_and_aborts(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    called = {"n": 0}
+
+    def fake_status(*_a, **_k):
+        called["n"] += 1
+
+    _patch_users_module(monkeypatch, update_user_status=fake_status)
+    result = runner.invoke(main, ["users", "activate", "u-1"], input="n\n")
+    assert result.exit_code == 0, result.output
+    assert "Aborted" in result.output
+    assert called["n"] == 0
+
+
+def test_users_password_prompts_via_getpass(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Password is read via getpass.getpass — never via argv. We patch
+    getpass to return a known value and confirm the helper sees it."""
+    import getpass
+
+    _save_creds()
+    captured: dict[str, object] = {}
+    pw_responses = iter(["hunter2hunter2", "hunter2hunter2"])
+
+    def fake_getpass(_prompt):
+        return next(pw_responses)
+
+    monkeypatch.setattr(getpass, "getpass", fake_getpass)
+
+    def fake_password(_client, user_id, *, new_password):
+        captured["user_id"] = user_id
+        captured["new_password"] = new_password
+
+    _patch_users_module(monkeypatch, update_user_password=fake_password)
+    result = runner.invoke(main, ["users", "password", "u-1", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert captured["user_id"] == "u-1"
+    assert captured["new_password"] == "hunter2hunter2"
+    assert "Reset password for user u-1" in result.output
+
+
+def test_users_password_rejects_mismatched_confirmation(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the confirm-prompt doesn't match the first prompt, abort
+    without calling the API."""
+    import getpass
+
+    _save_creds()
+    pw_responses = iter(["one", "two"])
+    monkeypatch.setattr(getpass, "getpass", lambda _p: next(pw_responses))
+
+    called = {"n": 0}
+    _patch_users_module(
+        monkeypatch,
+        update_user_password=lambda *_a, **_k: called.__setitem__("n", called["n"] + 1),
+    )
+    result = runner.invoke(main, ["users", "password", "u-1", "--yes"])
+    assert result.exit_code == 1
+    assert "do not match" in result.output
+    assert called["n"] == 0
+
+
+def test_users_password_rejects_empty(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    import getpass
+
+    _save_creds()
+    monkeypatch.setattr(getpass, "getpass", lambda _p: "")
+    called = {"n": 0}
+    _patch_users_module(
+        monkeypatch,
+        update_user_password=lambda *_a, **_k: called.__setitem__("n", called["n"] + 1),
+    )
+    result = runner.invoke(main, ["users", "password", "u-1", "--yes"])
+    assert result.exit_code == 1
+    assert "Empty password" in result.output
+    assert called["n"] == 0
+
+
+def test_users_email_yes_calls_api(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_email(_client, user_id, *, new_email):
+        captured["user_id"] = user_id
+        captured["new_email"] = new_email
+
+    _patch_users_module(monkeypatch, update_user_email=fake_email)
+    result = runner.invoke(main, ["users", "email", "u-1", "new@example.com", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert captured["user_id"] == "u-1"
+    assert captured["new_email"] == "new@example.com"
+    assert "Email change initiated" in result.output
+
+
+def test_users_email_confirms_and_surfaces_target_address(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Confirmation message must surface the target email so the user
+    sees what's about to be changed."""
+    _save_creds()
+    called = {"n": 0}
+    _patch_users_module(
+        monkeypatch,
+        update_user_email=lambda *_a, **_k: called.__setitem__("n", called["n"] + 1),
+    )
+    result = runner.invoke(main, ["users", "email", "u-1", "new@example.com"], input="n\n")
+    assert result.exit_code == 0, result.output
+    assert "new@example.com" in result.output
+    assert "Aborted" in result.output
+    assert called["n"] == 0
+
+
+def test_users_token_default_zak(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_token(_client, user_id, *, token_type):
+        captured["user_id"] = user_id
+        captured["token_type"] = token_type
+        return {"token": "abc.def.ghi"}
+
+    _patch_users_module(monkeypatch, get_user_token=fake_token)
+    result = runner.invoke(main, ["users", "token", "u-1"])
+    assert result.exit_code == 0, result.output
+    assert captured["token_type"] == "zak"
+    assert "abc.def.ghi" in result.output
+
+
+def test_users_token_forwards_type(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_token(_client, _uid, *, token_type):
+        captured["type"] = token_type
+        return {"token": "x"}
+
+    _patch_users_module(monkeypatch, get_user_token=fake_token)
+    result = runner.invoke(main, ["users", "token", "u-1", "--type", "token"])
+    assert result.exit_code == 0, result.output
+    assert captured["type"] == "token"
+
+
+def test_users_permissions_prints_one_per_line(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+
+    def fake_perm(_client, user_id):
+        assert user_id == "u-1"
+        return {"permissions": ["AccountSettingPermission", "MeetingPermission"]}
+
+    _patch_users_module(monkeypatch, get_user_permissions=fake_perm)
+    result = runner.invoke(main, ["users", "permissions", "u-1"])
+    assert result.exit_code == 0, result.output
+    assert "AccountSettingPermission" in result.output
+    assert "MeetingPermission" in result.output

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -935,6 +935,168 @@ def users_settings_update(user_id, from_json, yes, dry_run):
     click.echo(f"Updated settings for user {user_id}.")
 
 
+# ---- Users depth-completion: status + password + email + token + perms --
+
+
+def _user_status_action(action: str, action_past: str):
+    """Build one of the ``activate`` / ``deactivate`` subcommands.
+
+    Same factory pattern as the registrant status verbs — extract the
+    shared confirmation + dispatch shape so the per-verb body is empty."""
+
+    @users_cmd.command(
+        action,
+        help=f"{action.capitalize()} a user (PUT /users/<user-id>/status, action={action}).",
+    )
+    @click.argument("user_id")
+    @click.option(
+        "--yes",
+        "-y",
+        is_flag=True,
+        default=False,
+        help="Skip the confirmation prompt.",
+    )
+    @_translate_keyring_errors
+    def _cmd(user_id, yes):
+        if not yes and not click.confirm(f"{action.capitalize()} user {user_id}?", default=False):
+            click.echo("Aborted.")
+            return
+        creds = _load_creds_or_exit()
+        try:
+            with _build_api_client(creds) as client:
+                users.update_user_status(client, user_id, action=action)
+        except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+            _exit_on_api_error(exc)
+        click.echo(f"{action_past} user {user_id}.")
+
+    _cmd.__name__ = f"users_{action}"
+    return _cmd
+
+
+_users_activate = _user_status_action("activate", "Activated")
+_users_deactivate = _user_status_action("deactivate", "Deactivated")
+
+
+@users_cmd.command(
+    "password",
+    help="Reset a user's password (PUT /users/<user-id>/password). Prompts via getpass — never accepted as a flag.",
+)
+@click.argument("user_id")
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@_translate_keyring_errors
+def users_password(user_id, yes):
+    """Password is read from a masked prompt (getpass) — never via argv,
+    never via env var. Confirms the change before sending."""
+    import getpass
+
+    new_password = getpass.getpass(f"New password for {user_id}: ")
+    if not new_password:
+        click.echo("Empty password — aborted.", err=True)
+        raise click.exceptions.Exit(code=1)
+    confirm_password = getpass.getpass("Confirm new password: ")
+    if confirm_password != new_password:
+        click.echo("Passwords do not match — aborted.", err=True)
+        raise click.exceptions.Exit(code=1)
+
+    if not yes and not click.confirm(f"Reset password for user {user_id}?", default=False):
+        click.echo("Aborted.")
+        return
+
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            users.update_user_password(client, user_id, new_password=new_password)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Reset password for user {user_id}.")
+
+
+@users_cmd.command(
+    "email",
+    help="Change a user's email (PUT /users/<user-id>/email; sends Zoom confirmation link).",
+)
+@click.argument("user_id")
+@click.argument("new_email")
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@_translate_keyring_errors
+def users_email(user_id, new_email, yes):
+    """Zoom sends the new address a confirmation link — the change isn't
+    active until the user clicks. Confirms by default since it triggers
+    user-visible email."""
+    if not yes and not click.confirm(
+        f"Change email for user {user_id} to {new_email}? "
+        f"(Zoom will send a confirmation link to {new_email})",
+        default=False,
+    ):
+        click.echo("Aborted.")
+        return
+
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            users.update_user_email(client, user_id, new_email=new_email)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Email change initiated for user {user_id} -> {new_email}.")
+
+
+@users_cmd.command(
+    "token",
+    help="Get a user-level token (GET /users/<user-id>/token; sensitive).",
+)
+@click.argument("user_id")
+@click.option(
+    "--type",
+    "token_type",
+    type=click.Choice(list(users.ALLOWED_USER_TOKEN_TYPES)),
+    default="zak",
+    show_default=True,
+    help="Token type. Default zak (start-meeting on the user's behalf).",
+)
+@_translate_keyring_errors
+def users_token(user_id, token_type):
+    """Output is the raw token string. Sensitive — anyone with a zak can
+    start the user's meetings as them. Don't paste into chat / tickets."""
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            data = users.get_user_token(client, user_id, token_type=token_type)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(data.get("token", ""))
+
+
+@users_cmd.command(
+    "permissions",
+    help="List a user's role + assigned permissions (GET /users/<user-id>/permissions).",
+)
+@click.argument("user_id")
+@_translate_keyring_errors
+def users_permissions(user_id):
+    """One permission per line. The set is what the user can DO — useful
+    for "why can't this person create a meeting on behalf of X?" audits."""
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            data = users.get_user_permissions(client, user_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    for perm in data.get("permissions", []):
+        click.echo(perm)
+
+
 # ---- Zoom Meetings — write commands -------------------------------------
 #
 # Closes #13 (write piece). Confirmation-flow design mirrors `zoom rm`:

--- a/zoom_cli/api/users.py
+++ b/zoom_cli/api/users.py
@@ -193,3 +193,102 @@ def list_users(
         params={"status": status},
         page_size=page_size,
     )
+
+
+# ---- depth-completion: status + password + email + token + permissions --
+
+#: Allowed values for ``update_user_status(action=...)``. Zoom's
+#: PUT /users/<id>/status accepts only these two verbs.
+ALLOWED_STATUS_ACTIONS: tuple[str, ...] = ("activate", "deactivate")
+
+#: Allowed values for ``get_user_token(token_type=...)``. Zoom's
+#: ``type`` query param at /users/<id>/token accepts:
+#: - zak: start-meeting token (most common)
+#: - token: SDK / web embed token
+#: - zpk: host-presence token (legacy)
+ALLOWED_USER_TOKEN_TYPES: tuple[str, ...] = ("zak", "token", "zpk")
+
+
+def update_user_status(client: ApiClient, user_id: str, *, action: str) -> dict[str, Any]:
+    """``PUT /users/{user_id}/status`` — activate or deactivate a user.
+
+    Args:
+        client: Authenticated :class:`ApiClient`.
+        user_id: Zoom user ID or email.
+        action: One of :data:`ALLOWED_STATUS_ACTIONS`.
+
+    Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``user:write:user:admin`` or admin equivalent.
+    """
+    if action not in ALLOWED_STATUS_ACTIONS:
+        raise ValueError(f"action must be one of {ALLOWED_STATUS_ACTIONS!r}, got {action!r}")
+    return client.put(f"/users/{quote(user_id, safe='')}/status", json={"action": action})
+
+
+def update_user_password(client: ApiClient, user_id: str, *, new_password: str) -> dict[str, Any]:
+    """``PUT /users/{user_id}/password`` — set a new password.
+
+    The CLI should accept ``new_password`` via getpass (interactive
+    masked prompt) — never as a flag (would leak through argv / shell
+    history). The helper takes cleartext because it needs to put it on
+    the wire.
+
+    Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``user:write:password:admin`` or admin equivalent.
+    """
+    return client.put(
+        f"/users/{quote(user_id, safe='')}/password",
+        json={"password": new_password},
+    )
+
+
+def update_user_email(client: ApiClient, user_id: str, *, new_email: str) -> dict[str, Any]:
+    """``PUT /users/{user_id}/email`` — initiate an email change.
+
+    Zoom sends the new address a confirmation link; the change isn't
+    active until they click. Returns ``{}`` (Zoom responds with 204 No
+    Content) — no indication of confirmation success here.
+
+    Required scopes: ``user:write:email:admin`` or admin equivalent.
+    """
+    return client.put(f"/users/{quote(user_id, safe='')}/email", json={"email": new_email})
+
+
+def get_user_token(
+    client: ApiClient,
+    user_id: str,
+    *,
+    token_type: str = "zak",  # noqa: S107 — "zak" is Zoom's enum value, not a credential
+) -> dict[str, Any]:
+    """``GET /users/{user_id}/token`` — fetch a user-level token.
+
+    Args:
+        client: Authenticated :class:`ApiClient`.
+        user_id: Zoom user ID or email.
+        token_type: One of :data:`ALLOWED_USER_TOKEN_TYPES`. Default
+            ``"zak"`` (start-meeting token).
+
+    Returns ``{token: str}``. The value is sensitive — anyone with a
+    ``zak`` can start the user's meetings as them.
+
+    Required scopes: ``user:read:token:admin``.
+    """
+    if token_type not in ALLOWED_USER_TOKEN_TYPES:
+        raise ValueError(
+            f"token_type must be one of {ALLOWED_USER_TOKEN_TYPES!r}, got {token_type!r}"
+        )
+    return client.get(f"/users/{quote(user_id, safe='')}/token", params={"type": token_type})
+
+
+def get_user_permissions(client: ApiClient, user_id: str) -> dict[str, Any]:
+    """``GET /users/{user_id}/permissions`` — list the user's assigned
+    role + permission set.
+
+    Returns ``{permissions: [str]}`` plus role metadata. Useful for
+    "what can this user do?" audits.
+
+    Required scopes: ``user:read:permission:admin``.
+    """
+    return client.get(f"/users/{quote(user_id, safe='')}/permissions")


### PR DESCRIPTION
## Summary
First iteration of the **Users** depth-first push (after Meetings hit ~80% in PR #76). Adds 5 endpoints covering the most-asked-for admin operations on a user.

## Why
Users was at ~25% (list / get / me / create / delete / settings get|update). Status/password/email/token/permissions are the day-to-day admin actions — biggest single-PR win on this surface. Bundling them because they share a single pattern (one PUT or GET each, all on \`/users/<id>/...\`).

## What changed
**API helpers** (\`zoom_cli/api/users.py\`):
- \`update_user_status(*, action)\` — validated against \`ALLOWED_STATUS_ACTIONS = (\"activate\", \"deactivate\")\`.
- \`update_user_password(*, new_password)\` — cleartext on the wire (CLI handles getpass prompting).
- \`update_user_email(*, new_email)\` — triggers Zoom's confirmation flow.
- \`get_user_token(*, token_type=\"zak\")\` — validated against \`ALLOWED_USER_TOKEN_TYPES = (\"zak\", \"token\", \"zpk\")\`.
- \`get_user_permissions\` — read-only role/permission audit.

**CLI** (under \`zoom users\`):
- \`activate\` / \`deactivate\` — confirm by default; \`--yes\` to skip. Factory pattern matches meeting registrants approve/deny/cancel.
- \`password\` — reads the new password via \`getpass.getpass\` (masked) with a confirm-prompt match check. **Never accepted as a flag or env var** (would leak via argv / shell history). Empty / mismatched abort with exit 1 + clear error.
- \`email <id> <new-email>\` — confirmation surfaces the target email so the operator sees what's about to change.
- \`token <id> [--type ...]\` — sensitive output (anyone with a \`zak\` can start the user's meetings as them); flagged in help text + docstring.
- \`permissions\` — one-per-line so it's grep-friendly.

## Coverage update
Users goes from ~25% (7 endpoints) to ~40% (12 endpoints). Next on the queue: virtual backgrounds, schedulers, vanity URL, presence — to bring Users to ~80%.

## Test plan
- [x] \`pytest -q\` — 735 pass (703 → 735, 21 new API + 11 new CLI)
- [x] \`ruff check . && ruff format --check .\` — clean
- [x] \`mypy\` — clean
- [x] Smoke: \`zoom users --help\` shows the new entries
- [ ] CI passes on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)