### PR TITLE
feat(users): schedulers + assistants + presence (depth-completion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Meeting livestream surface (PR #74): get / update RTMP config + start/stop the livestream — under `zoom meetings livestream`. Third iteration of the depth-first push.
 > Past instances + invitation + recover (PR #75): `zoom meetings invitation`, `zoom meetings recover`, and a new `zoom meetings past` subgroup with `instances / get / participants`. Fourth iteration of the depth-first push.
 > Survey + token + batch register + in-meeting controls (PR #76): `zoom meetings survey [get/update/delete]`, `zoom meetings token`, `zoom meetings registrants batch`, `zoom meetings control`. Fifth iteration of the depth-first push — closes Meetings to ~80% of Zoom's documented surface.
-> Users status + password + email + token + permissions (this branch): `zoom users [activate|deactivate|password|email|token|permissions]`. First iteration of the Users depth-first push (~25% → target ~80%).
+> Users status + password + email + token + permissions (PR #77): `zoom users [activate|deactivate|password|email|token|permissions]`. First iteration of the Users depth-first push (~25% → target ~80%).
+> Users schedulers + assistants + presence (this branch): `zoom users schedulers [list|delete]`, `zoom users assistants [add|delete]`, `zoom users presence [get|set]`. Second iteration of the Users depth-first push.
+
+### Added (post-#14 depth-completion: schedulers + assistants + presence)
+- `zoom users schedulers list <user-id>` — TSV (id / email) of users authorized to schedule meetings on this user's behalf.
+- `zoom users schedulers delete <user-id> <scheduler-id|--all>` — revoke one or all. Confirms by default; `--yes` to skip. Mutually-exclusive arg/flag validation.
+- `zoom users assistants add <user-id> --email E [--email E ...]` — assign assistants by email. `--from-json FILE` accepts the full body (with IDs) and is mutually exclusive with `--email`.
+- `zoom users assistants delete <user-id> <assistant-id|--all>` — revoke one or all. Confirms by default; `--yes` to skip.
+- `zoom users presence get <user-id>` — print current chat presence status.
+- `zoom users presence set <user-id> <STATUS>` — set presence. STATUS is case-sensitive (Available / Away / Do_Not_Disturb / In_Calendar_Event / Presenting / In_A_Zoom_Meeting / On_A_Call); validated by Click's Choice.
+- New API helpers: `users.list_schedulers`, `users.delete_scheduler`, `users.delete_all_schedulers`, `users.add_assistants`, `users.delete_assistant`, `users.delete_all_assistants`, `users.get_presence`, `users.set_presence` (status validated against `ALLOWED_PRESENCE_STATUSES`).
 
 ### Added (post-#14 depth-completion: status + password + email + token + permissions)
 - `zoom users activate|deactivate <user-id>` — toggle account status. Confirms by default; `--yes` to skip. Same factory pattern as the meeting registrant status verbs.

--- a/tests/test_api_users.py
+++ b/tests/test_api_users.py
@@ -417,3 +417,124 @@ def test_get_user_permissions_url_encodes_id() -> None:
     arg = fake_client.get.call_args[0][0]
     assert "/.." not in arg
     assert "%2F" in arg
+
+
+# ---- depth-completion: schedulers + assistants + presence --------------
+
+
+def test_list_schedulers_targets_correct_path() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"schedulers": [{"id": "s-1", "email": "a@e.com"}]}
+
+    result = users.list_schedulers(fake_client, "u-1")
+
+    fake_client.get.assert_called_once_with("/users/u-1/schedulers")
+    assert result["schedulers"][0]["email"] == "a@e.com"
+
+
+def test_list_schedulers_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {}
+    users.list_schedulers(fake_client, "evil/../1")
+    arg = fake_client.get.call_args[0][0]
+    assert "/.." not in arg
+    assert "%2F" in arg
+
+
+def test_delete_scheduler_targets_specific_path() -> None:
+    fake_client = MagicMock()
+    fake_client.delete.return_value = {}
+
+    users.delete_scheduler(fake_client, "u-1", "s-1")
+
+    fake_client.delete.assert_called_once_with("/users/u-1/schedulers/s-1")
+
+
+def test_delete_scheduler_url_encodes_both_segments() -> None:
+    fake_client = MagicMock()
+    fake_client.delete.return_value = {}
+    users.delete_scheduler(fake_client, "u/../1", "s/../1")
+    arg = fake_client.delete.call_args[0][0]
+    assert arg.count("%2F") == 4
+    assert "/.." not in arg
+
+
+def test_delete_all_schedulers_targets_collection_path() -> None:
+    """Bulk delete: same path as list, just DELETE."""
+    fake_client = MagicMock()
+    fake_client.delete.return_value = {}
+
+    users.delete_all_schedulers(fake_client, "u-1")
+
+    fake_client.delete.assert_called_once_with("/users/u-1/schedulers")
+
+
+def test_add_assistants_posts_payload() -> None:
+    """Assistant assignment — payload contains an array of
+    ``{id?, email}`` dicts. Identifying by email is the common case."""
+    fake_client = MagicMock()
+    fake_client.post.return_value = {
+        "ids": "a-1,a-2",
+        "add_at": "2026-04-30T12:00:00Z",
+    }
+
+    payload = {"assistants": [{"email": "alice@e.com"}, {"email": "bob@e.com"}]}
+    result = users.add_assistants(fake_client, "u-1", payload)
+
+    fake_client.post.assert_called_once_with("/users/u-1/assistants", json=payload)
+    assert result["ids"] == "a-1,a-2"
+
+
+def test_delete_assistant_targets_specific_path() -> None:
+    fake_client = MagicMock()
+    fake_client.delete.return_value = {}
+
+    users.delete_assistant(fake_client, "u-1", "a-1")
+
+    fake_client.delete.assert_called_once_with("/users/u-1/assistants/a-1")
+
+
+def test_delete_all_assistants_targets_collection_path() -> None:
+    fake_client = MagicMock()
+    fake_client.delete.return_value = {}
+
+    users.delete_all_assistants(fake_client, "u-1")
+
+    fake_client.delete.assert_called_once_with("/users/u-1/assistants")
+
+
+def test_get_presence_targets_correct_path() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"status": "Available"}
+
+    result = users.get_presence(fake_client, "u-1")
+
+    fake_client.get.assert_called_once_with("/users/u-1/presence_status")
+    assert result["status"] == "Available"
+
+
+def test_set_presence_puts_status_with_action() -> None:
+    """PUT body is {status: <state>}; Zoom's API quirk."""
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+
+    users.set_presence(fake_client, "u-1", status="Do_Not_Disturb")
+
+    fake_client.put.assert_called_once_with(
+        "/users/u-1/presence_status", json={"status": "Do_Not_Disturb"}
+    )
+
+
+@pytest.mark.parametrize("bad_status", ["bogus", "", "available", "DND"])
+def test_set_presence_rejects_unknown_status(bad_status: str) -> None:
+    """Pinned set — case-sensitive and exact (Zoom uses Available /
+    Away / Do_Not_Disturb / In_Calendar_Event etc.)."""
+    fake_client = MagicMock()
+    with pytest.raises(ValueError, match="status"):
+        users.set_presence(fake_client, "u-1", status=bad_status)
+
+
+def test_allowed_presence_statuses_pinned() -> None:
+    assert "Available" in users.ALLOWED_PRESENCE_STATUSES
+    assert "Away" in users.ALLOWED_PRESENCE_STATUSES
+    assert "Do_Not_Disturb" in users.ALLOWED_PRESENCE_STATUSES

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4377,3 +4377,251 @@ def test_users_permissions_prints_one_per_line(
     assert result.exit_code == 0, result.output
     assert "AccountSettingPermission" in result.output
     assert "MeetingPermission" in result.output
+
+
+# ---- users depth-completion: schedulers / assistants / presence --------
+
+
+def test_users_schedulers_list_prints_tsv(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+
+    def fake_list(_client, user_id):
+        assert user_id == "u-1"
+        return {
+            "schedulers": [
+                {"id": "s-1", "email": "a@e.com"},
+                {"id": "s-2", "email": "b@e.com"},
+            ]
+        }
+
+    _patch_users_module(monkeypatch, list_schedulers=fake_list)
+    result = runner.invoke(main, ["users", "schedulers", "list", "u-1"])
+    assert result.exit_code == 0, result.output
+    assert "id\temail" in result.output
+    assert "s-1\ta@e.com" in result.output
+    assert "s-2\tb@e.com" in result.output
+
+
+def test_users_schedulers_delete_one_yes_calls_specific_endpoint(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_one(_client, user_id, scheduler_id):
+        captured["one"] = (user_id, scheduler_id)
+
+    def fake_all(*_a, **_k):
+        captured["all_called"] = True
+
+    _patch_users_module(
+        monkeypatch,
+        delete_scheduler=fake_one,
+        delete_all_schedulers=fake_all,
+    )
+    result = runner.invoke(main, ["users", "schedulers", "delete", "u-1", "s-1", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert captured.get("one") == ("u-1", "s-1")
+    assert "all_called" not in captured
+    assert "Revoked scheduler s-1" in result.output
+
+
+def test_users_schedulers_delete_all_yes_calls_collection_endpoint(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_all(_client, user_id):
+        captured["all"] = user_id
+
+    _patch_users_module(
+        monkeypatch,
+        delete_scheduler=lambda *_a, **_k: None,
+        delete_all_schedulers=fake_all,
+    )
+    result = runner.invoke(main, ["users", "schedulers", "delete", "u-1", "--all", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert captured["all"] == "u-1"
+    assert "Revoked all schedulers" in result.output
+
+
+def test_users_schedulers_delete_rejects_no_args(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    _patch_users_module(
+        monkeypatch,
+        delete_scheduler=lambda *_a, **_k: None,
+        delete_all_schedulers=lambda *_a, **_k: None,
+    )
+    result = runner.invoke(main, ["users", "schedulers", "delete", "u-1", "--yes"])
+    assert result.exit_code == 1
+    assert "scheduler-id" in result.output and "--all" in result.output
+
+
+def test_users_schedulers_delete_rejects_id_and_all(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    _patch_users_module(
+        monkeypatch,
+        delete_scheduler=lambda *_a, **_k: None,
+        delete_all_schedulers=lambda *_a, **_k: None,
+    )
+    result = runner.invoke(
+        main,
+        ["users", "schedulers", "delete", "u-1", "s-1", "--all", "--yes"],
+    )
+    assert result.exit_code == 1
+    assert "mutually exclusive" in result.output
+
+
+def test_users_assistants_add_field_flags_build_payload(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_add(_client, user_id, payload):
+        captured["user_id"] = user_id
+        captured["payload"] = payload
+        return {"ids": "a-1,a-2", "add_at": "T"}
+
+    _patch_users_module(monkeypatch, add_assistants=fake_add)
+    result = runner.invoke(
+        main,
+        [
+            "users",
+            "assistants",
+            "add",
+            "u-1",
+            "--email",
+            "a@e.com",
+            "--email",
+            "b@e.com",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["user_id"] == "u-1"
+    assert captured["payload"] == {"assistants": [{"email": "a@e.com"}, {"email": "b@e.com"}]}
+    assert "Added assistants" in result.output
+    assert "a-1,a-2" in result.output
+
+
+def test_users_assistants_add_from_json_mutually_exclusive(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+    json_file = tmp_path / "as.json"
+    json_file.write_text('{"assistants": [{"email": "a@e.com"}]}')
+    _patch_users_module(monkeypatch, add_assistants=lambda *_a, **_k: {})
+    result = runner.invoke(
+        main,
+        [
+            "users",
+            "assistants",
+            "add",
+            "u-1",
+            "--from-json",
+            str(json_file),
+            "--email",
+            "x@e.com",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "mutually exclusive" in result.output
+
+
+def test_users_assistants_add_rejects_no_args(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    _patch_users_module(monkeypatch, add_assistants=lambda *_a, **_k: {})
+    result = runner.invoke(main, ["users", "assistants", "add", "u-1"])
+    assert result.exit_code == 1
+    assert "--email" in result.output
+
+
+def test_users_assistants_delete_one_yes_calls_specific_endpoint(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_one(_client, user_id, assistant_id):
+        captured["one"] = (user_id, assistant_id)
+
+    _patch_users_module(
+        monkeypatch,
+        delete_assistant=fake_one,
+        delete_all_assistants=lambda *_a, **_k: None,
+    )
+    result = runner.invoke(main, ["users", "assistants", "delete", "u-1", "a-1", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert captured["one"] == ("u-1", "a-1")
+    assert "Revoked assistant a-1" in result.output
+
+
+def test_users_assistants_delete_all_yes_calls_collection_endpoint(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_all(_client, user_id):
+        captured["all"] = user_id
+
+    _patch_users_module(
+        monkeypatch,
+        delete_assistant=lambda *_a, **_k: None,
+        delete_all_assistants=fake_all,
+    )
+    result = runner.invoke(main, ["users", "assistants", "delete", "u-1", "--all", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert captured["all"] == "u-1"
+    assert "Revoked all assistants" in result.output
+
+
+def test_users_presence_get_prints_status(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+
+    def fake_get(_client, user_id):
+        assert user_id == "u-1"
+        return {"status": "Available"}
+
+    _patch_users_module(monkeypatch, get_presence=fake_get)
+    result = runner.invoke(main, ["users", "presence", "get", "u-1"])
+    assert result.exit_code == 0, result.output
+    assert "Available" in result.output
+
+
+def test_users_presence_set_calls_api(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_set(_client, user_id, *, status):
+        captured["user_id"] = user_id
+        captured["status"] = status
+
+    _patch_users_module(monkeypatch, set_presence=fake_set)
+    result = runner.invoke(main, ["users", "presence", "set", "u-1", "Do_Not_Disturb"])
+    assert result.exit_code == 0, result.output
+    assert captured["user_id"] == "u-1"
+    assert captured["status"] == "Do_Not_Disturb"
+    assert "Do_Not_Disturb" in result.output
+
+
+def test_users_presence_set_rejects_unknown_status(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Click's Choice rejects bogus values before the API call."""
+    _save_creds()
+    _patch_users_module(monkeypatch, set_presence=lambda *_a, **_k: None)
+    result = runner.invoke(main, ["users", "presence", "set", "u-1", "DND"])
+    assert result.exit_code != 0
+    assert "DND" in result.output or "Invalid value" in result.output

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -1097,6 +1097,244 @@ def users_permissions(user_id):
         click.echo(perm)
 
 
+# ---- Users depth-completion: schedulers + assistants + presence --------
+
+
+@users_cmd.group(
+    "schedulers",
+    help="Manage users authorized to schedule meetings on this user's behalf.",
+)
+def users_schedulers_cmd():
+    """Group for ``zoom users schedulers ...``."""
+
+
+@users_schedulers_cmd.command(
+    "list", help="List schedulers for a user (GET /users/<user-id>/schedulers)."
+)
+@click.argument("user_id")
+@_translate_keyring_errors
+def users_schedulers_list(user_id):
+    """TSV output (id\\temail)."""
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            data = users.list_schedulers(client, user_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo("id\temail")
+    for s in data.get("schedulers", []):
+        click.echo(f"{s.get('id', '')}\t{s.get('email', '')}")
+
+
+@users_schedulers_cmd.command(
+    "delete",
+    help=(
+        "Revoke a scheduler (DELETE /users/<user-id>/schedulers/<scheduler-id>); "
+        "omit the scheduler id with --all to revoke all schedulers."
+    ),
+)
+@click.argument("user_id")
+@click.argument("scheduler_id", required=False)
+@click.option(
+    "--all",
+    "all_schedulers",
+    is_flag=True,
+    default=False,
+    help="Revoke ALL schedulers (DELETE /users/<user-id>/schedulers).",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@_translate_keyring_errors
+def users_schedulers_delete(user_id, scheduler_id, all_schedulers, yes):
+    if all_schedulers and scheduler_id:
+        click.echo("--all is mutually exclusive with a scheduler-id argument.", err=True)
+        raise click.exceptions.Exit(code=1)
+    if not all_schedulers and not scheduler_id:
+        click.echo(
+            "Pass either a scheduler-id or --all to delete all schedulers.",
+            err=True,
+        )
+        raise click.exceptions.Exit(code=1)
+
+    if all_schedulers:
+        prompt = f"Revoke ALL schedulers for user {user_id}?"
+    else:
+        prompt = f"Revoke scheduler {scheduler_id} for user {user_id}?"
+    if not yes and not click.confirm(prompt, default=False):
+        click.echo("Aborted.")
+        return
+
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            if all_schedulers:
+                users.delete_all_schedulers(client, user_id)
+                click.echo(f"Revoked all schedulers for user {user_id}.")
+            else:
+                users.delete_scheduler(client, user_id, scheduler_id)
+                click.echo(f"Revoked scheduler {scheduler_id} for user {user_id}.")
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+
+
+@users_cmd.group(
+    "assistants",
+    help="Manage assistants who can manage meetings on this user's behalf.",
+)
+def users_assistants_cmd():
+    """Group for ``zoom users assistants ...``."""
+
+
+@users_assistants_cmd.command(
+    "add",
+    help="Assign assistants (POST /users/<user-id>/assistants).",
+)
+@click.argument("user_id")
+@click.option(
+    "--email",
+    multiple=True,
+    help="Assistant email. Repeat for multiple.",
+)
+@click.option(
+    "--from-json",
+    "from_json",
+    type=click.File("r", encoding="utf-8"),
+    default=None,
+    help="Read the full assistants payload from a JSON file (or '-' for stdin).",
+)
+@_translate_keyring_errors
+def users_assistants_add(user_id, email, from_json):
+    """Two payload-construction modes:
+    1. ``--email a@e.com --email b@e.com`` builds the assistants array from emails.
+    2. ``--from-json FILE`` accepts the full body (also lets you pass IDs).
+    Mutually exclusive."""
+    if from_json is not None:
+        if email:
+            click.echo("--from-json is mutually exclusive with --email.", err=True)
+            raise click.exceptions.Exit(code=1)
+        payload = _load_json_payload_or_exit(from_json, label="--from-json input")
+    else:
+        if not email:
+            click.echo(
+                "Pass at least one --email, or --from-json with a full body.",
+                err=True,
+            )
+            raise click.exceptions.Exit(code=1)
+        payload = {"assistants": [{"email": e} for e in email]}
+
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            result = users.add_assistants(client, user_id, payload)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Added assistants. ids: {result.get('ids', '')}")
+
+
+@users_assistants_cmd.command(
+    "delete",
+    help=(
+        "Revoke an assistant (DELETE /users/<user-id>/assistants/<assistant-id>); "
+        "use --all to revoke all assistants."
+    ),
+)
+@click.argument("user_id")
+@click.argument("assistant_id", required=False)
+@click.option(
+    "--all",
+    "all_assistants",
+    is_flag=True,
+    default=False,
+    help="Revoke ALL assistants (DELETE /users/<user-id>/assistants).",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@_translate_keyring_errors
+def users_assistants_delete(user_id, assistant_id, all_assistants, yes):
+    if all_assistants and assistant_id:
+        click.echo("--all is mutually exclusive with an assistant-id argument.", err=True)
+        raise click.exceptions.Exit(code=1)
+    if not all_assistants and not assistant_id:
+        click.echo(
+            "Pass either an assistant-id or --all to delete all assistants.",
+            err=True,
+        )
+        raise click.exceptions.Exit(code=1)
+
+    if all_assistants:
+        prompt = f"Revoke ALL assistants for user {user_id}?"
+    else:
+        prompt = f"Revoke assistant {assistant_id} for user {user_id}?"
+    if not yes and not click.confirm(prompt, default=False):
+        click.echo("Aborted.")
+        return
+
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            if all_assistants:
+                users.delete_all_assistants(client, user_id)
+                click.echo(f"Revoked all assistants for user {user_id}.")
+            else:
+                users.delete_assistant(client, user_id, assistant_id)
+                click.echo(f"Revoked assistant {assistant_id} for user {user_id}.")
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+
+
+@users_cmd.group(
+    "presence",
+    help="Read or set the user's chat presence status.",
+)
+def users_presence_cmd():
+    """Group for ``zoom users presence ...``."""
+
+
+@users_presence_cmd.command(
+    "get", help="Print the user's current presence (GET /users/<user-id>/presence_status)."
+)
+@click.argument("user_id")
+@_translate_keyring_errors
+def users_presence_get(user_id):
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            data = users.get_presence(client, user_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(data.get("status", ""))
+
+
+@users_presence_cmd.command(
+    "set",
+    help="Set the user's presence (PUT /users/<user-id>/presence_status).",
+)
+@click.argument("user_id")
+@click.argument("status", type=click.Choice(list(users.ALLOWED_PRESENCE_STATUSES)))
+@_translate_keyring_errors
+def users_presence_set(user_id, status):
+    """Status is case-sensitive — Zoom uses Available / Away /
+    Do_Not_Disturb / In_Calendar_Event / Presenting / In_A_Zoom_Meeting /
+    On_A_Call."""
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            users.set_presence(client, user_id, status=status)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Set presence for user {user_id} -> {status}.")
+
+
 # ---- Zoom Meetings — write commands -------------------------------------
 #
 # Closes #13 (write piece). Confirmation-flow design mirrors `zoom rm`:

--- a/zoom_cli/api/users.py
+++ b/zoom_cli/api/users.py
@@ -292,3 +292,128 @@ def get_user_permissions(client: ApiClient, user_id: str) -> dict[str, Any]:
     Required scopes: ``user:read:permission:admin``.
     """
     return client.get(f"/users/{quote(user_id, safe='')}/permissions")
+
+
+# ---- depth-completion: schedulers + assistants + presence --------------
+
+#: Allowed values for ``set_presence(status=...)``. Mirrors Zoom's
+#: chat presence-status enum. Case-sensitive and exact (``DND`` is NOT
+#: an alias — Zoom uses ``Do_Not_Disturb``).
+ALLOWED_PRESENCE_STATUSES: tuple[str, ...] = (
+    "Available",
+    "Away",
+    "Do_Not_Disturb",
+    "In_Calendar_Event",
+    "Presenting",
+    "In_A_Zoom_Meeting",
+    "On_A_Call",
+)
+
+
+def list_schedulers(client: ApiClient, user_id: str) -> dict[str, Any]:
+    """``GET /users/{user_id}/schedulers`` — list users authorized to
+    schedule meetings on behalf of this user.
+
+    Returns ``{schedulers: [{id, email}, ...]}``.
+
+    Required scopes: ``user:read:user``.
+    """
+    return client.get(f"/users/{quote(user_id, safe='')}/schedulers")
+
+
+def delete_scheduler(client: ApiClient, user_id: str, scheduler_id: str) -> dict[str, Any]:
+    """``DELETE /users/{user_id}/schedulers/{scheduler_id}`` — revoke
+    one scheduler's permission.
+
+    Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``user:write:scheduler:admin``.
+    """
+    return client.delete(
+        f"/users/{quote(user_id, safe='')}/schedulers/{quote(scheduler_id, safe='')}"
+    )
+
+
+def delete_all_schedulers(client: ApiClient, user_id: str) -> dict[str, Any]:
+    """``DELETE /users/{user_id}/schedulers`` — revoke all schedulers
+    in one call. Same path as :func:`list_schedulers`, just DELETE.
+
+    Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``user:write:scheduler:admin``.
+    """
+    return client.delete(f"/users/{quote(user_id, safe='')}/schedulers")
+
+
+def add_assistants(client: ApiClient, user_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """``POST /users/{user_id}/assistants`` — assign assistants who
+    can manage meetings on behalf of this user.
+
+    ``payload`` is ``{assistants: [{id?, email}, ...]}``. Identifying
+    by email is the common case; ``id`` is for already-known Zoom user
+    IDs.
+
+    Returns Zoom's response with comma-separated assistant IDs and
+    assignment timestamp.
+
+    Required scopes: ``user:write:assistant:admin``.
+    """
+    return client.post(f"/users/{quote(user_id, safe='')}/assistants", json=payload)
+
+
+def delete_assistant(client: ApiClient, user_id: str, assistant_id: str) -> dict[str, Any]:
+    """``DELETE /users/{user_id}/assistants/{assistant_id}`` — revoke
+    one assistant.
+
+    Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``user:write:assistant:admin``.
+    """
+    return client.delete(
+        f"/users/{quote(user_id, safe='')}/assistants/{quote(assistant_id, safe='')}"
+    )
+
+
+def delete_all_assistants(client: ApiClient, user_id: str) -> dict[str, Any]:
+    """``DELETE /users/{user_id}/assistants`` — revoke all assistants
+    in one call. Same path as :func:`add_assistants`, just DELETE.
+
+    Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``user:write:assistant:admin``.
+    """
+    return client.delete(f"/users/{quote(user_id, safe='')}/assistants")
+
+
+def get_presence(client: ApiClient, user_id: str) -> dict[str, Any]:
+    """``GET /users/{user_id}/presence_status`` — fetch the user's
+    current chat presence status.
+
+    Returns ``{status: str}`` where status is one of
+    :data:`ALLOWED_PRESENCE_STATUSES`.
+
+    Required scopes: ``user:read:user`` or chat-specific equivalent.
+    """
+    return client.get(f"/users/{quote(user_id, safe='')}/presence_status")
+
+
+def set_presence(client: ApiClient, user_id: str, *, status: str) -> dict[str, Any]:
+    """``PUT /users/{user_id}/presence_status`` — set presence status.
+
+    Args:
+        client: Authenticated :class:`ApiClient`.
+        user_id: Zoom user ID. Setting on others requires admin scope;
+            self-set works with the user's own OAuth.
+        status: One of :data:`ALLOWED_PRESENCE_STATUSES`.
+
+    Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``user:write:presence_status:admin`` or
+    ``user:write:presence_status`` (self).
+    """
+    if status not in ALLOWED_PRESENCE_STATUSES:
+        raise ValueError(f"status must be one of {ALLOWED_PRESENCE_STATUSES!r}, got {status!r}")
+    return client.put(
+        f"/users/{quote(user_id, safe='')}/presence_status",
+        json={"status": status},
+    )


### PR DESCRIPTION
## Summary
Second iteration of the **Users** depth-first push. Adds 8 endpoints across three clusters: schedulers (3), assistants (3), presence (2).

## Why
After PR #77 added the admin-action cluster (status / password / email / token / permissions), the next-most-asked-for surface on Users is delegation: who can schedule on my behalf, who can manage on my behalf. Plus presence — the chat-status read/write that's needed for "set me to Do Not Disturb during this meeting" automation. All three clusters share the same shape (CRUD on a sub-resource of /users/<id>) so they ship as one PR.

## What changed
**API helpers** (\`zoom_cli/api/users.py\`):
- \`list_schedulers\` / \`delete_scheduler\` / \`delete_all_schedulers\` — bulk-or-one delete via the same parent path.
- \`add_assistants(payload)\` / \`delete_assistant\` / \`delete_all_assistants\` — same pattern.
- \`get_presence\` / \`set_presence(*, status)\` — status validated against \`ALLOWED_PRESENCE_STATUSES = (\"Available\", \"Away\", \"Do_Not_Disturb\", \"In_Calendar_Event\", \"Presenting\", \"In_A_Zoom_Meeting\", \"On_A_Call\")\`. Case-sensitive (Zoom uses \`Do_Not_Disturb\`, not \`DND\`).

**CLI** (under \`zoom users\`):
- \`schedulers list / delete <user-id> <scheduler-id|--all>\` — confirms by default, \`--yes\` to skip. Mutually exclusive validation: argless without \`--all\` rejected; both args+\`--all\` rejected.
- \`assistants add <user-id> --email E [--email E ...]\` — repeatable email flag builds the assistants array. \`--from-json FILE\` is the escape hatch for ID-based assignments and is mutually exclusive with \`--email\`.
- \`assistants delete\` — same one-or-all pattern as schedulers.
- \`presence get / set\` — status arg uses Click \`Choice\` so bogus values fail before the API call.

## Coverage update
Users goes from ~40% (12 endpoints after PR #77) to ~65% (20 endpoints). Remaining tail: virtual backgrounds (multipart upload — bigger lift), vanity URL, ZAK-token alias, and a few admin-only audits.

## Test plan
- [x] \`pytest -q\` — 763 pass (735 → 763, 15 new API + 13 new CLI)
- [x] \`ruff check . && ruff format --check .\` — clean
- [x] \`mypy\` — clean
- [x] Smoke: \`zoom users --help\` shows new \`schedulers / assistants / presence\` subgroups
- [ ] CI passes on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)