### PR TITLE
feat(users): update + revoke-sso + virtual-backgrounds (closes Users to ~80%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Users status + password + email + token + permissions (PR #77): `zoom users [activate|deactivate|password|email|token|permissions]`. First iteration of the Users depth-first push (~25% → target ~80%).
 > Users schedulers + assistants + presence (PR #78): `zoom users schedulers [list|delete]`, `zoom users assistants [add|delete]`, `zoom users presence [get|set]`. Second iteration of the Users depth-first push.
 > Recordings recover + settings + registrants (PR #79): `zoom recordings recover`, `zoom recordings settings [get|update]`, `zoom recordings registrants [list|add|approve|deny]`. First iteration of the Recordings depth-first push (~25% → target ~80%).
-> Recordings analytics + registrant questions + archive (this branch): `zoom recordings analytics [summary|details]`, `zoom recordings registrants questions [get|update]`, `zoom recordings archive [list|get|delete]`. Second iteration — closes Recordings to ~80%.
+> Recordings analytics + registrant questions + archive (PR #80): `zoom recordings analytics [summary|details]`, `zoom recordings registrants questions [get|update]`, `zoom recordings archive [list|get|delete]`. Second iteration — closes Recordings to ~80%.
+> Users update + revoke-sso + virtual-backgrounds list/delete (this branch): `zoom users update`, `zoom users revoke-sso`, `zoom users virtual-backgrounds [list|delete]`. Third iteration of the Users depth-first push — closes Users to ~80% (multipart-upload for VB upload deferred as a separate iter).
+
+### Added (post-#14 depth-completion: update + sso revoke + virtual backgrounds)
+- `zoom users update <user-id>` — partial profile update (PATCH /users/<id>). Per-field flags (`--first-name`, `--last-name`, `--type`, `--language`, `--dept`, `--vanity-name`) OR `--from-json FILE`; mutually exclusive. Rejects empty payload.
+- `zoom users revoke-sso <user-id>` — invalidate every active SSO session (forces re-auth). Confirms by default since this is a user-visible disruption.
+- `zoom users virtual-backgrounds list <user-id>` — paginated TSV (id / name / type / size / is_default).
+- `zoom users virtual-backgrounds delete <user-id> --id ID [--id ID ...]` — bulk delete by file ID. Builds Zoom's CSV `ids=` query param; rejects empty list. Confirms by default.
+- New API helpers: `users.update_user`, `users.revoke_sso_token`, `users.list_virtual_backgrounds` (paginated), `users.delete_virtual_backgrounds` (CSV `ids` query param).
 
 ### Added (post-#15 depth-completion: analytics + registrant questions + archive)
 - `zoom recordings analytics summary <meeting-id>` — aggregated viewer metrics (view count, unique viewers, average watch time) for a past-meeting recording. JSON output. Business+ plan.

--- a/tests/test_api_users.py
+++ b/tests/test_api_users.py
@@ -538,3 +538,96 @@ def test_allowed_presence_statuses_pinned() -> None:
     assert "Available" in users.ALLOWED_PRESENCE_STATUSES
     assert "Away" in users.ALLOWED_PRESENCE_STATUSES
     assert "Do_Not_Disturb" in users.ALLOWED_PRESENCE_STATUSES
+
+
+# ---- depth-completion: update_user + SSO revoke + virtual backgrounds --
+
+
+def test_update_user_patches_user_path() -> None:
+    """PATCH /users/<id> — partial update on the user profile."""
+    fake_client = MagicMock()
+    fake_client.patch.return_value = {}
+
+    payload = {"first_name": "Alice", "last_name": "Smith", "language": "en-US"}
+    users.update_user(fake_client, "u-1", payload)
+
+    fake_client.patch.assert_called_once_with("/users/u-1", json=payload)
+
+
+def test_update_user_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.patch.return_value = {}
+    users.update_user(fake_client, "evil/../1", {})
+    arg = fake_client.patch.call_args[0][0]
+    assert "/.." not in arg
+    assert "%2F" in arg
+
+
+def test_revoke_sso_token_targets_correct_path() -> None:
+    """PUT /users/<id>/sso_token — invalidates all active SSO sessions."""
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+
+    users.revoke_sso_token(fake_client, "u-1")
+
+    fake_client.put.assert_called_once_with("/users/u-1/sso_token")
+
+
+def test_revoke_sso_token_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.put.return_value = {}
+    users.revoke_sso_token(fake_client, "evil/../1")
+    arg = fake_client.put.call_args[0][0]
+    assert "/.." not in arg
+    assert "%2F" in arg
+
+
+def test_list_virtual_backgrounds_walks_pagination() -> None:
+    fake_client = MagicMock()
+    fake_client.get.side_effect = [
+        {"files": [{"id": "vb-1"}, {"id": "vb-2"}], "next_page_token": "tok-2"},
+        {"files": [{"id": "vb-3"}], "next_page_token": ""},
+    ]
+
+    result = list(users.list_virtual_backgrounds(fake_client, "u-1"))
+
+    assert result == [{"id": "vb-1"}, {"id": "vb-2"}, {"id": "vb-3"}]
+    first = fake_client.get.call_args_list[0]
+    assert first[0][0] == "/users/u-1/settings/virtual_backgrounds"
+
+
+def test_list_virtual_backgrounds_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.get.return_value = {"files": [], "next_page_token": ""}
+    list(users.list_virtual_backgrounds(fake_client, "evil/../1"))
+    call_path = fake_client.get.call_args_list[0][0][0]
+    assert "/.." not in call_path
+    assert "%2F" in call_path
+
+
+def test_delete_virtual_backgrounds_passes_ids_csv_param() -> None:
+    """Zoom takes a comma-separated `ids` query param — the helper builds it."""
+    fake_client = MagicMock()
+    fake_client.delete.return_value = {}
+
+    users.delete_virtual_backgrounds(fake_client, "u-1", ids=["vb-1", "vb-2"])
+
+    fake_client.delete.assert_called_once_with(
+        "/users/u-1/settings/virtual_backgrounds",
+        params={"ids": "vb-1,vb-2"},
+    )
+
+
+def test_delete_virtual_backgrounds_rejects_empty_ids() -> None:
+    fake_client = MagicMock()
+    with pytest.raises(ValueError, match="at least one"):
+        users.delete_virtual_backgrounds(fake_client, "u-1", ids=[])
+
+
+def test_delete_virtual_backgrounds_url_encodes_id() -> None:
+    fake_client = MagicMock()
+    fake_client.delete.return_value = {}
+    users.delete_virtual_backgrounds(fake_client, "evil/../1", ids=["vb-1"])
+    arg = fake_client.delete.call_args[0][0]
+    assert "/.." not in arg
+    assert "%2F" in arg

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5038,3 +5038,205 @@ def test_recordings_archive_delete_confirms_and_aborts(
     assert "no recover step" in result.output
     assert "Aborted" in result.output
     assert called["n"] == 0
+
+
+# ---- users depth-completion: update / revoke-sso / virtual-backgrounds --
+
+
+def test_users_update_field_flags_build_payload(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_update(_client, user_id, payload):
+        captured["user_id"] = user_id
+        captured["payload"] = payload
+
+    _patch_users_module(monkeypatch, update_user=fake_update)
+    result = runner.invoke(
+        main,
+        [
+            "users",
+            "update",
+            "u-1",
+            "--first-name",
+            "Alice",
+            "--last-name",
+            "Smith",
+            "--type",
+            "2",
+            "--language",
+            "en-US",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["user_id"] == "u-1"
+    assert captured["payload"] == {
+        "first_name": "Alice",
+        "last_name": "Smith",
+        "type": 2,
+        "language": "en-US",
+    }
+    assert "Updated user u-1" in result.output
+
+
+def test_users_update_rejects_no_fields(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    _save_creds()
+    _patch_users_module(monkeypatch, update_user=lambda *_a, **_k: None)
+    result = runner.invoke(main, ["users", "update", "u-1"])
+    assert result.exit_code == 1
+    assert "Nothing to update" in result.output
+
+
+def test_users_update_from_json_mutually_exclusive(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+    json_file = tmp_path / "u.json"
+    json_file.write_text('{"first_name": "Alice"}')
+    _patch_users_module(monkeypatch, update_user=lambda *_a, **_k: None)
+    result = runner.invoke(
+        main,
+        [
+            "users",
+            "update",
+            "u-1",
+            "--from-json",
+            str(json_file),
+            "--first-name",
+            "Bob",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "mutually exclusive" in result.output
+
+
+def test_users_update_from_json_sends_full_payload(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _save_creds()
+    json_file = tmp_path / "u.json"
+    json_file.write_text('{"first_name": "Alice", "vanity_name": "alice-room"}')
+    captured: dict[str, object] = {}
+
+    def fake_update(_client, _uid, payload):
+        captured["payload"] = payload
+
+    _patch_users_module(monkeypatch, update_user=fake_update)
+    result = runner.invoke(main, ["users", "update", "u-1", "--from-json", str(json_file)])
+    assert result.exit_code == 0, result.output
+    assert captured["payload"] == {
+        "first_name": "Alice",
+        "vanity_name": "alice-room",
+    }
+
+
+def test_users_revoke_sso_yes_calls_api(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_revoke(_client, user_id):
+        captured["user_id"] = user_id
+
+    _patch_users_module(monkeypatch, revoke_sso_token=fake_revoke)
+    result = runner.invoke(main, ["users", "revoke-sso", "u-1", "--yes"])
+    assert result.exit_code == 0, result.output
+    assert captured["user_id"] == "u-1"
+    assert "Revoked SSO sessions" in result.output
+
+
+def test_users_revoke_sso_confirms_and_aborts(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    called = {"n": 0}
+    _patch_users_module(
+        monkeypatch,
+        revoke_sso_token=lambda *_a, **_k: called.__setitem__("n", called["n"] + 1),
+    )
+    result = runner.invoke(main, ["users", "revoke-sso", "u-1"], input="n\n")
+    assert result.exit_code == 0, result.output
+    assert "Aborted" in result.output
+    assert called["n"] == 0
+
+
+def test_users_vb_list_prints_tsv(runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    _save_creds()
+
+    def fake_list(_client, user_id, *, page_size):
+        assert user_id == "u-1"
+        return iter(
+            [
+                {
+                    "id": "vb-1",
+                    "name": "office.jpg",
+                    "type": "image",
+                    "size": 12345,
+                    "is_default": True,
+                },
+                {
+                    "id": "vb-2",
+                    "name": "blur.mp4",
+                    "type": "video",
+                    "size": 98765,
+                    "is_default": False,
+                },
+            ]
+        )
+
+    _patch_users_module(monkeypatch, list_virtual_backgrounds=fake_list)
+    result = runner.invoke(main, ["users", "virtual-backgrounds", "list", "u-1"])
+    assert result.exit_code == 0, result.output
+    assert "id\tname\ttype\tsize\tis_default" in result.output
+    assert "vb-1\toffice.jpg\timage\t12345\tTrue" in result.output
+
+
+def test_users_vb_delete_yes_sends_csv_ids(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    captured: dict[str, object] = {}
+
+    def fake_delete(_client, user_id, *, ids):
+        captured["user_id"] = user_id
+        captured["ids"] = list(ids)
+
+    _patch_users_module(monkeypatch, delete_virtual_backgrounds=fake_delete)
+    result = runner.invoke(
+        main,
+        [
+            "users",
+            "virtual-backgrounds",
+            "delete",
+            "u-1",
+            "--id",
+            "vb-1",
+            "--id",
+            "vb-2",
+            "--yes",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["user_id"] == "u-1"
+    assert captured["ids"] == ["vb-1", "vb-2"]
+    assert "Deleted 2 virtual background(s)" in result.output
+
+
+def test_users_vb_delete_confirms_and_aborts(
+    runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _save_creds()
+    called = {"n": 0}
+    _patch_users_module(
+        monkeypatch,
+        delete_virtual_backgrounds=lambda *_a, **_k: called.__setitem__("n", called["n"] + 1),
+    )
+    result = runner.invoke(
+        main,
+        ["users", "virtual-backgrounds", "delete", "u-1", "--id", "vb-1"],
+        input="n\n",
+    )
+    assert result.exit_code == 0, result.output
+    assert "Aborted" in result.output
+    assert called["n"] == 0

--- a/zoom_cli/__main__.py
+++ b/zoom_cli/__main__.py
@@ -1335,6 +1335,186 @@ def users_presence_set(user_id, status):
     click.echo(f"Set presence for user {user_id} -> {status}.")
 
 
+# ---- Users depth-completion: update + sso-revoke + virtual-backgrounds --
+
+
+@users_cmd.command(
+    "update",
+    help="Update a user's profile (PATCH /users/<user-id>).",
+)
+@click.argument("user_id")
+@click.option("--first-name", help="New first name.")
+@click.option("--last-name", help="New last name.")
+@click.option(
+    "--type",
+    "user_type",
+    type=click.IntRange(1, 3),
+    help="1=Basic, 2=Licensed, 3=On-prem.",
+)
+@click.option("--language", help="Locale (e.g. en-US).")
+@click.option("--dept", help="Department.")
+@click.option("--vanity-name", help="Vanity URL prefix (Pro+).")
+@click.option(
+    "--from-json",
+    "from_json",
+    type=click.File("r", encoding="utf-8"),
+    default=None,
+    help="Read full user-update body from JSON. Mutually exclusive with the per-field flags.",
+)
+@_translate_keyring_errors
+def users_update(user_id, first_name, last_name, user_type, language, dept, vanity_name, from_json):
+    """Two payload-construction modes (mirrors the rest of the CLI):
+
+    1. Per-field flags — at least one must be passed.
+    2. ``--from-json FILE`` — full Zoom PATCH body."""
+    field_flags = (first_name, last_name, user_type, language, dept, vanity_name)
+    any_field_flag = any(f is not None for f in field_flags)
+
+    if from_json is not None:
+        if any_field_flag:
+            click.echo(
+                "--from-json is mutually exclusive with the per-field flags.",
+                err=True,
+            )
+            raise click.exceptions.Exit(code=1)
+        payload = _load_json_payload_or_exit(from_json, label="--from-json input")
+    else:
+        payload = {}
+        if first_name is not None:
+            payload["first_name"] = first_name
+        if last_name is not None:
+            payload["last_name"] = last_name
+        if user_type is not None:
+            payload["type"] = user_type
+        if language is not None:
+            payload["language"] = language
+        if dept is not None:
+            payload["dept"] = dept
+        if vanity_name is not None:
+            payload["vanity_name"] = vanity_name
+        if not payload:
+            click.echo(
+                "Nothing to update — pass at least one --field, or --from-json.",
+                err=True,
+            )
+            raise click.exceptions.Exit(code=1)
+
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            users.update_user(client, user_id, payload)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Updated user {user_id}.")
+
+
+@users_cmd.command(
+    "revoke-sso",
+    help="Invalidate the user's active SSO sessions (PUT /users/<user-id>/sso_token).",
+)
+@click.argument("user_id")
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@_translate_keyring_errors
+def users_revoke_sso(user_id, yes):
+    """Forces re-auth on the user's next access. Confirms by default
+    since this is a user-visible disruption."""
+    if not yes and not click.confirm(
+        f"Revoke all SSO sessions for user {user_id}?",
+        default=False,
+    ):
+        click.echo("Aborted.")
+        return
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            users.revoke_sso_token(client, user_id)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Revoked SSO sessions for user {user_id}.")
+
+
+@users_cmd.group(
+    "virtual-backgrounds",
+    help="Manage a user's uploaded virtual backgrounds.",
+)
+def users_vb_cmd():
+    """Group for ``zoom users virtual-backgrounds ...``."""
+
+
+@users_vb_cmd.command(
+    "list",
+    help="List a user's virtual backgrounds (paginates GET /users/<user-id>/settings/virtual_backgrounds).",
+)
+@click.argument("user_id")
+@click.option(
+    "--page-size",
+    type=click.IntRange(1, 300),
+    default=300,
+    show_default=True,
+    help="Items per page request.",
+)
+@_translate_keyring_errors
+def users_vb_list(user_id, page_size):
+    """TSV output (id\\tname\\ttype\\tsize\\tis_default)."""
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            click.echo("id\tname\ttype\tsize\tis_default")
+            for vb in users.list_virtual_backgrounds(client, user_id, page_size=page_size):
+                click.echo(
+                    f"{vb.get('id', '')}\t"
+                    f"{vb.get('name', '')}\t"
+                    f"{vb.get('type', '')}\t"
+                    f"{vb.get('size', '')}\t"
+                    f"{vb.get('is_default', '')}"
+                )
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+
+
+@users_vb_cmd.command(
+    "delete",
+    help="Delete one or more virtual backgrounds by file ID.",
+)
+@click.argument("user_id")
+@click.option(
+    "--id",
+    "ids",
+    multiple=True,
+    required=True,
+    help="VB file ID. Repeat for bulk delete.",
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip the confirmation prompt.",
+)
+@_translate_keyring_errors
+def users_vb_delete(user_id, ids, yes):
+    id_list = list(ids)
+    if not yes and not click.confirm(
+        f"Delete {len(id_list)} virtual background(s) for user {user_id}?",
+        default=False,
+    ):
+        click.echo("Aborted.")
+        return
+    creds = _load_creds_or_exit()
+    try:
+        with _build_api_client(creds) as client:
+            users.delete_virtual_backgrounds(client, user_id, ids=id_list)
+    except (oauth.ZoomAuthError, ZoomApiError, httpx.HTTPError) as exc:
+        _exit_on_api_error(exc)
+    click.echo(f"Deleted {len(id_list)} virtual background(s) for user {user_id}.")
+
+
 # ---- Zoom Meetings — write commands -------------------------------------
 #
 # Closes #13 (write piece). Confirmation-flow design mirrors `zoom rm`:

--- a/zoom_cli/api/users.py
+++ b/zoom_cli/api/users.py
@@ -417,3 +417,85 @@ def set_presence(client: ApiClient, user_id: str, *, status: str) -> dict[str, A
         f"/users/{quote(user_id, safe='')}/presence_status",
         json={"status": status},
     )
+
+
+# ---- depth-completion: update_user + SSO revoke + virtual backgrounds --
+
+
+def update_user(client: ApiClient, user_id: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """``PATCH /users/{user_id}`` — partial-update the user profile.
+
+    ``payload`` accepts ``first_name``, ``last_name``, ``type`` (Basic /
+    Licensed / On-prem), ``language``, ``dept``, ``vanity_name``, etc.
+    Zoom's PATCH semantics leave omitted fields untouched.
+
+    Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``user:write:user``.
+    """
+    return client.patch(f"/users/{quote(user_id, safe='')}", json=payload)
+
+
+def revoke_sso_token(client: ApiClient, user_id: str) -> dict[str, Any]:
+    """``PUT /users/{user_id}/sso_token`` — invalidate every active SSO
+    session for the user. Forces re-authentication on next access.
+
+    Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``user:write:admin``.
+    """
+    return client.put(f"/users/{quote(user_id, safe='')}/sso_token")
+
+
+def list_virtual_backgrounds(
+    client: ApiClient,
+    user_id: str,
+    *,
+    page_size: int = DEFAULT_PAGE_SIZE,
+) -> Iterator[dict[str, Any]]:
+    """``GET /users/{user_id}/settings/virtual_backgrounds`` — yield
+    every uploaded virtual background across all pages.
+
+    Args:
+        client: Authenticated :class:`ApiClient`.
+        user_id: Zoom user ID or email.
+        page_size: Items per page; see :data:`DEFAULT_PAGE_SIZE`.
+
+    Yields:
+        One file dict per VB (id, name, type, size, is_default, etc.).
+
+    Required scopes: ``user:read:settings``.
+    """
+    return paginate(
+        client,
+        f"/users/{quote(user_id, safe='')}/settings/virtual_backgrounds",
+        item_key="files",
+        params={},
+        page_size=page_size,
+    )
+
+
+def delete_virtual_backgrounds(
+    client: ApiClient, user_id: str, *, ids: list[str]
+) -> dict[str, Any]:
+    """``DELETE /users/{user_id}/settings/virtual_backgrounds?ids=...`` —
+    delete one or more VBs by their file ID.
+
+    Zoom takes a comma-separated ``ids`` query parameter (NOT a JSON
+    body). The helper builds the CSV.
+
+    Args:
+        client: Authenticated :class:`ApiClient`.
+        user_id: Zoom user ID or email.
+        ids: Non-empty list of VB file IDs to delete.
+
+    Returns ``{}`` (Zoom responds with 204 No Content).
+
+    Required scopes: ``user:write:settings``.
+    """
+    if not ids:
+        raise ValueError("ids must contain at least one VB file ID")
+    return client.delete(
+        f"/users/{quote(user_id, safe='')}/settings/virtual_backgrounds",
+        params={"ids": ",".join(ids)},
+    )


### PR DESCRIPTION
## Summary
Third iteration of the **Users** depth-first push. Adds 4 endpoints — most importantly the missing \`PATCH /users/<id>\` (general profile update), plus admin SSO revoke and the read/delete side of virtual backgrounds. With this PR Users reaches **~80%** of Zoom's documented surface.

## Why
After PR #77 (status/password/email/token/permissions) and PR #78 (schedulers/assistants/presence), the conspicuous remaining gap was the simple "edit a user's first/last name / type / language" workflow — which uses the bare \`PATCH /users/<id>\` endpoint we hadn't covered. Bundling it with \`revoke_sso_token\` (admin auth invalidation) and the VB read/delete endpoints because they're all small and share the same shape.

The VB **upload** endpoint is multipart and requires a new \`ApiClient.post_multipart\` helper — deferred to a separate iter so this PR stays scoped.

## What changed
**API helpers** (\`zoom_cli/api/users.py\`):
- \`update_user(payload)\` — PATCH /users/<id>; accepts first_name / last_name / type / language / dept / vanity_name / etc.
- \`revoke_sso_token\` — PUT /users/<id>/sso_token; invalidates all active SSO sessions.
- \`list_virtual_backgrounds\` — paginated GET; yields VB file dicts.
- \`delete_virtual_backgrounds(*, ids)\` — DELETE with CSV \`ids=\` query param. Refuses empty list early so the silent no-op turns into a fast local error.

**CLI** (under \`zoom users\`):
- \`update <id>\` — per-field flags (\`--first-name\`, \`--last-name\`, \`--type\`, \`--language\`, \`--dept\`, \`--vanity-name\`) OR \`--from-json FILE\`; mutually exclusive. Rejects empty payload.
- \`revoke-sso <id>\` — confirms by default (user-visible disruption); \`--yes\` to skip.
- \`virtual-backgrounds list <id>\` — TSV (id / name / type / size / is_default).
- \`virtual-backgrounds delete <id> --id ID [--id ID ...]\` — repeatable ID flag; confirms by default.

## Coverage update
Users goes from ~65% (20 endpoints after PR #78) to ~80% (24 endpoints). The multipart VB upload is the only obvious remaining gap on this surface — needs an \`ApiClient.post_multipart\` enhancement.

Next on queue: cross-cutting \`--output json\` flag uniformly (the scriptability gap from the parity audit), or the multipart upload work.

## Test plan
- [x] \`pytest -q\` — 829 pass (811 → 829, 9 new API + 9 new CLI)
- [x] \`ruff check . && ruff format --check .\` — clean
- [x] \`mypy\` — clean
- [x] Smoke: \`zoom users --help\` shows new \`update / revoke-sso / virtual-backgrounds\` entries
- [ ] CI passes on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)