### PR TITLE
fix(packaging): rename binary entrypoint zoom_cli -> zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Binary name**: `pipx install` now puts `zoom` on PATH (was `zoom_cli`). The `[project.scripts]` entry in `pyproject.toml` was misnamed, breaking every doc command that called `zoom ...`. Re-install with `pipx install --force ...` (or `pipx upgrade zoom_cli`) to pick up the new entrypoint.
+
+### Changed
+- README install snippet now points at the `develop` branch (`git+https://github.com/jordan8037310/zoom-cli.git@develop`) — that's where every depth-completion feature lands first; `main` cuts releases periodically.
+
 > Bootstrap PR: [#25](https://github.com/jordan8037310/zoom-cli/pull/25) — closes #4, #7, #8 and partially addresses #9, #10.
 > Codex review follow-ups (PR #32): closes #34, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #45, #46, #47.
 > CC security setup (PR #33): adds `.claude/settings.json`, `SECURITY.md`, `LOCAL-SECURITY.md`, `TASKS.md`, and three FACET developer skills.

--- a/README.md
+++ b/README.md
@@ -65,13 +65,23 @@ For users without admin marketplace access, `zoom auth login --client-id <id>` r
 
 ## Installation
 
-### macOS / Linux (via PyPI)
+### macOS / Linux (recommended: pipx from `develop`)
+
+The fork's active branch is `develop` — every depth-completion feature lands there first and `main` cuts releases periodically. Install from `develop` to get the full surface:
 
 ```bash
-pip install zoom-cli           # (planned — not yet on PyPI)
-# Or directly from GitHub:
-pip install git+https://github.com/jordan8037310/zoom-cli.git
+# Cleanest: pipx puts the `zoom` binary on your PATH inside an isolated venv
+brew install pipx
+pipx ensurepath
+pipx install "git+https://github.com/jordan8037310/zoom-cli.git@develop"
+
+# To upgrade later (pulls the develop tip and rebuilds):
+pipx upgrade zoom_cli   # (package name; the binary stays `zoom`)
+# or, if --spec is needed to pin the branch again:
+pipx install --force "git+https://github.com/jordan8037310/zoom-cli.git@develop"
 ```
+
+`pip install zoom-cli` (PyPI) is planned but inert — the Trusted Publisher entry isn't registered yet. Until then, use the pipx command above (or `pip install` from GitHub if you don't have pipx).
 
 ### macOS / Linux (legacy Homebrew, upstream)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ codegen = [
 ]
 
 [project.scripts]
-zoom_cli = "zoom_cli.__main__:main"
+zoom = "zoom_cli.__main__:main"
 
 [project.urls]
 Homepage = "https://github.com/jordan8037310/zoom-cli"


### PR DESCRIPTION
## Summary
The \`[project.scripts]\` entry in \`pyproject.toml\` was misnamed — \`pipx install\` (and \`pip install\`) put \`zoom_cli\` on PATH, but every README example and docstring uses \`zoom\`. The mismatch silently broke every doc command until the binary was aliased manually.

Also updates the README install snippet to pin the \`develop\` branch explicitly — that's where every depth-completion feature lands first; \`main\` cuts releases periodically (the fork has been ~70 commits ahead of \`main\` for some time).

## What changed
- \`pyproject.toml\`: \`zoom_cli = \"zoom_cli.__main__:main\"\` → \`zoom = \"zoom_cli.__main__:main\"\`. Package name stays \`zoom_cli\` (snake_case Python convention); only the CLI binary name changes.
- \`README.md\`: pipx install now uses \`@develop\` branch fragment; clarifies that \`pip install zoom-cli\` from PyPI is planned but inert.
- \`CHANGELOG.md\`: under \`[Unreleased]\` Fixed/Changed.

## Re-install instructions
For users who got the old \`zoom_cli\` binary:

\`\`\`bash
pipx install --force \"git+https://github.com/jordan8037310/zoom-cli.git@develop\"
# Or, if you keep the package installed:
pipx upgrade zoom_cli
\`\`\`

After install, \`zoom --version\` should print the version (was: \`zoom: command not found\`).

## Test plan
- [x] \`pip install -e .\` then \`zoom --version\` — works locally
- [x] \`pytest -q\` — 847 pass (no test changes needed; tests import the Python package, not the binary)
- [x] \`ruff check . && ruff format --check .\` — clean
- [ ] CI passes on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)