### PR TITLE
feat(recordings): analytics + registrant questions + archive (closes Recordings to ~80%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Survey + token + batch register + in-meeting controls (PR #76): `zoom meetings survey [get/update/delete]`, `zoom meetings token`, `zoom meetings registrants batch`, `zoom meetings control`. Fifth iteration of the depth-first push — closes Meetings to ~80% of Zoom's documented surface.
 > Users status + password + email + token + permissions (PR #77): `zoom users [activate|deactivate|password|email|token|permissions]`. First iteration of the Users depth-first push (~25% → target ~80%).
 > Users schedulers + assistants + presence (PR #78): `zoom users schedulers [list|delete]`, `zoom users assistants [add|delete]`, `zoom users presence [get|set]`. Second iteration of the Users depth-first push.
-> Recordings recover + settings + registrants (this branch): `zoom recordings recover`, `zoom recordings settings [get|update]`, `zoom recordings registrants [list|add|approve|deny]`. First iteration of the Recordings depth-first push (~25% → target ~80%).
+> Recordings recover + settings + registrants (PR #79): `zoom recordings recover`, `zoom recordings settings [get|update]`, `zoom recordings registrants [list|add|approve|deny]`. First iteration of the Recordings depth-first push (~25% → target ~80%).
+> Recordings analytics + registrant questions + archive (this branch): `zoom recordings analytics [summary|details]`, `zoom recordings registrants questions [get|update]`, `zoom recordings archive [list|get|delete]`. Second iteration — closes Recordings to ~80%.
+
+### Added (post-#15 depth-completion: analytics + registrant questions + archive)
+- `zoom recordings analytics summary <meeting-id>` — aggregated viewer metrics (view count, unique viewers, average watch time) for a past-meeting recording. JSON output. Business+ plan.
+- `zoom recordings analytics details <meeting-id>` — per-viewer breakdown (who watched, when, how long). JSON output (nested per-viewer too irregular for TSV). Business+ plan.
+- `zoom recordings registrants questions get <meeting-id>` — print recording-registration form schema (standard + custom questions) as JSON.
+- `zoom recordings registrants questions update <meeting-id> --from-json FILE` — replace the questions array wholesale (PATCH semantics; round-trip via the `get` first).
+- `zoom recordings archive list [--from DATE] [--to DATE]` — paginated TSV (id / meeting_id / topic / archive_date) of Business+ archive files.
+- `zoom recordings archive get <file-id>` — print archive file metadata + per-format download URLs as JSON.
+- `zoom recordings archive delete <file-id>` — permanently remove an archive file. **No trash/recover step here** (unlike standard recordings — flagged in the confirmation prompt).
+- New API helpers: `recordings.get_analytics_summary`, `recordings.get_analytics_details`, `recordings.get_recording_registration_questions`, `recordings.update_recording_registration_questions`, `recordings.list_archive_files` (paginated), `recordings.get_archive_file`, `recordings.delete_archive_file`.
 
 ### Added (post-#15 depth-completion: recover + settings + registrants)
 - `zoom recordings recover <meeting-id> [--file-id ID]` — restore trashed recordings (whole meeting or one specific file). Counterpart to `recordings delete` (which trashes by default; recoverable for 30 days). Confirms by default; `--yes` to skip.

--- a/tests/test_api_recordings.py
+++ b/tests/test_api_recordings.py
@@ -288,3 +288,132 @@ def test_allowed_recording_registrant_actions_pinned() -> None:
     """Recording registrants only support approve/deny — no cancel."""
     assert "approve" in recordings.ALLOWED_REGISTRANT_ACTIONS
     assert "deny" in recordings.ALLOWED_REGISTRANT_ACTIONS
+
+
+# ---- depth-completion: analytics + registrant questions + archive ------
+
+
+def test_get_analytics_summary_targets_past_meetings_endpoint() -> None:
+    """Recording analytics live under /past_meetings (not /meetings) —
+    same namespace shape as past_poll_results."""
+    fake_client = MagicMock()
+    fake_client.get.return_value = {
+        "id": 12345,
+        "analytics_summary": [{"name": "view_count", "value": 42}],
+    }
+
+    result = recordings.get_analytics_summary(fake_client, 12345)
+
+    fake_client.get.assert_called_once_with("/past_meetings/12345/recordings/analytics_summary")
+    assert result["analytics_summary"][0]["name"] == "view_count"
+
+
+def test_get_analytics_summary_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {}
+    recordings.get_analytics_summary(fake_client, "evil/../1")
+    arg = fake_client.get.call_args[0][0]
+    assert "/.." not in arg
+    assert "%2F" in arg
+
+
+def test_get_analytics_details_targets_past_meetings_endpoint() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {
+        "id": 12345,
+        "analytics_details": [{"viewer": "a@e.com", "view_time": 120}],
+    }
+
+    result = recordings.get_analytics_details(fake_client, 12345)
+
+    fake_client.get.assert_called_once_with("/past_meetings/12345/recordings/analytics_details")
+    assert result["analytics_details"][0]["viewer"] == "a@e.com"
+
+
+def test_get_recording_registration_questions_targets_correct_path() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"questions": [], "custom_questions": []}
+
+    result = recordings.get_recording_registration_questions(fake_client, 12345)
+
+    fake_client.get.assert_called_once_with("/meetings/12345/recordings/registrants/questions")
+    assert result == {"questions": [], "custom_questions": []}
+
+
+def test_update_recording_registration_questions_patches_with_payload() -> None:
+    fake_client = MagicMock()
+    fake_client.patch.return_value = {}
+
+    payload = {"questions": [{"field_name": "company", "required": True}]}
+    recordings.update_recording_registration_questions(fake_client, 12345, payload)
+
+    fake_client.patch.assert_called_once_with(
+        "/meetings/12345/recordings/registrants/questions", json=payload
+    )
+
+
+def test_get_archive_file_targets_correct_path() -> None:
+    """Archive files (Business+ archiving feature) sit at /archive_files
+    with a global file_id — no meeting context."""
+    fake_client = MagicMock()
+    fake_client.get.return_value = {
+        "id": "arch-1",
+        "files": [{"file_type": "MP4", "size": 12345}],
+    }
+
+    result = recordings.get_archive_file(fake_client, "arch-1")
+
+    fake_client.get.assert_called_once_with("/archive_files/arch-1")
+    assert result["files"][0]["file_type"] == "MP4"
+
+
+def test_get_archive_file_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {}
+    recordings.get_archive_file(fake_client, "evil/../bad")
+    arg = fake_client.get.call_args[0][0]
+    assert "/.." not in arg
+    assert "%2F" in arg
+
+
+def test_delete_archive_file_targets_correct_path() -> None:
+    fake_client = MagicMock()
+    fake_client.delete.return_value = {}
+
+    recordings.delete_archive_file(fake_client, "arch-1")
+
+    fake_client.delete.assert_called_once_with("/archive_files/arch-1")
+
+
+def test_delete_archive_file_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.delete.return_value = {}
+    recordings.delete_archive_file(fake_client, "evil/../bad")
+    arg = fake_client.delete.call_args[0][0]
+    assert "/.." not in arg
+    assert "%2F" in arg
+
+
+def test_list_archive_files_walks_pagination() -> None:
+    fake_client = MagicMock()
+    fake_client.get.side_effect = [
+        {"archive_files": [{"id": "a-1"}, {"id": "a-2"}], "next_page_token": "tok-2"},
+        {"archive_files": [{"id": "a-3"}], "next_page_token": ""},
+    ]
+
+    result = list(recordings.list_archive_files(fake_client))
+
+    assert result == [{"id": "a-1"}, {"id": "a-2"}, {"id": "a-3"}]
+    first = fake_client.get.call_args_list[0]
+    assert first[0][0] == "/archive_files"
+
+
+def test_list_archive_files_forwards_date_filters() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"archive_files": [], "next_page_token": ""}
+
+    list(recordings.list_archive_files(fake_client, from_="2026-04-01", to="2026-04-30"))
+
+    params = fake_client.get.call_args_list[0][1]["params"]
+    assert params["from"] == "2026-04-01"
+    assert params["to"] == "2026-04-30"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4839,3 +4839,202 @@ def test_recordings_registrants_status_actions_send_correct_action(
     assert captured["action"] == expected_action
     assert captured["registrant_ids"] == ["r-1", "r-2"]
     assert past in result.output
+
+
+# ---- recordings depth-completion: analytics + reg questions + archive --
+
+
+def test_recordings_analytics_summary_prints_json(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    payload = {"id": 12345, "analytics_summary": [{"name": "view_count", "value": 42}]}
+
+    def fake_summary(_client, mid):
+        assert mid == "12345"
+        return payload
+
+    _patch_recordings_module(monkeypatch, get_analytics_summary=fake_summary)
+    result = runner.invoke(main, ["recordings", "analytics", "summary", "12345"])
+    assert result.exit_code == 0, result.output
+    import json as _json
+
+    assert _json.loads(result.output) == payload
+
+
+def test_recordings_analytics_details_prints_json(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    payload = {
+        "id": 12345,
+        "analytics_details": [{"viewer": "a@e.com", "view_time": 120}],
+    }
+
+    def fake_details(_client, mid):
+        return payload
+
+    _patch_recordings_module(monkeypatch, get_analytics_details=fake_details)
+    result = runner.invoke(main, ["recordings", "analytics", "details", "12345"])
+    assert result.exit_code == 0, result.output
+    import json as _json
+
+    assert _json.loads(result.output) == payload
+
+
+def test_recordings_registrants_questions_get_prints_json(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    payload = {"questions": [{"field_name": "company", "required": True}]}
+
+    def fake_get(_client, mid):
+        return payload
+
+    _patch_recordings_module(monkeypatch, get_recording_registration_questions=fake_get)
+    result = runner.invoke(main, ["recordings", "registrants", "questions", "get", "12345"])
+    assert result.exit_code == 0, result.output
+    import json as _json
+
+    assert _json.loads(result.output) == payload
+
+
+def test_recordings_registrants_questions_update_yes_calls_patch(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+    json_file = tmp_path / "q.json"
+    json_file.write_text('{"questions": [{"field_name": "country"}]}')
+    captured: dict[str, object] = {}
+
+    def fake_update(_client, mid, payload):
+        captured["mid"] = mid
+        captured["payload"] = payload
+
+    _patch_recordings_module(monkeypatch, update_recording_registration_questions=fake_update)
+    result = runner.invoke(
+        main,
+        [
+            "recordings",
+            "registrants",
+            "questions",
+            "update",
+            "12345",
+            "--from-json",
+            str(json_file),
+            "--yes",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["payload"] == {"questions": [{"field_name": "country"}]}
+    assert "Updated recording registration questions" in result.output
+
+
+def test_recordings_archive_list_prints_tsv(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+
+    def fake_list(_client, *, from_, to, page_size):
+        return iter(
+            [
+                {
+                    "id": "a-1",
+                    "meeting_id": 12345,
+                    "topic": "Daily Standup",
+                    "archive_date": "2026-04-29",
+                },
+                {
+                    "id": "a-2",
+                    "meeting_id": 99999,
+                    "topic": "Other",
+                    "archive_date": "2026-04-30",
+                },
+            ]
+        )
+
+    _patch_recordings_module(monkeypatch, list_archive_files=fake_list)
+    result = runner.invoke(main, ["recordings", "archive", "list"])
+    assert result.exit_code == 0, result.output
+    assert "id\tmeeting_id\ttopic\tarchive_date" in result.output
+    assert "a-1\t12345\tDaily Standup\t2026-04-29" in result.output
+
+
+def test_recordings_archive_list_forwards_date_filters(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_list(_client, *, from_, to, page_size):
+        captured["from_"] = from_
+        captured["to"] = to
+        return iter([])
+
+    _patch_recordings_module(monkeypatch, list_archive_files=fake_list)
+    result = runner.invoke(
+        main,
+        [
+            "recordings",
+            "archive",
+            "list",
+            "--from",
+            "2026-04-01",
+            "--to",
+            "2026-04-30",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["from_"] == "2026-04-01"
+    assert captured["to"] == "2026-04-30"
+
+
+def test_recordings_archive_get_prints_json(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    payload = {"id": "arch-1", "files": [{"file_type": "MP4", "size": 12345}]}
+
+    def fake_get(_client, file_id):
+        assert file_id == "arch-1"
+        return payload
+
+    _patch_recordings_module(monkeypatch, get_archive_file=fake_get)
+    result = runner.invoke(main, ["recordings", "archive", "get", "arch-1"])
+    assert result.exit_code == 0, result.output
+    import json as _json
+
+    assert _json.loads(result.output) == payload
+
+
+def test_recordings_archive_delete_yes_calls_api(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_delete(_client, file_id):
+        captured["file_id"] = file_id
+
+    _patch_recordings_module(monkeypatch, delete_archive_file=fake_delete)
+    result = runner.invoke(main, ["recordings", "archive", "delete", "arch-1", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert captured["file_id"] == "arch-1"
+    assert "Deleted archive file arch-1" in result.output
+
+
+def test_recordings_archive_delete_confirms_and_aborts(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Confirmation surfaces the 'no recover step' warning."""
+    _save_creds()
+    called = {"n": 0}
+    _patch_recordings_module(
+        monkeypatch,
+        delete_archive_file=lambda *_a, **_k: called.__setitem__("n", called["n"] + 1),
+    )
+    result = runner.invoke(main, ["recordings", "archive", "delete", "arch-1"], input="n\n")
+    assert result.exit_code == 0, result.output
+    assert "no recover step" in result.output
+    assert "Aborted" in result.output
+    assert called["n"] == 0

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -3020,6 +3020,219 @@ _recordings_registrants_approve = _recording_registrant_status_action("approve",
 _recordings_registrants_deny = _recording_registrant_status_action("deny", "Denied")
 
 
+# ---- Recordings depth-completion: analytics + reg questions + archive --
+
+
+@recordings_cmd.group(
+    "analytics",
+    help="Recording viewer analytics for a past meeting (Business+ plan).",
+)
+def recordings_analytics_cmd():
+    """Group for ``zoom recordings analytics ...``."""
+
+
+@recordings_analytics_cmd.command(
+    "summary",
+    help="Aggregated viewer metrics (GET /past_meetings/<id>/recordings/analytics_summary).",
+)
+@click.argument("meeting_id")
+@_translate_keyring_errors
+def recordings_analytics_summary(meeting_id):
+    """JSON output. The summary contains aggregated stats (view_count,
+    unique_viewer_count, average_watch_time, etc.)."""
+    import json as _json
+
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            data = recordings.get_analytics_summary(client, meeting_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(_json.dumps(data, indent=2))
+
+
+@recordings_analytics_cmd.command(
+    "details",
+    help="Per-viewer breakdown (GET /past_meetings/<id>/recordings/analytics_details).",
+)
+@click.argument("meeting_id")
+@_translate_keyring_errors
+def recordings_analytics_details(meeting_id):
+    """JSON output. The details list nests per-viewer (who watched,
+    when, how long) — too irregular for TSV."""
+    import json as _json
+
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            data = recordings.get_analytics_details(client, meeting_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(_json.dumps(data, indent=2))
+
+
+@recordings_registrants_cmd.group(
+    "questions",
+    help="Manage the recording registration form (custom questions).",
+)
+def recordings_registrants_questions_cmd():
+    """Group for ``zoom recordings registrants questions ...``."""
+
+
+@recordings_registrants_questions_cmd.command(
+    "get",
+    help="Print the registration form's questions as JSON.",
+)
+@click.argument("meeting_id")
+@_translate_keyring_errors
+def recordings_registrants_questions_get(meeting_id):
+    """Output is raw JSON so it round-trips into ``... questions update --from-json``."""
+    import json as _json
+
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            data = recordings.get_recording_registration_questions(client, meeting_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(_json.dumps(data, indent=2))
+
+
+@recordings_registrants_questions_cmd.command(
+    "update",
+    help="Replace the registration form's questions (PATCH .../registrants/questions).",
+)
+@click.argument("meeting_id")
+@click.option(
+    "--from-json",
+    "from_json",
+    type=click.File("r", encoding="utf-8"),
+    required=True,
+    help="Read the full questions payload from JSON (or '-' for stdin).",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@_translate_keyring_errors
+def recordings_registrants_questions_update(meeting_id, from_json, yes):
+    """Wholesale-replace semantics — round-trip via ``questions get`` first."""
+    payload = _load_json_payload_or_exit(from_json, label="--from-json input")
+    if not yes and not click.confirm(
+        f"Replace recording registration questions on meeting {meeting_id}?",
+        default=False,
+    ):
+        click.echo("Aborted.")
+        return
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            recordings.update_recording_registration_questions(client, meeting_id, payload)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Updated recording registration questions for meeting {meeting_id}.")
+
+
+@recordings_cmd.group(
+    "archive",
+    help="Manage archive files (Business+ archiving feature).",
+)
+def recordings_archive_cmd():
+    """Group for ``zoom recordings archive ...``."""
+
+
+@recordings_archive_cmd.command(
+    "list",
+    help="List archive files (paginates GET /archive_files).",
+)
+@click.option(
+    "--from",
+    "from_",
+    help="ISO date (YYYY-MM-DD) lower bound on archive date.",
+)
+@click.option(
+    "--to",
+    help="ISO date (YYYY-MM-DD) upper bound on archive date.",
+)
+@click.option(
+    "--page-size",
+    type=click.IntRange(1, 300),
+    default=300,
+    show_default=True,
+    help="Items per page request.",
+)
+@_translate_keyring_errors
+def recordings_archive_list(from_, to, page_size):
+    """TSV output (id\\tmeeting_id\\ttopic\\tarchive_date)."""
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            click.echo("id\tmeeting_id\ttopic\tarchive_date")
+            for af in recordings.list_archive_files(
+                client, from_=from_, to=to, page_size=page_size
+            ):
+                click.echo(
+                    f"{af.get('id', '')}\t"
+                    f"{af.get('meeting_id', '')}\t"
+                    f"{af.get('topic', '')}\t"
+                    f"{af.get('archive_date', af.get('start_time', ''))}"
+                )
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+
+
+@recordings_archive_cmd.command(
+    "get",
+    help="Print an archive file's metadata + per-format download URLs as JSON (GET /archive_files/<file-id>).",
+)
+@click.argument("file_id")
+@_translate_keyring_errors
+def recordings_archive_get(file_id):
+    import json as _json
+
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            data = recordings.get_archive_file(client, file_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(_json.dumps(data, indent=2))
+
+
+@recordings_archive_cmd.command(
+    "delete",
+    help="Permanently delete an archive file (DELETE /archive_files/<file-id>).",
+)
+@click.argument("file_id")
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@_translate_keyring_errors
+def recordings_archive_delete(file_id, yes):
+    """No trash/recover step here — unlike standard recordings, archive
+    file deletion is permanent. Confirms by default; `--yes` to skip."""
+    if not yes and not click.confirm(
+        f"Permanently delete archive file {file_id}? (no recover step)",
+        default=False,
+    ):
+        click.echo("Aborted.")
+        return
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            recordings.delete_archive_file(client, file_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Deleted archive file {file_id}.")
+
+
 # ---- Zoom Dashboard / Metrics ------------------------------------------
 
 

--- a/zoom_cli/api/recordings.py
+++ b/zoom_cli/api/recordings.py
@@ -297,3 +297,121 @@ def update_recording_registrant_status(
             "registrants": [{"id": rid} for rid in registrant_ids],
         },
     )
+
+
+# ---- depth-completion: analytics + registrant questions + archive ------
+
+
+def get_analytics_summary(client: ApiClient, meeting_id: str | int) -> dict[str, Any]:
+    """``GET /past_meetings/{meeting_id}/recordings/analytics_summary`` —
+    aggregated viewer metrics (view count, average watch time, etc.) for
+    a past meeting's recording.
+
+    Lives under /past_meetings (not /meetings) — Zoom's namespace
+    convention for after-the-fact data. Requires Business+ Zoom plan.
+
+    Required scopes: ``recording:read:recording``.
+    """
+    return client.get(
+        f"/past_meetings/{quote(str(meeting_id), safe='')}/recordings/analytics_summary"
+    )
+
+
+def get_analytics_details(client: ApiClient, meeting_id: str | int) -> dict[str, Any]:
+    """``GET /past_meetings/{meeting_id}/recordings/analytics_details`` —
+    per-viewer breakdown of who watched, when, and for how long.
+
+    Same Business+ requirement as :func:`get_analytics_summary`.
+
+    Required scopes: ``recording:read:recording``.
+    """
+    return client.get(
+        f"/past_meetings/{quote(str(meeting_id), safe='')}/recordings/analytics_details"
+    )
+
+
+def get_recording_registration_questions(
+    client: ApiClient, meeting_id: str | int
+) -> dict[str, Any]:
+    """``GET /meetings/{meeting_id}/recordings/registrants/questions`` —
+    fetch the recording-registration form schema (standard + custom).
+
+    Returns the full questions envelope so the caller can round-trip it
+    through :func:`update_recording_registration_questions`.
+
+    Required scopes: ``recording:read:recording``.
+    """
+    return client.get(
+        f"/meetings/{quote(str(meeting_id), safe='')}/recordings/registrants/questions"
+    )
+
+
+def update_recording_registration_questions(
+    client: ApiClient, meeting_id: str | int, payload: dict[str, Any]
+) -> dict[str, Any]:
+    """``PATCH /meetings/{meeting_id}/recordings/registrants/questions``
+    — replace the recording-registration form's questions.
+
+    Same wholesale-replace semantics as the meetings registrants
+    questions endpoint — round-trip via the get first.
+
+    Required scopes: ``recording:write:recording``.
+    """
+    return client.patch(
+        f"/meetings/{quote(str(meeting_id), safe='')}/recordings/registrants/questions",
+        json=payload,
+    )
+
+
+def list_archive_files(
+    client: ApiClient,
+    *,
+    from_: str | None = None,
+    to: str | None = None,
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> Iterator[dict[str, Any]]:
+    """``GET /archive_files`` — yield archive files (Business+ archiving
+    feature) across all pages.
+
+    Args:
+        client: Authenticated :class:`ApiClient`.
+        from_: ISO date (YYYY-MM-DD) lower bound on archive date.
+        to: ISO date upper bound.
+        page_size: Items per page; see :data:`DEFAULT_PAGE_SIZE`.
+
+    Yields:
+        One archive_file dict per record.
+
+    Required scopes: ``recording:read:archive_file:admin``.
+    """
+    params: dict[str, Any] = {}
+    if from_ is not None:
+        params["from"] = from_
+    if to is not None:
+        params["to"] = to
+    return paginate(
+        client,
+        "/archive_files",
+        item_key="archive_files",
+        params=params,
+        page_size=page_size,
+    )
+
+
+def get_archive_file(client: ApiClient, file_id: str) -> dict[str, Any]:
+    """``GET /archive_files/{file_id}`` — fetch one archive file's
+    metadata + per-format download URLs.
+
+    Required scopes: ``recording:read:archive_file:admin``.
+    """
+    return client.get(f"/archive_files/{quote(file_id, safe='')}")
+
+
+def delete_archive_file(client: ApiClient, file_id: str) -> dict[str, Any]:
+    """``DELETE /archive_files/{file_id}`` — permanently remove an
+    archive file. No trash/recover step here (unlike standard
+    recordings).
+
+    Required scopes: ``recording:write:archive_file:admin``.
+    """
+    return client.delete(f"/archive_files/{quote(file_id, safe='')}")


### PR DESCRIPTION
## Summary
Second iteration of the Recordings depth-first push. Adds 7 endpoints across three clusters: analytics (2), registrant questions (2), archive files (3). With this PR Recordings reaches **~80% of Zoom's documented surface** — the depth-first target.

## Why
After PR #79 added recover / settings / registrants, the remaining gap was analytics (Business+ admin metrics on recording viewership), the per-meeting registrant questions schema (round-trip pair), and Business+ archive files (a separate top-level resource at \`/archive_files\`).

## What changed
**API helpers** (\`zoom_cli/api/recordings.py\`):
- \`get_analytics_summary\` / \`get_analytics_details\` — under \`/past_meetings\` namespace; Business+ feature.
- \`get_recording_registration_questions\` / \`update_recording_registration_questions\` — round-trip pair (PATCH replaces wholesale).
- \`list_archive_files\` (paginated, with \`from_\`/\`to\` date filters), \`get_archive_file\`, \`delete_archive_file\` — separate top-level resource. **No trash/recover step** for archive deletion (permanent).

**CLI** (under \`zoom recordings\`):
- \`analytics summary / details\` — JSON output (per-viewer detail nests too irregularly for TSV).
- \`registrants questions get / update\` — same JSON-only update pattern as meetings registrants questions.
- \`archive list / get / delete\` — TSV list, JSON get, \`--yes\` guard on delete with confirmation copy that surfaces the "no recover step" warning.

## Coverage update
Recordings goes from ~50% (11 endpoints after PR #79) to **~80% (18 endpoints)** with this PR. The last bits (per-recording transcript via dedicated endpoint, password get/update on the recording itself) are minor enough that they can pick up later as one-off PRs.

Next on the depth-first queue: cross-cutting work — \`--output json\` flag uniformly across all surfaces (the scriptability gap from the parity audit).

## Test plan
- [x] \`pytest -q\` — 811 pass (791 → 811, 11 new API + 9 new CLI)
- [x] \`ruff check . && ruff format --check .\` — clean
- [x] \`mypy\` — clean
- [x] Smoke: \`zoom recordings --help\` shows new \`analytics / archive\` subgroups; \`zoom recordings registrants --help\` shows new \`questions\` subgroup
- [ ] CI passes on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)