### PR TITLE
feat(recordings): recover + settings + registrants (depth-completion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Past instances + invitation + recover (PR #75): `zoom meetings invitation`, `zoom meetings recover`, and a new `zoom meetings past` subgroup with `instances / get / participants`. Fourth iteration of the depth-first push.
 > Survey + token + batch register + in-meeting controls (PR #76): `zoom meetings survey [get/update/delete]`, `zoom meetings token`, `zoom meetings registrants batch`, `zoom meetings control`. Fifth iteration of the depth-first push — closes Meetings to ~80% of Zoom's documented surface.
 > Users status + password + email + token + permissions (PR #77): `zoom users [activate|deactivate|password|email|token|permissions]`. First iteration of the Users depth-first push (~25% → target ~80%).
-> Users schedulers + assistants + presence (this branch): `zoom users schedulers [list|delete]`, `zoom users assistants [add|delete]`, `zoom users presence [get|set]`. Second iteration of the Users depth-first push.
+> Users schedulers + assistants + presence (PR #78): `zoom users schedulers [list|delete]`, `zoom users assistants [add|delete]`, `zoom users presence [get|set]`. Second iteration of the Users depth-first push.
+> Recordings recover + settings + registrants (this branch): `zoom recordings recover`, `zoom recordings settings [get|update]`, `zoom recordings registrants [list|add|approve|deny]`. First iteration of the Recordings depth-first push (~25% → target ~80%).
+
+### Added (post-#15 depth-completion: recover + settings + registrants)
+- `zoom recordings recover <meeting-id> [--file-id ID]` — restore trashed recordings (whole meeting or one specific file). Counterpart to `recordings delete` (which trashes by default; recoverable for 30 days). Confirms by default; `--yes` to skip.
+- `zoom recordings settings get <meeting-id>` — print recording sharing/permission settings as JSON.
+- `zoom recordings settings update <meeting-id> --from-json FILE` — JSON-only because settings nest deep (share_recording / viewer_download / on_demand / password / authentication / etc.). Confirms by default.
+- `zoom recordings registrants list <meeting-id> [--status pending|approved|denied]` — paginated TSV of on-demand recording viewer registrations.
+- `zoom recordings registrants add <meeting-id>` — register a viewer (per-field flags OR `--from-json`; mutually exclusive). Returns the per-viewer `share_url`.
+- `zoom recordings registrants approve|deny <meeting-id> --registrant ID [--registrant ID ...]` — bulk status change. Note: recording registrants only support approve/deny — no `cancel` (unlike meeting registrants). Confirms by default.
+- New API helpers: `recordings.recover_recordings`, `recordings.recover_recording_file`, `recordings.get_recording_settings`, `recordings.update_recording_settings`, `recordings.list_recording_registrants` (paginated), `recordings.add_recording_registrant`, `recordings.update_recording_registrant_status`. New pinned-tuple constants `recordings.ALLOWED_REGISTRANT_STATUSES` and `recordings.ALLOWED_REGISTRANT_ACTIONS = ("approve", "deny")`.
 
 ### Added (post-#14 depth-completion: schedulers + assistants + presence)
 - `zoom users schedulers list <user-id>` — TSV (id / email) of users authorized to schedule meetings on this user's behalf.

--- a/tests/test_api_recordings.py
+++ b/tests/test_api_recordings.py
@@ -126,3 +126,165 @@ def test_delete_recording_file_rejects_unknown_action() -> None:
 
 def test_allowed_delete_actions_pinned() -> None:
     assert recordings.ALLOWED_DELETE_ACTIONS == ("trash", "delete")
+
+
+# ---- depth-completion: recover + settings + registrants ----------------
+
+
+def test_recover_recordings_puts_status_with_action_recover() -> None:
+    """Recover all of a meeting's trashed recordings."""
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+
+    recordings.recover_recordings(fake_client, 12345)
+
+    fake_client.put.assert_called_once_with(
+        "/meetings/12345/recordings/status", json={"action": "recover"}
+    )
+
+
+def test_recover_recordings_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+    recordings.recover_recordings(fake_client, "evil/../1")
+    arg = fake_client.put.call_args[0][0]
+    assert "/.." not in arg
+    assert "%2F" in arg
+
+
+def test_recover_recording_file_puts_specific_path() -> None:
+    """Recover one trashed file (not all)."""
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+
+    recordings.recover_recording_file(fake_client, 12345, "rec-1")
+
+    fake_client.put.assert_called_once_with(
+        "/meetings/12345/recordings/rec-1/status", json={"action": "recover"}
+    )
+
+
+def test_recover_recording_file_url_encodes_both() -> None:
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+    recordings.recover_recording_file(fake_client, "m/../1", "r/../2")
+    arg = fake_client.put.call_args[0][0]
+    assert "/.." not in arg
+
+
+def test_get_recording_settings_targets_correct_path() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {
+        "share_recording": "publicly",
+        "topic": "Daily Standup",
+    }
+
+    result = recordings.get_recording_settings(fake_client, 12345)
+
+    fake_client.get.assert_called_once_with("/meetings/12345/recordings/settings")
+    assert result["share_recording"] == "publicly"
+
+
+def test_update_recording_settings_patches_with_payload() -> None:
+    fake_client = MagicMock()
+    fake_client.patch.return_value = {}
+
+    payload = {"share_recording": "internally", "viewer_download": False}
+    recordings.update_recording_settings(fake_client, 12345, payload)
+
+    fake_client.patch.assert_called_once_with("/meetings/12345/recordings/settings", json=payload)
+
+
+def test_recording_settings_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {}
+    fake_client.patch.return_value = {}
+    recordings.get_recording_settings(fake_client, "evil/../1")
+    recordings.update_recording_settings(fake_client, "evil/../1", {})
+    for arg in (
+        fake_client.get.call_args[0][0],
+        fake_client.patch.call_args[0][0],
+    ):
+        assert "/.." not in arg
+        assert "%2F" in arg
+
+
+def test_list_recording_registrants_default_status_pending_walks_pagination() -> None:
+    """Same default-pending shape as meeting registrants."""
+    fake_client = MagicMock()
+    fake_client.get.side_effect = [
+        {"registrants": [{"id": "r-1"}, {"id": "r-2"}], "next_page_token": "t-2"},
+        {"registrants": [{"id": "r-3"}], "next_page_token": ""},
+    ]
+
+    result = list(recordings.list_recording_registrants(fake_client, 12345))
+
+    assert result == [{"id": "r-1"}, {"id": "r-2"}, {"id": "r-3"}]
+    first = fake_client.get.call_args_list[0]
+    assert first[0][0] == "/meetings/12345/recordings/registrants"
+    assert first[1]["params"]["status"] == "pending"
+
+
+@pytest.mark.parametrize("bad_status", ["bogus", "", "rejected"])
+def test_list_recording_registrants_rejects_unknown_status(bad_status: str) -> None:
+    fake_client = MagicMock()
+    with pytest.raises(ValueError, match="status"):
+        list(recordings.list_recording_registrants(fake_client, 12345, status=bad_status))
+
+
+def test_add_recording_registrant_posts_payload() -> None:
+    fake_client = MagicMock()
+    fake_client.post.return_value = {
+        "id": "r-1",
+        "share_url": "https://zoom.us/rec/share/abc",
+    }
+
+    payload = {"email": "a@e.com", "first_name": "A"}
+    result = recordings.add_recording_registrant(fake_client, 12345, payload)
+
+    fake_client.post.assert_called_once_with("/meetings/12345/recordings/registrants", json=payload)
+    assert result["share_url"].startswith("https://")
+
+
+def test_update_recording_registrant_status_puts_action_and_list() -> None:
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+
+    recordings.update_recording_registrant_status(
+        fake_client, 12345, action="approve", registrant_ids=["r-1", "r-2"]
+    )
+
+    fake_client.put.assert_called_once_with(
+        "/meetings/12345/recordings/registrants/status",
+        json={"action": "approve", "registrants": [{"id": "r-1"}, {"id": "r-2"}]},
+    )
+
+
+@pytest.mark.parametrize("bad_action", ["bogus", "", "cancel"])
+def test_update_recording_registrant_status_rejects_unknown_action(bad_action: str) -> None:
+    """Recording registrants only support approve/deny — no cancel like meetings."""
+    fake_client = MagicMock()
+    with pytest.raises(ValueError, match="action"):
+        recordings.update_recording_registrant_status(
+            fake_client, 12345, action=bad_action, registrant_ids=["r-1"]
+        )
+
+
+def test_update_recording_registrant_status_rejects_empty_id_list() -> None:
+    fake_client = MagicMock()
+    with pytest.raises(ValueError, match="at least one"):
+        recordings.update_recording_registrant_status(
+            fake_client, 12345, action="approve", registrant_ids=[]
+        )
+
+
+def test_allowed_recording_registrant_statuses_pinned() -> None:
+    assert "pending" in recordings.ALLOWED_REGISTRANT_STATUSES
+    assert "approved" in recordings.ALLOWED_REGISTRANT_STATUSES
+    assert "denied" in recordings.ALLOWED_REGISTRANT_STATUSES
+
+
+def test_allowed_recording_registrant_actions_pinned() -> None:
+    """Recording registrants only support approve/deny — no cancel."""
+    assert "approve" in recordings.ALLOWED_REGISTRANT_ACTIONS
+    assert "deny" in recordings.ALLOWED_REGISTRANT_ACTIONS

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4625,3 +4625,217 @@ def test_users_presence_set_rejects_unknown_status(
     result = runner.invoke(main, ["users", "presence", "set", "u-1", "DND"])
     assert result.exit_code != 0
     assert "DND" in result.output or "Invalid value" in result.output
+
+
+# ---- recordings depth-completion: recover / settings / registrants -----
+
+
+def test_recordings_recover_all_yes_calls_recover_recordings(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_recover(_client, mid):
+        captured["mid"] = mid
+        captured["whole"] = True
+
+    def fake_recover_file(_client, mid, fid):
+        captured["file"] = (mid, fid)
+
+    _patch_recordings_module(
+        monkeypatch,
+        recover_recordings=fake_recover,
+        recover_recording_file=fake_recover_file,
+    )
+    result = runner.invoke(main, ["recordings", "recover", "12345", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert captured.get("mid") == "12345"
+    assert captured.get("whole") is True
+    assert "file" not in captured
+    assert "all trashed recordings" in result.output
+
+
+def test_recordings_recover_specific_file_yes_calls_file_endpoint(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_recover_file(_client, mid, fid):
+        captured["file"] = (mid, fid)
+
+    _patch_recordings_module(
+        monkeypatch,
+        recover_recordings=lambda *_a, **_k: None,
+        recover_recording_file=fake_recover_file,
+    )
+    result = runner.invoke(main, ["recordings", "recover", "12345", "--file-id", "rec-1", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert captured["file"] == ("12345", "rec-1")
+    assert "Recovered recording rec-1" in result.output
+
+
+def test_recordings_recover_confirms_and_aborts(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    called = {"n": 0}
+    _patch_recordings_module(
+        monkeypatch,
+        recover_recordings=lambda *_a, **_k: called.__setitem__("n", called["n"] + 1),
+        recover_recording_file=lambda *_a, **_k: None,
+    )
+    result = runner.invoke(main, ["recordings", "recover", "12345"], input="n\n")
+    assert result.exit_code == 0, result.output
+    assert "Aborted" in result.output
+    assert called["n"] == 0
+
+
+def test_recordings_settings_get_prints_json(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    payload = {"share_recording": "publicly", "viewer_download": True}
+
+    def fake_get(_client, mid):
+        assert mid == "12345"
+        return payload
+
+    _patch_recordings_module(monkeypatch, get_recording_settings=fake_get)
+    result = runner.invoke(main, ["recordings", "settings", "get", "12345"])
+    assert result.exit_code == 0, result.output
+    import json as _json
+
+    assert _json.loads(result.output) == payload
+
+
+def test_recordings_settings_update_yes_calls_patch(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+    json_file = tmp_path / "rs.json"
+    json_file.write_text('{"share_recording": "internally"}')
+    captured: dict[str, object] = {}
+
+    def fake_update(_client, mid, payload):
+        captured["mid"] = mid
+        captured["payload"] = payload
+
+    _patch_recordings_module(monkeypatch, update_recording_settings=fake_update)
+    result = runner.invoke(
+        main,
+        [
+            "recordings",
+            "settings",
+            "update",
+            "12345",
+            "--from-json",
+            str(json_file),
+            "--yes",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["mid"] == "12345"
+    assert captured["payload"] == {"share_recording": "internally"}
+    assert "Updated recording settings" in result.output
+
+
+def test_recordings_registrants_list_prints_tsv(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+
+    def fake_list(_client, mid, *, status, page_size):
+        assert (mid, status) == ("12345", "pending")
+        return iter(
+            [
+                {
+                    "id": "r-1",
+                    "email": "a@e.com",
+                    "first_name": "A",
+                    "last_name": "Z",
+                    "status": "pending",
+                },
+            ]
+        )
+
+    _patch_recordings_module(monkeypatch, list_recording_registrants=fake_list)
+    result = runner.invoke(main, ["recordings", "registrants", "list", "12345"])
+    assert result.exit_code == 0, result.output
+    assert "id\temail\tfirst_name\tlast_name\tstatus" in result.output
+    assert "r-1\ta@e.com\tA\tZ\tpending" in result.output
+
+
+def test_recordings_registrants_add_field_flags_build_payload(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_add(_client, mid, payload):
+        captured["mid"] = mid
+        captured["payload"] = payload
+        return {"id": "r-1", "share_url": "https://zoom.us/rec/share/abc"}
+
+    _patch_recordings_module(monkeypatch, add_recording_registrant=fake_add)
+    result = runner.invoke(
+        main,
+        [
+            "recordings",
+            "registrants",
+            "add",
+            "12345",
+            "--email",
+            "a@e.com",
+            "--first-name",
+            "A",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["payload"] == {"email": "a@e.com", "first_name": "A"}
+    assert "share_url" in result.output
+    assert "https://zoom.us/rec/share/abc" in result.output
+
+
+@pytest.mark.parametrize(
+    "subcmd,expected_action,past",
+    [
+        ("approve", "approve", "Approved"),
+        ("deny", "deny", "Denied"),
+    ],
+)
+def test_recordings_registrants_status_actions_send_correct_action(
+    runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+    subcmd: str,
+    expected_action: str,
+    past: str,
+) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_update(_client, mid, *, action, registrant_ids):
+        captured["mid"] = mid
+        captured["action"] = action
+        captured["registrant_ids"] = list(registrant_ids)
+
+    _patch_recordings_module(monkeypatch, update_recording_registrant_status=fake_update)
+    result = runner.invoke(
+        main,
+        [
+            "recordings",
+            "registrants",
+            subcmd,
+            "12345",
+            "--registrant",
+            "r-1",
+            "--registrant",
+            "r-2",
+            "--yes",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["action"] == expected_action
+    assert captured["registrant_ids"] == ["r-1", "r-2"]
+    assert past in result.output

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -2759,6 +2759,267 @@ def recordings_delete(meeting_id, file_id, action, yes, dry_run):
     click.echo(f"{verb} {target}.")
 
 
+# ---- Recordings depth-completion: recover + settings + registrants -----
+
+
+@recordings_cmd.command(
+    "recover",
+    help="Restore trashed recordings (PUT /meetings/<id>/recordings[/<file-id>]/status, action=recover).",
+)
+@click.argument("meeting_id")
+@click.option(
+    "--file-id",
+    "file_id",
+    default=None,
+    help="Recover only this specific recording file. If omitted, all of the meeting's trashed recordings are recovered.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@_translate_keyring_errors
+def recordings_recover(meeting_id, file_id, yes):
+    """Counterpart to ``recordings delete`` (which trashes by default).
+    Trashed recordings stay recoverable for 30 days."""
+    target = (
+        f"recording {file_id} in meeting {meeting_id}"
+        if file_id
+        else f"all trashed recordings in meeting {meeting_id}"
+    )
+    if not yes and not click.confirm(f"Recover {target}?", default=False):
+        click.echo("Aborted.")
+        return
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            if file_id:
+                recordings.recover_recording_file(client, meeting_id, file_id)
+            else:
+                recordings.recover_recordings(client, meeting_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Recovered {target}.")
+
+
+@recordings_cmd.group(
+    "settings",
+    help="Read or update a meeting's recording sharing/permission settings.",
+)
+def recordings_settings_cmd():
+    """Group for ``zoom recordings settings ...``."""
+
+
+@recordings_settings_cmd.command(
+    "get",
+    help="Print recording settings as JSON (GET /meetings/<id>/recordings/settings).",
+)
+@click.argument("meeting_id")
+@_translate_keyring_errors
+def recordings_settings_get(meeting_id):
+    """JSON output so it round-trips into ``settings update --from-json``."""
+    import json as _json
+
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            data = recordings.get_recording_settings(client, meeting_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(_json.dumps(data, indent=2))
+
+
+@recordings_settings_cmd.command(
+    "update",
+    help="Update recording settings (PATCH /meetings/<id>/recordings/settings).",
+)
+@click.argument("meeting_id")
+@click.option(
+    "--from-json",
+    "from_json",
+    type=click.File("r", encoding="utf-8"),
+    required=True,
+    help="Read the settings body from JSON (or '-' for stdin).",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@_translate_keyring_errors
+def recordings_settings_update(meeting_id, from_json, yes):
+    """Recording settings nest deep (share_recording / viewer_download /
+    on_demand / password / authentication / etc.) — JSON-only by design.
+    Round-trip via ``settings get`` first."""
+    payload = _load_json_payload_or_exit(from_json, label="--from-json input")
+    if not yes and not click.confirm(
+        f"Update recording settings on meeting {meeting_id}?",
+        default=False,
+    ):
+        click.echo("Aborted.")
+        return
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            recordings.update_recording_settings(client, meeting_id, payload)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Updated recording settings for meeting {meeting_id}.")
+
+
+@recordings_cmd.group(
+    "registrants",
+    help="Manage on-demand recording viewer registrants.",
+)
+def recordings_registrants_cmd():
+    """Group for ``zoom recordings registrants ...``."""
+
+
+@recordings_registrants_cmd.command(
+    "list",
+    help="List on-demand recording registrants (paginates GET /meetings/<id>/recordings/registrants).",
+)
+@click.argument("meeting_id")
+@click.option(
+    "--status",
+    type=click.Choice(list(recordings.ALLOWED_REGISTRANT_STATUSES)),
+    default="pending",
+    show_default=True,
+    help="Filter by registration status.",
+)
+@click.option(
+    "--page-size",
+    type=click.IntRange(1, 300),
+    default=300,
+    show_default=True,
+    help="Items per page request.",
+)
+@_translate_keyring_errors
+def recordings_registrants_list(meeting_id, status, page_size):
+    """TSV output (id\\temail\\tfirst_name\\tlast_name\\tstatus)."""
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            click.echo("id\temail\tfirst_name\tlast_name\tstatus")
+            for r in recordings.list_recording_registrants(
+                client, meeting_id, status=status, page_size=page_size
+            ):
+                click.echo(
+                    f"{r.get('id', '')}\t"
+                    f"{r.get('email', '')}\t"
+                    f"{r.get('first_name', '')}\t"
+                    f"{r.get('last_name', '')}\t"
+                    f"{r.get('status', '')}"
+                )
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+
+
+@recordings_registrants_cmd.command(
+    "add",
+    help="Register a viewer for an on-demand recording (POST /meetings/<id>/recordings/registrants).",
+)
+@click.argument("meeting_id")
+@click.option(
+    "--from-json",
+    "from_json",
+    type=click.File("r", encoding="utf-8"),
+    default=None,
+    help="Read the full registration body from JSON (or '-' for stdin). Mutually exclusive with --email / --first-name / --last-name.",
+)
+@click.option("--email", help="Registrant email (required unless --from-json).")
+@click.option("--first-name", help="Registrant first name (required unless --from-json).")
+@click.option("--last-name", help="Registrant last name (optional).")
+@_translate_keyring_errors
+def recordings_registrants_add(meeting_id, from_json, email, first_name, last_name):
+    """Same two-mode payload pattern as meetings registrants add."""
+    field_flags = (email, first_name, last_name)
+    any_field_flag = any(f is not None for f in field_flags)
+
+    if from_json is not None:
+        if any_field_flag:
+            click.echo(
+                "--from-json is mutually exclusive with --email / --first-name / --last-name.",
+                err=True,
+            )
+            raise click.exceptions.Exit(code=1)
+        payload = _load_json_payload_or_exit(from_json, label="--from-json input")
+    else:
+        if not email or not first_name:
+            click.echo(
+                "Either (--email AND --first-name) or --from-json is required.",
+                err=True,
+            )
+            raise click.exceptions.Exit(code=1)
+        payload = {"email": email, "first_name": first_name}
+        if last_name:
+            payload["last_name"] = last_name
+
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            result = recordings.add_recording_registrant(client, meeting_id, payload)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Registered. id: {result.get('id', '')}")
+    if "share_url" in result:
+        click.echo(f"share_url: {result['share_url']}")
+
+
+def _recording_registrant_status_action(action: str, action_past: str):
+    """Build one of the ``approve`` / ``deny`` subcommands. Recording
+    registrants don't have ``cancel`` (unlike meeting registrants)."""
+
+    @recordings_registrants_cmd.command(
+        action,
+        help=f"{action.capitalize()} one or more recording registrants.",
+    )
+    @click.argument("meeting_id")
+    @click.option(
+        "--registrant",
+        "registrant_ids",
+        multiple=True,
+        required=True,
+        help="Registrant ID. Repeat for bulk action.",
+    )
+    @click.option(
+        "--yes",
+        "-y",
+        is_flag=True,
+        default=False,
+        help="Skip the confirmation prompt.",
+    )
+    @_translate_keyring_errors
+    def _cmd(meeting_id, registrant_ids, yes):
+        ids = list(registrant_ids)
+        if not yes and not click.confirm(
+            f"{action.capitalize()} {len(ids)} recording registrant(s) on meeting {meeting_id}?",
+            default=False,
+        ):
+            click.echo("Aborted.")
+            return
+        creds = _load_creds_or_exit()
+        try:
+            with _build_api_client(creds) as client:
+                recordings.update_recording_registrant_status(
+                    client, meeting_id, action=action, registrant_ids=ids
+                )
+        except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+            _exit_on_api_error(exc)
+        click.echo(f"{action_past} {len(ids)} recording registrant(s) on meeting {meeting_id}.")
+
+    _cmd.__name__ = f"recordings_registrants_{action}"
+    return _cmd
+
+
+_recordings_registrants_approve = _recording_registrant_status_action("approve", "Approved")
+_recordings_registrants_deny = _recording_registrant_status_action("deny", "Denied")
+
+
 # ---- Zoom Dashboard / Metrics ------------------------------------------
 
 

--- a/zoom_cli/api/recordings.py
+++ b/zoom_cli/api/recordings.py
@@ -137,3 +137,163 @@ def delete_recording_file(
         f"{quote(str(recording_id), safe='')}",
         params={"action": action},
     )
+
+
+# ---- depth-completion: recover + settings + registrants ----------------
+
+#: Allowed values for ``list_recording_registrants(status=...)``.
+#: Same shape as meeting registrants — pending is the default (the bucket
+#: admins approve from).
+ALLOWED_REGISTRANT_STATUSES: tuple[str, ...] = ("pending", "approved", "denied")
+
+#: Allowed values for ``update_recording_registrant_status(action=...)``.
+#: Note: recording registrants do NOT support ``cancel`` (unlike meeting
+#: registrants — Zoom's recording-share approval flow is just yes/no).
+ALLOWED_REGISTRANT_ACTIONS: tuple[str, ...] = ("approve", "deny")
+
+
+def recover_recordings(client: ApiClient, meeting_id: str | int) -> dict[str, Any]:
+    """``PUT /meetings/{meeting_id}/recordings/status`` with
+    ``action=recover`` — restore all of a meeting's trashed recordings.
+
+    Counterpart to :func:`delete_recordings` with ``action="trash"``
+    (Zoom keeps trashed recordings recoverable for 30 days).
+
+    Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``recording:write:recording``.
+    """
+    return client.put(
+        f"/meetings/{quote(str(meeting_id), safe='')}/recordings/status",
+        json={"action": "recover"},
+    )
+
+
+def recover_recording_file(
+    client: ApiClient,
+    meeting_id: str | int,
+    recording_id: str,
+) -> dict[str, Any]:
+    """``PUT /meetings/{meeting_id}/recordings/{recording_id}/status``
+    with ``action=recover`` — restore one trashed recording file.
+
+    Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``recording:write:recording``.
+    """
+    return client.put(
+        f"/meetings/{quote(str(meeting_id), safe='')}/recordings/"
+        f"{quote(str(recording_id), safe='')}/status",
+        json={"action": "recover"},
+    )
+
+
+def get_recording_settings(client: ApiClient, meeting_id: str | int) -> dict[str, Any]:
+    """``GET /meetings/{meeting_id}/recordings/settings`` — fetch
+    recording sharing/permission settings.
+
+    Returns the settings envelope (share_recording, viewer_download,
+    on_demand, password, recording_authentication, etc.).
+
+    Required scopes: ``recording:read:recording``.
+    """
+    return client.get(f"/meetings/{quote(str(meeting_id), safe='')}/recordings/settings")
+
+
+def update_recording_settings(
+    client: ApiClient, meeting_id: str | int, payload: dict[str, Any]
+) -> dict[str, Any]:
+    """``PATCH /meetings/{meeting_id}/recordings/settings`` — partial
+    update to recording sharing/permission settings.
+
+    Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``recording:write:recording``.
+    """
+    return client.patch(
+        f"/meetings/{quote(str(meeting_id), safe='')}/recordings/settings",
+        json=payload,
+    )
+
+
+def list_recording_registrants(
+    client: ApiClient,
+    meeting_id: str | int,
+    *,
+    status: str = "pending",
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> Iterator[dict[str, Any]]:
+    """``GET /meetings/{meeting_id}/recordings/registrants`` — yield
+    registrants who requested access to the on-demand recording.
+
+    Args:
+        client: Authenticated :class:`ApiClient`.
+        meeting_id: Numeric Zoom meeting ID.
+        status: One of :data:`ALLOWED_REGISTRANT_STATUSES`. Default
+            ``"pending"``.
+        page_size: Items per page.
+
+    Required scopes: ``recording:read:recording``.
+    """
+    if status not in ALLOWED_REGISTRANT_STATUSES:
+        raise ValueError(f"status must be one of {ALLOWED_REGISTRANT_STATUSES!r}, got {status!r}")
+    return paginate(
+        client,
+        f"/meetings/{quote(str(meeting_id), safe='')}/recordings/registrants",
+        item_key="registrants",
+        params={"status": status},
+        page_size=page_size,
+    )
+
+
+def add_recording_registrant(
+    client: ApiClient,
+    meeting_id: str | int,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """``POST /meetings/{meeting_id}/recordings/registrants`` — register
+    a viewer for the on-demand recording.
+
+    Returns Zoom's response with the registrant id and ``share_url`` —
+    the actionable thing to send to the viewer.
+
+    Required scopes: ``recording:write:recording``.
+    """
+    return client.post(
+        f"/meetings/{quote(str(meeting_id), safe='')}/recordings/registrants",
+        json=payload,
+    )
+
+
+def update_recording_registrant_status(
+    client: ApiClient,
+    meeting_id: str | int,
+    *,
+    action: str,
+    registrant_ids: list[str],
+) -> dict[str, Any]:
+    """``PUT /meetings/{meeting_id}/recordings/registrants/status`` —
+    bulk-update registrant approval status.
+
+    Args:
+        client: Authenticated :class:`ApiClient`.
+        meeting_id: Numeric Zoom meeting ID.
+        action: One of :data:`ALLOWED_REGISTRANT_ACTIONS`. Recording
+            registrants only support approve/deny — no cancel verb.
+        registrant_ids: Zoom registrant IDs (must be non-empty).
+
+    Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``recording:write:recording``.
+    """
+    if action not in ALLOWED_REGISTRANT_ACTIONS:
+        raise ValueError(f"action must be one of {ALLOWED_REGISTRANT_ACTIONS!r}, got {action!r}")
+    if not registrant_ids:
+        raise ValueError("registrant_ids must contain at least one ID")
+    return client.put(
+        f"/meetings/{quote(str(meeting_id), safe='')}/recordings/registrants/status",
+        json={
+            "action": action,
+            "registrants": [{"id": rid} for rid in registrant_ids],
+        },
+    )


### PR DESCRIPTION
## Summary
First iteration of the **Recordings** depth-first push (after Users hit ~65% in PR #78). Adds 7 endpoints across three clusters: recover (2), settings (2), registrants (3).

## Why
Recordings was at ~25% (just list / get / delete / download). The most-asked-for missing piece is the recover counterpart to delete — Zoom keeps trashed recordings recoverable for 30 days, but the CLI had no way to act on that. Settings + registrants round out the per-meeting recording management story.

## What changed
**API helpers** (\`zoom_cli/api/recordings.py\`):
- \`recover_recordings\` / \`recover_recording_file\` — counterparts to \`delete_recordings\` / \`delete_recording_file\` with \`action=\"trash\"\`.
- \`get_recording_settings\` / \`update_recording_settings\` — sharing/permission config (PATCH semantics).
- \`list_recording_registrants\` (paginated; default status=pending), \`add_recording_registrant\`, \`update_recording_registrant_status\` — on-demand viewer registration. Note: \`ALLOWED_REGISTRANT_ACTIONS\` is \`(\"approve\", \"deny\")\` — recording registrants don't support \`cancel\` like meeting registrants do.

**CLI** (under \`zoom recordings\`):
- \`recover <id> [--file-id ID]\` — whole-meeting or single-file. Confirms by default; \`--yes\` to skip.
- \`settings get / update\` — JSON-only update because settings nest deep.
- \`registrants list (TSV) / add (per-field flags OR --from-json) / approve / deny\` — same factory pattern for the two status verbs as meetings registrants.

## Coverage update
Recordings goes from ~25% (4 endpoints) to ~50% (11 endpoints). Remaining tail: analytics summary/details (admin-heavy), transcript download, password get/update, archive files. Most of those are read-only — next iteration on this surface should be straightforward.

## Test plan
- [x] \`pytest -q\` — 791 pass (763 → 791, 19 new API + 9 new CLI)
- [x] \`ruff check . && ruff format --check .\` — clean
- [x] \`mypy\` — clean
- [x] Smoke: \`zoom recordings --help\` shows new \`recover / settings / registrants\` entries
- [ ] CI passes on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)